### PR TITLE
#15 投稿新規作成（ユウタ）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -17,6 +17,7 @@ class PostsController extends Controller
             'posts' => $posts,    
         ]);
     }
+    
     public function store(PostRequest $request)
     {
         $post = new Post;

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\PostRequest;
 use App\Http\Controllers\Controller;
 use App\Post;
 
@@ -16,4 +17,13 @@ class PostsController extends Controller
                 'posts' => $posts,    
         ]);
     }
+    public function store(PostRequest $request)
+    {
+        $post = new Post;
+        $post->content = $request->content;
+        $post->user_id = \Auth::id();        
+        $post->save();
+        return redirect('/');
+    }
+
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+           'content' => 'required|max:140',
+        ];
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    public function user() 
+    public function user()
     {
         return $this->belongsTo(User::class);
     }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4,3 +4,7 @@
 .navbar-nav .nav-link:hover {
   color: #cbd3da!important;
 }
+
+.new-line{
+  word-break: break-all;
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -150,6 +150,6 @@ return [
         'name' => '名前',
         'email' => 'メールアドレス',
         'password' => 'パスワード',
+        'content' => '投稿'   
     ],
-
 ];

--- a/resources/views/posts/new_post.blade.php
+++ b/resources/views/posts/new_post.blade.php
@@ -1,5 +1,4 @@
 <div class="w-75 m-auto">@include('commons.error_messages')</div>
-<div class="w-75 m-auto"></div>
         <div class="text-center mb-3">
             <form method="post" action="{{ route('posts.store') }}" class="d-inline-block w-75">
                 @csrf
@@ -11,4 +10,3 @@
                 </div>
             </form>
         </div>
-

--- a/resources/views/posts/new_post.blade.php
+++ b/resources/views/posts/new_post.blade.php
@@ -1,0 +1,14 @@
+<div class="w-75 m-auto">@include('commons.error_messages')</div>
+<div class="w-75 m-auto"></div>
+        <div class="text-center mb-3">
+            <form method="post" action="{{ route('posts.store') }}" class="d-inline-block w-75">
+                @csrf
+                <div class="form-group">
+                    <textarea class="form-control" name="content" rows="4"></textarea>
+                    <div class="text-left mt-3">
+                        <button type="submit" class="btn btn-primary">投稿する</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -4,9 +4,9 @@
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
             <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $post->user->name }}</a></p>
         </div>
-        <div class="">
+        <div class="new-line">
             <div class="text-left d-inline-block w-75">
-                <p class="mb-2">{{ $post->content }}</p>
+                <p class="mb-2">{!! nl2br(e($post->content)) !!}</p>
                 <p class="text-muted">{{ $post->created_at }}</p>
             </div>      
         </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -7,8 +7,11 @@
         </div>    
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5> 
+    @if(Auth::check())
+        @include('posts.new_post')
+    @endif
     <ul class="list-unstyled">
-    @include('posts.post', ['posts' => $posts])
+        @include('posts.post', ['posts' => $posts])
     </ul>       
     <div class="d-flex justify-content-center">
         {{ $posts->links() }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,3 +20,6 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 Route::get('/', 'PostsController@index');
+Route::group(['middleware' => 'auth'], function () {
+    Route::post('posts', 'PostsController@store')->name('posts.store');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,5 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit');
         Route::put('{id}', 'PostsController@update')->name('posts.update');
-    });
-    
+    });   
 });


### PR DESCRIPTION
## issue
- closed #15

## 概要
- ログイン後に新規投稿機能を実装

## 動作手順
- 下記の情報でログインの実行
メールアドレス：sample@sample1.com
PW：sample

- 新規投稿機能の実行
ログイン後トップページに自動遷移します。テキストフォームが出現するので任意のテキストを入力し投稿ボタンクリック新規投稿を実行。投稿一覧にテキストが反映を確認しました。

- バリデーションの実行
文字数制限１４０文字、空欄禁止のバリデーションを実装しています。１４０文字以上の投稿と空欄の投稿を実施し、バリデーションの動作確認をしています。

## 考慮してほしいこと
- 英文字、かな、カナの投稿確認は実行しましたが特殊文字などの投稿は未実行です。

