### PR TITLE
#181 投稿削除(﨑園)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -15,5 +15,14 @@ class PostsController extends Controller
     
         return view('welcome', ['posts' => $posts]);
     }
+
+    public function destroy($id)
+    {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
+            $post->delete();
+        }
+        return back();
+    }
     
 }

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -15,7 +15,9 @@
                     </div>
                     @if (Auth::id() === $post->user_id)
                         <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                            <form method="POST" action="#">
+                            <form method="POST" action="{{ route('post.delete', $post->id) }}">
+                                @csrf
+                                @method('DELETE')
                                 <button type="submit" class="btn btn-danger">削除</button>
                             </form>
                             <a href="#" class="btn btn-primary">編集する</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,3 +29,11 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // 投稿一覧表示
 Route::get('/', 'PostsController@index')->name('posts');
+
+// 投稿削除
+Route::group(['middleware' => 'auth'], function () {
+    // 投稿関連
+    Route::prefix('posts')->group(function () {
+        Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,9 +30,9 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 // 投稿一覧表示
 Route::get('/', 'PostsController@index')->name('posts');
 
-// 投稿削除
+// 投稿関連
 Route::group(['middleware' => 'auth'], function () {
-    // 投稿関連
+    // 投稿（新規、編集、更新、削除）
     Route::prefix('posts')->group(function () {
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });


### PR DESCRIPTION
## issue
- Closes #181 

## 概要
- 投稿削除機能の実装

## 動作確認手順
- localhost:8080にアクセス
- 登録されているユーザーでログイン
- 本来はテストとして投稿するのですが、現状、新規投稿機能がマージされていないので、アドマイナーのPostsテーブルにてログインユーザーのidを使用しpostsテーブルに投稿を登録する
- アプリに戻り、ログインユーザーの投稿を探す
- ログインユーザーの投稿の下部に赤色の削除ボタンが表示されていることを確認
- 削除ボタンを押すと、投稿が削除されると共に一つ前の画面に戻ることを確認
- Postsテーブルも内容が物理削除されていることを確認

## 考慮してほしいこと
- 現状は新規投稿機能がマージされていないのでアドマイナーにて投稿を手入力していただかないといけない

## 確認してほしいこと
- 応用講座の内容をそのまま引用し、共同開発に反映しております。完成版とも比較完了しております。ご確認のほど何卒よろしくお願い致します。