### PR TITLE
#198 ユーザ新規登録画面共通ファイルマージ、ヘッダーリンク貼り付け　(﨑園)

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,3 +1,5 @@
+@extends('layouts.app')
+@section('content')
 <div class="text-center">
         <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
@@ -31,3 +33,4 @@
             </form>
         </div>
     </div>
+@endsection

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -12,7 +12,7 @@
                     <li class="nav-item"><a href="" class="nav-link text-light">ログアウト</a></li>
                 @else
                     <li class="nav-item"><a href="" class="nav-link text-light">ログイン</a></li>
-                    <li class="nav-item"><a href="" class="nav-link text-light">新規ユーザ登録</a></li>
+                    <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>
                 @endif
             </ul>
         </div>


### PR DESCRIPTION
## issues
- Closes #198 

## 概要
- ユーザ新規登録画面に共通ファイルをマージしCSSが適用されています。
- トップページヘッダーの新規ユーザ登録ボタン画面遷移リンク貼り付け。

## 動作確認手順
- http://localhost:8080/へ移行。
- ヘッダー部分の新規ユーザ登録をクリック。
- http://localhost:8080/signupへ画面遷移するか確認。
- 新規ユーザ登録画面の表示を完成版アプリと比較し相違が無いか確認。
- 新規ユーザ登録実施、正常登録、バリデーション確認登録の確認。

## 考慮してほしいこと
- 現在バリデーションエラーメッセージは表示されません。

## 確認してほしいこと
- 最新バージョンのチームブランチを、マージしたあとの作業完了時の注意ポイントや何かアドバイスなどございましたら、ご教授いただければ幸いでございます。