### PR TITLE
#50 投稿編集のフラッシュメッセージ（ユウタ）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -49,6 +49,7 @@ class PostsController extends Controller
     public function update(PostEditRequest $request, $id)
     {
         try { 
+            
             $post = Post::findOrFail($id);
                 if (\Auth::id() === $post->user_id) {
                     $post->content = $request->content;

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -29,13 +29,19 @@ class PostsController extends Controller
 
     public function edit($id)
     {
-        $user = \Auth::user();
-        $post = Post::findOrFail($id);
-        if (\Auth::id() === $post->user_id) {
-            return view('posts.edit', [
-                'user' => $user,
-                'post' => $post,
-            ]);
+        try {
+                throw new \Exception; 
+                $user = \Auth::user();
+                $post = Post::findOrFail($id);
+                if (\Auth::id() === $post->user_id) {
+                    return view('posts.edit', [
+                        'user' => $user,
+                        'post' => $post,
+                    ]);
+                }
+                $request->session()->flash('content', '投稿を変更しました');
+        } catch(\Exception $e) {
+                $request->session()->flash('error_content', '投稿の編集が失敗しました');
         }
         return back();
     }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -20,39 +20,44 @@ class PostsController extends Controller
 
     public function store(PostRequest $request)
     {
-        $post = new Post;
-        $post->content = $request->content;
-        $post->user_id = \Auth::id();        
-        $post->save();
+        try {
+            
+            $post = new Post;
+            $post->content = $request->content;
+            $post->user_id = \Auth::id();        
+            $post->save();
+            $request->session()->flash('content', '投稿を作成しました');
+        } catch(\Exception $e) { 
+            $request->session()->flash('error_content', '投稿が失敗しました');
+        }
         return redirect('/');
     }
 
     public function edit($id)
     {
-        try {
-                throw new \Exception; 
-                $user = \Auth::user();
-                $post = Post::findOrFail($id);
-                if (\Auth::id() === $post->user_id) {
-                    return view('posts.edit', [
-                        'user' => $user,
-                        'post' => $post,
-                    ]);
-                }
-                $request->session()->flash('content', '投稿を変更しました');
-        } catch(\Exception $e) {
-                $request->session()->flash('error_content', '投稿の編集が失敗しました');
+        $user = \Auth::user();
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
+            return view('posts.edit', [
+                'user' => $user,
+                'post' => $post,
+            ]);
         }
         return back();
     }
     
     public function update(PostEditRequest $request, $id)
     {
-        $post = Post::findOrFail($id);
-        if (\Auth::id() === $post->user_id) {
-            $post->content = $request->content;
-            $post->save();
-        }
-        return redirect('/');
+        try { 
+            $post = Post::findOrFail($id);
+                if (\Auth::id() === $post->user_id) {
+                    $post->content = $request->content;
+                    $post->save();
+                }
+            $request->session()->flash('content', '投稿を編集しました');
+            } catch(\Exception $e) {
+            $request->session()->flash('error_content', '投稿の編集が失敗しました');
+            }
+            return redirect('/');
     }
 }

--- a/resources/views/commons/flash_message.blade.php
+++ b/resources/views/commons/flash_message.blade.php
@@ -1,0 +1,9 @@
+@if (session('content'))
+  <div class="alert alert-success text-center">
+    {{ session('content') }}
+  </div> 
+@elseif (session('error_content'))
+  <div class="alert alert-danger text-center">
+    {{ session('error_content') }}
+  </div> 
+@endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -7,6 +7,7 @@
         </div>    
     </div>
     <h5 class="text-center mb-3">プロ野球チームについて140字以内で会話しよう！</h5> 
+    @include('commons.flash_message')
     @if(Auth::check())
         @include('posts.new_post')
     @endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -7,7 +7,7 @@
         </div>    
     </div>
     <h5 class="text-center mb-3">プロ野球チームについて140字以内で会話しよう！</h5> 
-    @include('commons.flash_message')
+    <div class="w-75 m-auto">@include('commons.flash_message')</div>
     @if(Auth::check())
         @include('posts.new_post')
     @endif


### PR DESCRIPTION
## issue
- closed #50 

## 概要
- 投稿編集した際フラッシュメッセージが表示される機能を追加

## 動作確認
- localhost:8080/posts/{posts id}/editにアクセスし投稿を編集し更新ボタンを押した際フラッシュメッセージが表示されることを確認しました。
※{posts id}はAdminerから適当なposts idを取得してください。
- PostsController.phpの５２行目に下記のコードを入力し投稿編集処理が失敗した際のフラッシュメッセージの表示を確認しました。
```
throw new \Exception;
```