### PR TITLE
#127 フォロー機能・マイグレーション・シーダー（岡田）

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -43,13 +43,13 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
-    // フォロー → フォロワー
+    // フォローしているuser → フォロされているuser
     public function follows()
     {
         return $this->belongsToMany(User::class, 'follow_users', 'following_id', 'followed_id')->withTimestamps();
     }
 
-    // フォロワー → フォロー
+    // フォロされているuser → フォローしているuser
     public function followers()
     {
         return $this->belongsToMany(User::class, 'follow_users', 'followed_id', 'following_id')->withTimestamps();
@@ -58,14 +58,16 @@ class User extends Authenticatable
     public function follow($followedId)
     {
         $exist = $this->isFollow($followedId);
-        if ($exist) {
+        $itsMe = $this->id === $followedId;
+        if ($exist || $itsMe) {
             return false;
         } else {
-            $this->Follows()->attach($followedId);
+            $this->follows()->attach($followedId);
             return true;
         }
     }
-    public function unfollow($followedId)
+
+    public function unFollow($followedId)
     {
         $exist = $this->isFollow($followedId);
         if ($exist) {
@@ -75,6 +77,7 @@ class User extends Authenticatable
             return false;
         }
     }
+
     public function isFollow($followedId)
     {
         return $this->follows()->where('followed_id', $followedId)->exists();

--- a/app/User.php
+++ b/app/User.php
@@ -42,4 +42,41 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    // フォロー → フォロワー
+    public function follows()
+    {
+        return $this->belongsToMany(User::class, 'follow_users', 'following_id', 'followed_id')->withTimestamps();
+    }
+
+    // フォロワー → フォロー
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'follow_users', 'followed_id', 'following_id')->withTimestamps();
+    }
+
+    public function follow($followedId)
+    {
+        $exist = $this->isFollow($followedId);
+        if ($exist) {
+            return false;
+        } else {
+            $this->Follows()->attach($followedId);
+            return true;
+        }
+    }
+    public function unfollow($followedId)
+    {
+        $exist = $this->isFollow($followedId);
+        if ($exist) {
+            $this->follows()->detach($followedId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+    public function isFollow($followedId)
+    {
+        return $this->follows()->where('followed_id', $followedId)->exists();
+    }
 }

--- a/database/migrations/2023_02_11_152043_create_follow_users_table.php
+++ b/database/migrations/2023_02_11_152043_create_follow_users_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follow_users', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('following_id')->unsigned()->index();
+            $table->bigInteger('followed_id')->unsigned()->index();
+            $table->timestamps();
+
+            // 外部キー制約
+            $table->foreign('following_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('followed_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['following_id','followed_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follow_users');
+    }
+}

--- a/database/migrations/2023_02_11_152043_create_follow_users_table.php
+++ b/database/migrations/2023_02_11_152043_create_follow_users_table.php
@@ -15,8 +15,8 @@ class CreateFollowUsersTable extends Migration
     {
         Schema::create('follow_users', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('following_id')->unsigned()->index();
-            $table->bigInteger('followed_id')->unsigned()->index();
+            $table->bigInteger('following_id')->unsigned()->index(); //フォローしているid
+            $table->bigInteger('followed_id')->unsigned()->index(); //フォローされているid
             $table->timestamps();
 
             // 外部キー制約

--- a/database/migrations/2023_02_11_152043_create_follow_users_table.php
+++ b/database/migrations/2023_02_11_152043_create_follow_users_table.php
@@ -15,8 +15,8 @@ class CreateFollowUsersTable extends Migration
     {
         Schema::create('follow_users', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('following_id')->unsigned()->index(); //フォローしているid
-            $table->bigInteger('followed_id')->unsigned()->index(); //フォローされているid
+            $table->bigInteger('following_id')->unsigned()->index(); //フォローしているユーザid
+            $table->bigInteger('followed_id')->unsigned()->index(); //フォローされているユーザid
             $table->timestamps();
 
             // 外部キー制約

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(FollowsTableSeeder::class);
     }
 }

--- a/database/seeds/FollowsTableSeeder.php
+++ b/database/seeds/FollowsTableSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\User;
+
+class FollowsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $following_data = [
+            ['following_id' => 1, 'followed_id' => 3], // id1はid3をフォローしてる
+            ['following_id' => 2, 'followed_id' => 3], // id2はid3をフォローしてる
+            ['following_id' => 3, 'followed_id' => 1], // id3はid1をフォローしてる
+        ];
+
+        foreach($following_data as $following_values) {
+
+            $following_user = User::find($following_values['following_id']);
+            $followed_user = User::find($following_values['followed_id']);
+            $following_user->follow($followed_user->id);
+        }
+    }
+}

--- a/database/seeds/FollowsTableSeeder.php
+++ b/database/seeds/FollowsTableSeeder.php
@@ -13,9 +13,11 @@ class FollowsTableSeeder extends Seeder
     public function run()
     {
         $following_data = [
-            ['following_id' => 1, 'followed_id' => 3], // id1はid3をフォローしてる
+            ['following_id' => 1, 'followed_id' => 2], // id1はid2をフォローしてる
+            ['following_id' => 1, 'followed_id' => 5], // id1はid5をフォローしてる
             ['following_id' => 2, 'followed_id' => 3], // id2はid3をフォローしてる
-            ['following_id' => 3, 'followed_id' => 1], // id3はid1をフォローしてる
+            ['following_id' => 2, 'followed_id' => 4], // id2はid4をフォローしてる
+            ['following_id' => 3, 'followed_id' => 2], // id3はid2をフォローしてる
         ];
 
         foreach($following_data as $following_values) {


### PR DESCRIPTION
## issue
- Closes #127

## 概要
- フォロー機能

## 動作確認手順
- 【Seeder】下記コマンドを実行
php artisan migrate:fresh --seed
- Adminerでfollow_usersテーブル(中間テーブル)にid、following_id(フォローしてるユーザid)、followed_id(フォローされているユーザid)、created_at、updated_atカラムが作成されていることの確認。
また、following_idとfollowed_idのレコードが下記の関係であることを確認
id1がid2とid5をフォローしている。id2がid3とid4をフォローしている。id3がid2をフォローしている。

- 【Tinker】下記コマンドを実行
php artisan tinker
- 名前空間の宣言
use App\User
- 確認したいユーザの定義
user1とuser2のフォロー関係を確認したい場合、$user1 = User::find(1)　と　$user2 = User::find(2)
- isFollowを使ってフォローしているかどうかの確認
例、$user1->isFollow($user2->id);
user1がuser2をフォローしていればtrue、フォローしていなければfalseが表示される
- followを使ってフォロー実行の確認
例、$user1->follow($user2->id);
user1がuser2をフォロー出来ればtrue、既にフォロー済みなどフォローできなければfalseが表示される
- unfollowを使ってフォローを外す確認
例、$user1->unfollow($user2->id);
user1がuser2をフォローを外せればtrue、フォローしておらずフォローを外せない場合にはfalseが表示される


## 考慮してほしいこと
特にありません。

## 確認してほしいこと
- 不要なものや簡潔にできる部分があればご教示お願いします。