### PR TITLE
#71フォロー機能(竹渕)

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    public function store($id)
+    {
+        \Auth::user()->follow($id);
+        return back();
+    }
+
+    public function destroy($id)
+    {
+        \Auth::user()->unfollow($id);
+        return back();
+    }
+}

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -6,12 +6,22 @@ use Illuminate\Http\Request;
 
 class FollowController extends Controller
 {
+    /**
+     *フォロー実行
+     *@param int $id
+     *@return back
+     */
     public function store($id)
     {
         \Auth::user()->follow($id);
         return back();
     }
 
+    /**
+     *フォロー解除
+     *@param int $id
+     *@return view
+     */
     public function destroy($id)
     {
         \Auth::user()->unfollow($id);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -54,13 +54,42 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
         if(\Auth::id() === $user->id) {
             $user->delete();
-
             return redirect(route('home'));
         }
 
         \Session::flash('err_msg', 'アクセス権限がありません。');
         return redirect(route('home'));
     }
+
+    /**
+    *フォロー中ユーザーの表示
+    */
+    public function follow($id)
+    {
+        $user = User::find($id);
+        $followings = $user->followings()->paginate(9);
+        $data = [
+            'user' => $user,
+            'users' => $followings,
+        ];
+        $data +=$this->conts($user);
+        return view('users.show', $data);
+    }
+    
+
+    /**
+     * フォロー解除
+     */
+    public function unfollow($id)
+    {
+        $follower = auth()->user();
+        $is_following = $follower->isFollowing($user->id);
+        if($is_following){
+            $follower->unfollow($user->id);
+            return back();
+        }
+    }
+
 }
 
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -61,35 +61,6 @@ class UsersController extends Controller
         return redirect(route('home'));
     }
 
-    /**
-    *フォロー中ユーザーの表示
-    */
-    public function follow($id)
-    {
-        $user = User::find($id);
-        $followings = $user->followings()->paginate(9);
-        $data = [
-            'user' => $user,
-            'users' => $followings,
-        ];
-        $data +=$this->conts($user);
-        return view('users.show', $data);
-    }
-    
-
-    /**
-     * フォロー解除
-     */
-    public function unfollow($id)
-    {
-        $follower = auth()->user();
-        $is_following = $follower->isFollowing($user->id);
-        if($is_following){
-            $follower->unfollow($user->id);
-            return back();
-        }
-    }
-
 }
 
 

--- a/app/User.php
+++ b/app/User.php
@@ -52,5 +52,44 @@ class User extends Authenticatable
         });
     }
 
+    //多対多リレーション
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'follow_user', 'user_id', 'follow_id')->withTimestamps();
+    }
+    //多対多リレーション逆
+    public function followings()
+    {
+        return $this->belongsToMany(User::class, 'follow_user', 'follow_id', 'user_id')->withTimestamps();
+    }
 
+    //フォローしているか判定
+    public function isFollowing($userId)
+    {
+        return $this->followers()->where('follow_id', $userId)->exists();
+    }
+
+    //フォローする
+    public function follow($userId)
+    {
+        $existing = $this->isFollowing($userId);
+        $myself = $this->id == $userId;
+        if (!$existing && !$myself) {
+            $this->followers()->attach($userId);
+        } else {
+            return false;
+        }
+    }
+
+    //フォロー解除する
+    public function unfollow($userId)
+    {
+        $existing = $this->isFollowing($userId);
+        $myself = $this->id == $userId;
+        if ($existing && !$myself) {
+            $this->followers()->detach($userId);
+        } else {
+            return false;
+        }
+    }
 }

--- a/database/migrations/2022_11_15_101643_create_follows_table.php
+++ b/database/migrations/2022_11_15_101643_create_follows_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follow_user', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->comment('ユーザーID')->index();
+            $table->bigInteger('follow_id')->unsigned()->comment('フォローするユーザーID')->index();
+            $table->timestamps();
+            //外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('follow_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique([
+                'user_id',
+                'follow_id'
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('followers');
+    }
+}

--- a/resources/views/users/follow.blade.php
+++ b/resources/views/users/follow.blade.php
@@ -1,0 +1,14 @@
+@if(Auth::check() && Auth::id() != $user->id)
+    @if (Auth::user()->isFollowing($user->id))
+    <form action="{{ route('unfollow', $user->id) }}" method="POST">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="btn btn-danger w-100 mt-4">フォロー解除</button>
+    </form>
+    @else
+    <form action="{{ route('follow', $user->id) }}" method="POST">
+        @csrf
+        <button type="submit" class="btn btn-primary w-100 mt-4">フォローする</button>
+    </form>
+    @endif
+@endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -13,6 +13,7 @@
                             <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                         </div>
                     @endif
+                    @include('users.follow', ['user' => $user])
                 </div>
             </div>
         </aside>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,7 +34,7 @@ Route::prefix('users')->group(function () {
     Route::post('{id}/delete', 'UsersController@delete')->name('users.delete');
 });
 
-// ログイン後
+// ログイン後投稿関係
 Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
         //新規投稿機能
@@ -48,3 +48,10 @@ Route::group(['middleware' => 'auth'], function () {
     });
 });
 
+//フォロー機能
+Route::group(['middleware' => 'auth'], function () {
+    Route::prefix('users/{id}')->group(function () {
+    Route::post('follow', 'FollowController@store')->name('follow');
+    Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
+    });
+});


### PR DESCRIPTION
## issue 
- Closes#71 
## 概要
- フォロー機能の実装

## 動作確認手順
php artisan migrate:fresh --seed
を実行したのち
新規ユーザー登録をして、フォロー機能を確認

## 確認してほしいこと
フォローしているか判定する関数
`public function isFollowing($userId)`
フォローする関数
 `public function follow($userId)`
フォロー解除する関数
  `public function unfollow($userId)`

上記の第一引数は、対象とする中間テーブルのカラムを
ローワーキャメルケースで記述したもの(今回の$userId)でないと機能しないのかを教えてほしいです。