### PR TITLE
#69 投稿編集画面・更新(竹渕)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -11,12 +11,11 @@ class PostsController extends Controller
 {
     public function index()
     {
-        $posts = Post::orderBy('id','desc')->paginate(10);
+        $posts = Post::orderBy('id', 'desc')->paginate(10);
 
-        return view('welcome',[
+        return view('welcome', [
             'posts' => $posts,
         ]);
-  
     }
 
 
@@ -39,23 +38,27 @@ class PostsController extends Controller
     {
         $user = \Auth::user();
         $post = Post::findOrFail($id);
-        
-        $data=[
+        $data = [
             'user' => $user,
             'post' => $post,
         ];
-        return view('posts.edit',$data);
+        if(\Auth::id() === $post->user_id) {
+            return view('posts.edit', $data);
+        } else {
+            \Session::flash('err_msg', 'アクセス権限がありません。');
+            return redirect(route('home'));
+        }
     }
 
     /**
      * 投稿編集を実行
+     * @param PostRequest $request
      * @param int $id
      * @return view
      */
     public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
-        $post->user_id = \Auth::id();
         $post->text = $request->text;
         $post->save();
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -42,12 +42,13 @@ class PostsController extends Controller
             'user' => $user,
             'post' => $post,
         ];
-        if(\Auth::id() === $post->user_id) {
+
+        if (\Auth::id() === $post->user_id) {
             return view('posts.edit', $data);
-        } else {
-            \Session::flash('err_msg', 'アクセス権限がありません。');
-            return redirect(route('home'));
         }
+
+        \Session::flash('err_msg', 'アクセス権限がありません。');
+        return redirect(route('home'));
     }
 
     /**
@@ -59,9 +60,13 @@ class PostsController extends Controller
     public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
-        $post->text = $request->text;
-        $post->save();
+        if (\Auth::id() === $post->user_id) {
+            $post->text = $request->text;
+            $post->save();
+            return redirect(route('home'));
+        }
 
+        \Session::flash('err_msg', 'アクセス権限がありません。');
         return redirect(route('home'));
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -29,4 +29,36 @@ class PostsController extends Controller
 
         return redirect(route('home'));
     }
+
+    /**
+     * 投稿編集画面の表示
+     * @param int $id
+     * @return view
+     */
+    public function showEdit($id)
+    {
+        $user = \Auth::user();
+        $post = Post::findOrFail($id);
+        
+        $data=[
+            'user' => $user,
+            'post' => $post,
+        ];
+        return view('posts.edit',$data);
+    }
+
+    /**
+     * 投稿編集を実行
+     * @param int $id
+     * @return view
+     */
+    public function update(PostRequest $request, $id)
+    {
+        $post = Post::findOrFail($id);
+        $post->user_id = \Auth::id();
+        $post->text = $request->text;
+        $post->save();
+
+        return redirect(route('home'));
+    }
 }

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -3,7 +3,7 @@
     <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
         @csrf
         <div class="form-group">
-            <textarea class="form-control" name="text" placeholder="〇〇について語る">{{ old('text') }}</textarea>
+            <textarea class="form-control" name="text"  rows="3" placeholder="〇〇について語る">{{ old('text') }}</textarea>
             <div class="text-left mt-3">
                 <button type="submit" class="btn btn-primary">投稿する</button>
             </div>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5">投稿を編集する</h2>
+    @include('commons.error_messages')
+    <form method="POST" action="{{ route('post.update', $post->id) }}">
+        @csrf
+        @method('PUT')
+        <div class="form-group">
+            <textarea id="content" class="form-control" name="text" rows="3">{{ old('text',$post->text) }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </form>
+@endsection('content')

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -6,7 +6,7 @@
         @csrf
         @method('PUT')
         <div class="form-group">
-            <textarea id="content" class="form-control" name="text" rows="3">{{ old('text',$post->text) }}</textarea>
+            <textarea id="content" class="form-control" name="text" rows="3">{{ old('text', $post->text) }}</textarea>
         </div>
         <button type="submit" class="btn btn-primary">更新する</button>
     </form>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -19,7 +19,7 @@
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="#" class="btn btn-primary">編集する</a>
+                            <a href="{{ route('post.edit',$post->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -7,6 +7,9 @@
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+    @if (session('err_msg'))
+        <p class="text-danger">{{ session('err_msg') }}</p>
+    @endif
     @if(Auth::check())
         @include('posts.create')
     @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,12 @@ Route::prefix('users')->group(function () {
 
 //ログイン後
 Route::group(['middleware' => 'auth'], function () {
-    //新規投稿機能
-    Route::post('posts', 'PostsController@store')->name('post.store');
+    Route::prefix('posts')->group(function () {
+        //新規投稿機能
+        Route::post('', 'PostsController@store')->name('post.store');
+        //投稿編集画面の表示
+        Route::get('edit/{id}','PostsController@showEdit')->name('post.edit');
+        //投稿編集機能
+        Route::put('{id}','PostsController@update')->name('post.update');
+    });
 });


### PR DESCRIPTION
## issue
- Closes #69 

## 概要
- 投稿編集画面の表示と更新

## 動作確認手順
localhost:8080にアクセスし
ログインしたうえで、投稿の編集が行えるかを確認する

## 確認してほしいこと
edit.blade.phpにて
①編集前の文字を表示
②バリデーションエラーが起こった場合、入力した文字を保持する
①②を目的に９行目にて`{{ old('text',$post->text) }}`を記述しましたが、こちらで適切か否か確認していただきたいです。