### PR TITLE
#127フォロー機能ボタン配置変更(岡田)

### DIFF
--- a/resources/views/commons/footer.blade.php
+++ b/resources/views/commons/footer.blade.php
@@ -1,4 +1,4 @@
-<footer class="mt-5">
+<footer class="mt-3">
     <nav class="navbar navbar-dark bg-info justify-content-center">
         <span class="navbar-brand">©Gut Familie, All rights reserved.</span>
     </nav>

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,12 +1,12 @@
-@if (Auth::check() && Auth::id() !== $post->user_id)
-    @if (Auth::user()->isFollow($post->user_id))
-        <form method="POST" action="{{ route('unFollow', $post->user_id) }}">
+@if (Auth::check() && Auth::user()->id !== $user->id)
+    @if (Auth::user()->isFollow($user->id))
+        <form method="POST" action="{{ route('unFollow', $user->id) }}">
             @csrf
             @method('DELETE')
             <button type="submit" class="btn btn-danger">フォローを外す</button>
         </form>
     @else
-        <form method="POST" action="{{ route('follow', $post->user_id) }}">
+        <form method="POST" action="{{ route('follow', $user->id) }}">
             @csrf
             <button type="submit" class="btn btn-success">フォローする</button>
         </form>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -3,8 +3,7 @@
         <li class="mb-3 text-center">
             <div class="d-flex d-inline-block w-75 pb-3 m-auto">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('users.show', $post->user_id) }}">＠{{ $post->user->name }}</a></p>
-                @include('follow.follow_button')
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('users.show', $post->user_id) }}">{{ $post->user->name }}</a></p>
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('content')
-<div class="row">
+    <div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">
                 <div class="card-header">
@@ -15,6 +15,7 @@
                         @endif
                 </div>
             </div>
+            <div class="text-center mt-4">@include('follow.follow_button')</div>
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">


### PR DESCRIPTION
## issue
- Closes #127

## 概要
- フォロー機能

## 動作確認手順
- <localhost:8080>にアクセスし、ログインを行う。

- ログイン後、ログインユーザーの名前をクリックし、ユーザー詳細ページでアイコンの下にフォローボタンがないことを確認。
- ログインユーザー以外のユーザー名をクリックし、ユーザー詳細ページのアイコン下にフォローボタンが表示されることを確認。
- フォローしているユーザーにはフォローを外すボタンが表示され、フォローをしていないユーザーにはフォローするボタンが表示されることを確認。
フォローしているかどうかは、<localhost:8088>のfollow_usersテーブルのレコードを参照する。

- 「フォローを外す確認」フォローしているユーザに対しフォローを外すボタンを押すと、ユーザー詳細ページのままフォローするボタンに変わることを確認。
localhost:8088のfollow_usersテーブルのレコードが削除されることを確認。

- 「フォローする確認」フォローしていないユーザに対しフォローするボタンを押すと、ユーザー詳細ページのままフォローを外すボタンに変わることを確認。
localhost:8088のfollow_usersテーブルのレコードが追加されることを確認。


## 考慮してほしいこと
- 特にありません。

## 確認してほしいこと
- 不要なものがあればご教示お願いします。