### PR TITLE
#215 #183 投稿編集画面・投稿更新(平林）

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -36,7 +36,7 @@ class PostController extends Controller
             ];
             return view('post.edit', $data);
         }
-            abort(404);
+        abort(404);
     }
 
     public function update(PostRequest $request, $id)

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -15,6 +15,7 @@ class PostController extends Controller
             'posts' => $posts,
         ]);
     }
+
     public function store(PostRequest $request)
     {
         $post = new Posts;
@@ -23,16 +24,21 @@ class PostController extends Controller
         $post->save();
         return back();
     }
+
     public function edit($id)
-    {
+    {   
         $user = \Auth::user();
-        $posts = Posts::findOrFail($id);
-        $data = [
-            'user' => $user,
-            'posts' => $posts,
-        ];
-        return view('post.edit', $data);
+        $post = Posts::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
+            $data = [
+                'user' => $user,
+                'post' => $post,
+            ];
+            return view('post.edit', $data);
+        }
+            abort(404);
     }
+
     public function update(PostRequest $request, $id)
     {
         $post = Posts::findOrFail($id);
@@ -41,6 +47,7 @@ class PostController extends Controller
         $post->save();
         return redirect('');
     }
+    
     public function destroy($id)
     {
         $post = Posts::findOrFail($id);

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -24,4 +24,22 @@ class PostController extends Controller
         $post->save();
         return back();
     }
+    public function edit($id)
+    {
+        $user = \Auth::user();
+        $posts = Posts::findOrFail($id);
+        $data = [
+            'user' => $user,
+            'posts' => $posts,
+        ];
+        return view('post.edit', $data);
+    }
+    public function update(PostRequest $request, $id)
+    {
+        $post = Posts::findOrFail($id);
+        $post->text = $request->contents;
+        $post->user_id = $request->user()->id;
+        $post->save();
+        return redirect('');
+    }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,6 +24,7 @@ class PostRequest extends FormRequest
     {
         return [
             'contents' => 'required|max:140',
+            
         ];
     }
     public function attributes()
@@ -32,4 +33,5 @@ class PostRequest extends FormRequest
             'contents' => '投稿',
         ];
     }
+    
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,7 +24,6 @@ class PostRequest extends FormRequest
     {
         return [
             'contents' => 'required|max:140',
-            
         ];
     }
     public function attributes()
@@ -33,5 +32,4 @@ class PostRequest extends FormRequest
             'contents' => '投稿',
         ];
     }
-    
 }

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -1,9 +1,12 @@
 @extends('layouts.app')
 @section('content')
 <h2 class="mt-5">投稿を編集する</h2>
-<form method="" action="">
+<form method="POST" action="{{ route('post.update', $posts->id) }}">
+    @csrf
+    @method('PUT')
     <div class="form-group">
-        <textarea id="content" class="form-control" name="" rows=""></textarea>
+        @include('commons.error_messages')
+        <textarea id="content" class="form-control" name="contents" rows="5"></textarea>
     </div>
     <button type="submit" class="btn btn-primary">更新する</button>
 </form>

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -6,7 +6,7 @@
     @method('PUT')
     <div class="form-group">
         @include('commons.error_messages')
-        <textarea id="content" class="form-control" name="contents" rows="5" >{{ old('contents', $post->contents) }}</textarea>
+        <textarea id="content" class="form-control" name="contents" rows="5" >{{ old('contents', $post->text) }}</textarea>
     </div>
     <button type="submit" class="btn btn-primary">更新する</button>
 </form>

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -1,12 +1,12 @@
 @extends('layouts.app')
 @section('content')
 <h2 class="mt-5">投稿を編集する</h2>
-<form method="POST" action="{{ route('post.update', $posts->id) }}">
+<form method="POST" action="{{ route('post.update', $post->id) }}">
     @csrf
     @method('PUT')
     <div class="form-group">
         @include('commons.error_messages')
-        <textarea id="content" class="form-control" name="contents" rows="5"></textarea>
+        <textarea id="content" class="form-control" name="contents" rows="5" >{{ old('contents', $post->contents) }}</textarea>
     </div>
     <button type="submit" class="btn btn-primary">更新する</button>
 </form>

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5">投稿を編集する</h2>
+<form method="" action="">
+    <div class="form-group">
+        <textarea id="content" class="form-control" name="" rows=""></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">更新する</button>
+</form>
+@endsection

--- a/resources/views/post/post.blade.php
+++ b/resources/views/post/post.blade.php
@@ -17,7 +17,7 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="{{ route('post.edit', $post->user->id) }}" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('post.edit', $post->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/resources/views/post/post.blade.php
+++ b/resources/views/post/post.blade.php
@@ -15,7 +15,7 @@
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('post.edit', $post->user->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,13 +10,26 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
-//トップページの表示
-Route::get('/', 'PostController@index');
-
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
-
+//トップページ
+Route::get('/', 'PostController@index');
+//ユーザー
+Route::prefix('users')->group(function () {
+    Route::get('{id}', 'UsersController@show')->name('users.show');
+});
 //ユーザ登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
+
+//ログイン後
+Route::group(['middleware' => 'auth'], function () {
+    // 投稿
+    Route::prefix('post')->group(function () {
+    Route::delete('{id}', 'PostController@destroy')->name('post.delete');
+    Route::get('{id}/edit', 'PostController@edit')->name('post.edit');
+    Route::put('{id}', 'PostController@update')->name('post.update');
+    });
+    
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,10 +25,9 @@ Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
-  // 投稿
+// 投稿
 Route::prefix('post')->group(function () {
     Route::post('', 'PostController@store')->name('post.store');
-    Route::delete('{id}', 'PostController@destroy')->name('post.delete');
     Route::get('{id}/edit', 'PostController@edit')->name('post.edit');
     Route::put('{id}', 'PostController@update')->name('post.update');
   });


### PR DESCRIPTION
## issue
- Closes #215 #183

## 概要
- 投稿編集画面・更新

## 動作確認手順
- adminerで更新を確認。
- テキストエリアで空欄または１４０字以上だとエラーを表示できている。
- 更新後トップページに遷移していることを確認。
- トップページの編集ボタンから編集画面にいくことを確認。
- ユーザー詳細画面の編集ボタンからも編集画面に行くことを確認。
- ログインしているユーザーと所有しているidが一致していると投稿を編集できることを確認。
- 編集画面に遷移したときにテキストの内容の値が保持されいることを確認。
## 確認してほしいこと
インデントの場所abort（404）;であってますでしょうか？

```
