### PR TITLE
#124 投稿編集画面・更新（岡田）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Post;
 use App\Http\Requests\PostRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\App;
 
 class PostsController extends Controller
 {
@@ -19,20 +21,26 @@ class PostsController extends Controller
 
     public function edit($id)
     {
-        $user = \Auth::user();
         $post = Post::findOrFail($id);
-        $data =[
-            'user' => $user,
-            'post' => $post,
-        ];
-        return view('posts.edit', $data);
+        if (Auth::id() === $post->user_id) {
+            return view('posts.edit', [
+                'post' => $post,
+            ]);
+        }
+
+        return App::abort(404);
     }
 
     public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
-        $post->content = $request->content;
-        $post->save();
-        return redirect("/");
+        if (Auth::id() === $post->user_id) {
+            $post->content = $request->content;
+            $post->save();
+            return redirect("/");
+        }
+
+        return App::abort(404);
     }
+
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Post;
+use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller
 {
@@ -14,5 +15,24 @@ class PostsController extends Controller
         return view('welcome', [
             'posts' => $posts,
         ]);
+    }
+
+    public function edit($id)
+    {
+        $user = \Auth::user();
+        $post = Post::findOrFail($id);
+        $data =[
+            'user' => $user,
+            'post' => $post,
+        ];
+        return view('posts.edit', $data);
+    }
+
+    public function update(PostRequest $request, $id)
+    {
+        $post = Post::findOrFail($id);
+        $post->content = $request->content;
+        $post->save();
+        return redirect("/");
     }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required'
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'content' => '投稿'
+        ];
+    }
+}

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,7 +24,7 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
-            'content' => 'required'
+            'content' => 'required|max:140'
         ];
     }
 
@@ -34,4 +34,13 @@ class PostRequest extends FormRequest
             'content' => '投稿'
         ];
     }
+
+    public function messages()
+    {
+        return [
+            'content.required' => '投稿は、必ず入力してください。',
+        ];
+
+    }
+
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -8,6 +8,6 @@
     <div class="form-group">
       <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
     </div>
-      <button type="submit" class="btn btn-primary" >更新する</button>
+    <button type="submit" class="btn btn-primary" >更新する</button>
   </form>
 @endsection

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+@section('content')
+  <h2 class="mt-5">投稿を編集する</h2>
+  @include('commons.error_messages')
+  <form method="POST" action="{{ route('post.update', $post->id) }}">
+    @csrf
+    @method('PUT')
+    <div class="form-group">
+      <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
+    </div>
+      <button type="submit" class="btn btn-primary" >更新する</button>
+  </form>
+@endsection

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -15,7 +15,7 @@
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('post.edit', $post->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,4 +24,12 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 //トップページ投稿表示
 Route::get('/', 'PostsController@index');
 
+// ログイン後
+Route::group(['middleware' => 'auth'], function (){
+  Route::prefix('posts')->group(function () {
+      Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
+      Route::put('{id}', 'PostsController@update')->name('post.update');
+  });
+});
+
 //Route::get('/', 'UsersController@index');


### PR DESCRIPTION
## issue
- Closes #124

## 概要
- 投稿編集画面・更新

## 動作確認手順
- 編集・更新
① <localhost:8080>にアクセスし、ログインを行う。（データベース上任意のユーザを選択しログイン。ex.ユーザ1番、email：test1@test.com、pass：test1 など）
②ログイン後、ログインユーザのみ編集するボタンが表示されることを確認。
③編集するボタンを押すと、投稿を編集するページへ移ることを確認。
その時、既に投稿した内容がテキストエリア内に保持されていることも確認。
④テキストエリアに文字や数字を入力し、更新するボタンを押すとトップページ遷移し、入力した投稿に変わっていることを確認。
また、 <http://localhost:8088>のpostsテーブルでログインしているuser_idのcontentが更新されていることを確認。

- エラー表示
上記④で、テキストエリア内に何も入力せず更新するボタンを押した場合、バリデーションエラー（投稿必須のエラー）が表示されることを確認。


## 考慮してほしいこと
- 特にありません。

## 確認してほしいこと
- 不要なものがあればご教示お願いします。