### PR TITLE
#127フォロー機能（岡田）

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    public function store($id)
+    {
+        \Auth::user()->follow($id);
+        return back();
+    }
+    public function destroy($id)
+    {
+        \Auth::user()->unFollow($id);
+        return back();
+    }
+}

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,12 +1,12 @@
 @if (Auth::check() && Auth::id() !== $post->user_id)
     @if (Auth::user()->isFollow($post->user_id))
-        <form method="POST" action="{{ route('unFollow', $post->id) }}">
+        <form method="POST" action="{{ route('unFollow', $post->user_id) }}">
             @csrf
             @method('DELETE')
             <button type="submit" class="btn btn-danger">フォローを外す</button>
         </form>
     @else
-        <form method="POST" action="{{ route('follow', $post->id) }}">
+        <form method="POST" action="{{ route('follow', $post->user_id) }}">
             @csrf
             <button type="submit" class="btn btn-success">フォローする</button>
         </form>

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,0 +1,14 @@
+@if (Auth::check() && Auth::id() !== $post->user_id)
+    @if (Auth::user()->isFollow($post->id))
+        <form method="POST" action="{{ route('unFollow', $post->id) }}">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">フォローを外す</button>
+        </form>
+    @else
+        <form method="POST" action="{{ route('follow', $post->id) }}">
+            @csrf
+            <button type="submit" class="btn btn-success">フォローする</button>
+        </form>
+    @endif
+@endif

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,5 +1,5 @@
 @if (Auth::check() && Auth::id() !== $post->user_id)
-    @if (Auth::user()->isFollow($post->id))
+    @if (Auth::user()->isFollow($post->user_id))
         <form method="POST" action="{{ route('unFollow', $post->id) }}">
             @csrf
             @method('DELETE')

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,9 +1,10 @@
 @foreach ($posts as $post)
     <ul class="list-unstyled">
         <li class="mb-3 text-center">
-            <div class="text-left d-inline-block w-75 mb-2">
+            <div class="d-flex d-inline-block w-75 pb-3 m-auto">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
                 <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $post->user->name }}</a></p>
+                @include('follow.follow_button')
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,11 @@ Route::group (['middleware' => 'auth'], function () {
         Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
         Route::post('{id}', 'UsersController@store')->name('users.store');
     });
-
+    // フォロー
+    Route::group(['prefix' => 'users/{id}'], function(){
+        Route::post('follow','FollowController@store')->name('follow');
+        Route::delete('unFollow','FollowController@destroy')->name('unFollow');
+    });
     // 投稿画面編集
     Route::prefix('posts')->group(function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');


### PR DESCRIPTION
## issue
- Closes #127

## 概要
- フォロー機能

## 動作確認手順
- <localhost:8080>にアクセスし、ログインを行う。

- ログイン後、ログインユーザ以外のユーザー名の横にフォローボタンが表示されることを確認。
例、テストデータ（Seeder）ではユーザ1番がユーザ2番とユーザ5番をフォローしているので、その2ユーザはフォローしていること（フォローを外す）を表示をする。
他ユーザは、フォローをしていないこと（フォローする）を表示する。

- 「フォローを外す確認」フォローしているユーザに対しフォローを外すボタンを押すと、トップページへ遷移しフォローするボタンに変わることを確認。
<localhost:8088>のfollow_usersテーブルのレコードが削除されることを確認。

- 「フォローする確認」フォローしていないユーザに対しフォローするボタンを押すと、トップページへ遷移しフォローを外すボタンに変わることを確認。
<localhost:8088>のfollow_usersテーブルのレコードが追加されることを確認。


## 考慮してほしいこと
- 特にありません。

## 確認してほしいこと
- 不要なものがあればご教示お願いします。