### PR TITLE
#186 ユーザ退会(﨑園)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -12,11 +12,6 @@ class UsersController extends Controller
 {
     use SoftDeletes;
 
-    public function index()
-    {
-        return view('welcome');
-    }
-
     public function show($id)
     {
         $user = User::findOrFail($id);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\User;
 
 class UsersController extends Controller
 {
@@ -10,4 +11,15 @@ class UsersController extends Controller
     {
         return view('welcome');
     }
+
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        // if (\Auth::id() === $user->id) {
+            $user->delete();
+            
+            return redirect('/');
+    }
 }
+        
+

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -12,27 +12,26 @@ class UsersController extends Controller
         return view('welcome');
     }
 
-    public function destroy($id)
-    {
-        $user = User::findOrFail($id);
-        if (\Auth::id() === $user->id) {
-            $user->delete();
-            
-            return redirect('/');
-        }                
-    }
-
     public function show($id)
     {
         $user = User::findOrFail($id);
         $posts = $user->posts()->orderBy('id', 'desc')->paginate(9);
         $data = [
-        'user' => $user,
-        'posts' => $posts,
+            'user' => $user,
+            'posts' => $posts,
         ];
         $data += $this->userCounts($user);
-
+        
         return view('users.show', $data);
+    }
+    
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id) {
+            $user->delete();            
+        }
+        return redirect('/');              
     }
 }
         

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -15,10 +15,11 @@ class UsersController extends Controller
     public function destroy($id)
     {
         $user = User::findOrFail($id);
-        // if (\Auth::id() === $user->id) {
+        if (\Auth::id() === $user->id) {
             $user->delete();
             
             return redirect('/');
+        }                
     }
 
     public function show($id)

--- a/app/Post.php
+++ b/app/Post.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/User.php
+++ b/app/User.php
@@ -39,8 +39,19 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
+    protected $dates = ['deleted_at'];
+
     public function posts()
     {
         return $this->hasMany(Post::class);
+    }
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -39,13 +39,16 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
-    protected $dates = ['deleted_at'];
+    protected $dates = [
+        'deleted_at'
+    ];
 
     public function posts()
     {
         return $this->hasMany(Post::class);
     }
 
+    // ユーザ退会と同時にユーザが所有する投稿も削除する内容
     public static function boot()
     {
         parent::boot();

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -13,6 +13,7 @@
         <div class="col-sm-6 offset-sm-3">
             <form method="POST" action="{{ route('signup.post') }}">
                 @csrf
+                @include('commons.error_messages')
                 <div class="form-group">
                     <label for="name">名前</label>
                     <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}">

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -7,6 +7,7 @@
                 <div class="text-left d-inline-block w-75 mb-2">
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像">
                     <p class="mt-3 mb-0 d-inline-block"><a href="#">{{ $user->name }}</a></p>
+                        
                 </div>
                 <div class="">
                     <div class="text-left d-inline-block w-75">
@@ -18,7 +19,7 @@
                             <form method="POST" action="{{ route('post.delete', $post->id) }}">
                                 @csrf
                                 @method('DELETE')
-                                <button type="submit" class="btn btn-danger">削除</button>
+                                <button type="submit" class="btn btn-danger">削除</button>            
                             </form>
                             <a href="#" class="btn btn-primary">編集する</a>
                         </div>
@@ -27,4 +28,31 @@
             </li>
     @endforeach
 </ul>
+
 <div class="m-auto" style="width: fit-content">{{ $posts->links() }}</div>
+
+<div class="d-flex justify-content-between">
+    <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+</div>
+
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>確認</h4>
+            </div>
+            <div class="modal-body">
+                <label>本当に退会しますか？</label>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <form action="{{ route('users.delete', $user->id) }}" method="POST">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">退会する</button>
+                </form>
+                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+            </div>
+        </div>
+    </div>
+</div>
+

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -30,28 +30,7 @@
 
 <div class="m-auto" style="width: fit-content">{{ $posts->links() }}</div>
 
-<div class="d-flex justify-content-between">
-    <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-</div>
 
-<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4>確認</h4>
-            </div>
-            <div class="modal-body">
-                <label>本当に退会しますか？</label>
-            </div>
-            <div class="modal-footer d-flex justify-content-between">
-                <form action="{{ route('users.delete', $user->id) }}" method="POST">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-danger">退会する</button>
-                </form>
-                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-            </div>
-        </div>
-    </div>
-</div>
+
+
 

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -29,8 +29,3 @@
 </ul>
 
 <div class="m-auto" style="width: fit-content">{{ $posts->links() }}</div>
-
-
-
-
-

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -31,22 +31,24 @@
         </div>
     </form>
 
-    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4>確認</h4>
-                </div>
-                <div class="modal-body">
-                    <label>本当に退会しますか？</label>
-                </div>
-                <div class="modal-footer d-flex justify-content-between">
-                    <form action="" method="POST">
-                        <button type="submit" class="btn btn-danger">退会する</button>
-                    </form>
-                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-                </div>
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>確認</h4>
+            </div>
+            <div class="modal-body">
+                <label>本当に退会しますか？</label>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <form action="{{ route('users.delete', $user->id) }}" method="POST">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">退会する</button>
+                </form>
+                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
             </div>
         </div>
     </div>
-    @endsection
+</div>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -31,24 +31,24 @@
         </div>
     </form>
 
-<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4>確認</h4>
-            </div>
-            <div class="modal-body">
-                <label>本当に退会しますか？</label>
-            </div>
-            <div class="modal-footer d-flex justify-content-between">
-                <form action="{{ route('users.delete', $user->id) }}" method="POST">
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="{{ route('users.delete', $user->id) }}" method="POST">
                     @csrf
                     @method('DELETE')
-                    <button type="submit" class="btn btn-danger">退会する</button>
-                </form>
-                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -24,12 +24,16 @@
          <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
       </ul>
       @include('posts.post',['user' =>$user,'posts' => $posts])
-      <div class="d-flex justify-content-between">
-         <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-      </div>
    </div>
+   @if(Auth::check() && Auth::id() == $user->id)
+   <div class="d-flex justify-content-between">
+      <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+   </div>
+   @endif
 </div>
 @endsection
+
+
 
 <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
     <div class="modal-dialog">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -24,6 +24,30 @@
          <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
       </ul>
       @include('posts.post',['user' =>$user,'posts' => $posts])
+      <div class="d-flex justify-content-between">
+         <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+      </div>
    </div>
 </div>
 @endsection
+
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>確認</h4>
+            </div>
+            <div class="modal-body">
+                <label>本当に退会しますか？</label>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <form action="{{ route('users.delete', $user->id) }}" method="POST">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">退会する</button>
+                </form>
+                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -10,8 +10,7 @@
             <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像" >
             @if(Auth::check() && Auth::id() == $user->id)
             <div class="mt-3">
-               <a href="{{ route('users.show',$user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
-               <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+               <a href="{{ route('users.edit',$user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
             </div>
             @endif
          </div>
@@ -29,23 +28,3 @@
 </div>
 @endsection
 
-<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4>確認</h4>
-            </div>
-            <div class="modal-body">
-                <label>本当に退会しますか？</label>
-            </div>
-            <div class="modal-footer d-flex justify-content-between">
-                <form action="{{ route('users.delete', $user->id) }}" method="POST">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-danger">退会する</button>
-                </form>
-                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-            </div>
-        </div>
-    </div>
-</div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -11,6 +11,7 @@
             @if(Auth::check() && Auth::id() == $user->id)
             <div class="mt-3">
                <a href="{{ route('users.show',$user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+               <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
             </div>
             @endif
          </div>
@@ -25,15 +26,8 @@
       </ul>
       @include('posts.post',['user' =>$user,'posts' => $posts])
    </div>
-   @if(Auth::check() && Auth::id() == $user->id)
-   <div class="d-flex justify-content-between">
-      <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-   </div>
-   @endif
 </div>
 @endsection
-
-
 
 <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
     <div class="modal-dialog">

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,7 @@ Route::prefix('users/{id}')->group(function () {
     Route::group(['middleware' => 'auth'], function () {
             Route::get('edit', 'UsersController@edit')->name('users.edit');
             Route::put('/', 'UsersController@update')->name('users.update');
-            Route::delete('', 'UsersController@destroy')->name('users.delete');  
+            Route::delete('/', 'UsersController@destroy')->name('users.delete');  
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,10 +22,12 @@ Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 // トップページの投稿表示のためコメントアウト
 // Route::get('/', 'UsersController@index');
 
-    // ユーザ詳細
+// ユーザ詳細
 Route::get('/', 'UsersController@index');
+// ユーザ（詳細、編集、更新、削除）
 Route::prefix('users')->group(function () {
     Route::get('{id}', 'UsersController@show')->name('users.show');
+    Route::delete('{id}', 'UsersController@destroy')->name('users.delete');
 });  
 
 // ログイン
@@ -44,5 +46,4 @@ Route::group(['middleware' => 'auth'], function () {
     });         
 });
 
-// ユーザ退会
-Route::delete('{id}', 'UsersController@destroy')->name('users.delete');
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,5 +45,3 @@ Route::group(['middleware' => 'auth'], function () {
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
 });
-
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,7 @@ Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('sign
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 // トップページの投稿表示のためコメントアウト
-    // Route::get('/', 'UsersController@index');
+// Route::get('/', 'UsersController@index');
 
 // ログイン
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
@@ -37,3 +37,6 @@ Route::group(['middleware' => 'auth'], function () {
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
 });
+
+// ユーザ退会
+Route::delete('{id}', 'UsersController@destroy')->name('users.delete');


### PR DESCRIPTION
## issue
- Closes #186 

## 概要
- ユーザ退会機能と新規ユーザ画面のエラー表示

## 動作確認手順

1. ユーザ退会機能
- 登録済ユーザでログイン
- ログインユーザ詳細画面へ移行
- アイコン下のユーザ情報の編集ボタンを押下
- 左下の退会ボタンを押下
- 退会確認画面が表示されたことを確認
- 退会確認画面で表示された退会ボタンを押下
- トップページに遷移することを確認(このときユーザネーム表示箇所を確認し、新規ユーザ表示画面になっていることを併せて確認)

2. 新規ユーザ登録画面エラーメッセージ表示
- 新規ユーザ登録画面へ遷移
- 各項目でエラー表示されるように登録
- 新規ユーザ登録の文字の下側にエラーメッセージが表示されることを確認

## 考慮してほしいこと
- 先に場所を変えて、ボタン配置をしたり他ブランチを確認したりしてcommit数が多くなっています。申し訳ございません。

## 確認してほしいこと
- ユーザ退会と同時にユーザの所有する情報を削除するコードが調べるとたくさん出てきました。他の書き方やもっとスマートに記述することなども出来ますでしょうか？あれば教えていただきたいです！