### PR TITLE
#188　フォロー機能のみ実装(杉原）

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    public function store($id)
+    {
+        \Auth::user()->follow($id);
+        return back();
+    }
+    public function destroy($id)
+    {
+        \Auth::user()->unfollow($id);
+        return back();
+    }
+}

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -11,9 +11,11 @@ class FollowController extends Controller
         \Auth::user()->follow($id);
         return back();
     }
+
     public function destroy($id)
     {
-        \Auth::user()->unfollow($id);
+        \Auth::user()->unFollow($id);
         return back();
     }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,37 @@ class User extends Authenticatable
     {
         return $this->hasMany(Posts::class);
     }
+
+    public function follows()
+    {
+        return $this->belongsToMany(User::class, 'user_follow', 'user_id', 'follow_id')->withTimestamps();
+    }
+
+    public function follow($userid)
+    {
+        $exist = $this->isfollow($userid);
+        if ($exist) {
+            return false;
+        } else {
+            $this->follows()->attach($userid);
+            return true;
+        }
+    }
+
+    public function unfollow($userid)
+    {
+        $exist = $this->isfollow($userid);
+        if ($exist) {
+            $this->follows()->detach($userid);
+            return true;
+        } else {
+            return false;
+        }
+    }
+    
+    public function isfollow($userid)
+    {
+        return $this->follows()->where('follow_id', $userid)->exists();
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -44,36 +44,41 @@ class User extends Authenticatable
         return $this->hasMany(Posts::class);
     }
 
-    public function follows()
+    public function followings()
     {
         return $this->belongsToMany(User::class, 'user_follow', 'user_id', 'follow_id')->withTimestamps();
     }
 
-    public function follow($userid)
+    public function followers()
     {
-        $exist = $this->isfollow($userid);
+        return $this->belongsToMany(User::class, 'user_follow', 'follow_id', 'user_id')->withTimestamps();
+    }
+
+    public function follow($userId)
+    {
+        $exist = $this->isFollow($userId);
         if ($exist) {
             return false;
         } else {
-            $this->follows()->attach($userid);
+            $this->followings()->attach($userId);
             return true;
         }
     }
 
-    public function unfollow($userid)
+    public function unFollow($userId)
     {
-        $exist = $this->isfollow($userid);
+        $exist = $this->isFollow($userId);
         if ($exist) {
-            $this->follows()->detach($userid);
+            $this->followings()->detach($userId);
             return true;
         } else {
             return false;
         }
     }
     
-    public function isfollow($userid)
+    public function isFollow($userId)
     {
-        return $this->follows()->where('follow_id', $userid)->exists();
+        return $this->followings()->where('follow_id', $userId)->exists();
     }
 
 }

--- a/database/migrations/2023_04_19_011219_create_user_follow_table.php
+++ b/database/migrations/2023_04_19_011219_create_user_follow_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserFollowTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('user_follow', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('follow_id')->unsigned()->index();
+            $table->timestamps();
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('follow_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['user_id','follow_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_follow');
+    }
+}

--- a/resources/views/users/follow_button.blade.php
+++ b/resources/views/users/follow_button.blade.php
@@ -1,6 +1,6 @@
-@if (Auth::check() && Auth::id() !== $followuser->id)
-    @if (Auth::user()->isfollow($followuser->id))
-        <form method="POST" action="{{ route('unfollow', $followuser->id) }}">
+@if (Auth::check() && Auth::id() !== $followUser->id)
+    @if (Auth::user()->isFollow($followUser->id))
+        <form method="POST" action="{{ route('unFollow', $followUser->id) }}">
             @csrf
             @method('DELETE')
             <div align="center">
@@ -8,7 +8,7 @@
             </div>
         </form>
     @else
-        <form method="POST" action="{{ route('follow', $followuser->id) }}">
+        <form method="POST" action="{{ route('follow', $followUser->id) }}">
             @csrf
             <div align="center">
                 <button type="submit" style="width:70%;padding:10px;font-size:20px;" class="btn btn-success">フォロ―する</button>

--- a/resources/views/users/follow_button.blade.php
+++ b/resources/views/users/follow_button.blade.php
@@ -1,0 +1,18 @@
+@if (Auth::check() && Auth::id() !== $followuser->id)
+    @if (Auth::user()->isfollow($followuser->id))
+        <form method="POST" action="{{ route('unfollow', $followuser->id) }}">
+            @csrf
+            @method('DELETE')
+            <div align="center">
+                <button type="submit" style="width:70%;padding:10px;font-size:20px;" class="btn btn-danger btn btn-primary">フォロ―を外す</button>
+            </div>
+        </form>
+    @else
+        <form method="POST" action="{{ route('follow', $followuser->id) }}">
+            @csrf
+            <div align="center">
+                <button type="submit" style="width:70%;padding:10px;font-size:20px;" class="btn btn-success">フォロ―する</button>
+            </div>
+        </form>
+    @endif
+@endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -16,7 +16,7 @@
                 @endif
           </div>
         </div><br>
-        @include('users.follow_button',['followuser'=>$user])
+        @include('users.follow_button', ['followUser'=>$user])
     </aside>
     <div class="col-sm-8">
       <ul class="nav nav-tabs nav-justified mb-3">
@@ -24,7 +24,7 @@
           <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
           <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
       </ul>
-      @include('post.post',['posts' => $posts])
+      @include('post.post', ['posts' => $posts])
     </div>
  </div>
  @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -15,7 +15,8 @@
                     </div>
                 @endif
           </div>
-        </div>
+        </div><br>
+        @include('users.follow_button',['followuser'=>$user])
     </aside>
     <div class="col-sm-8">
       <ul class="nav nav-tabs nav-justified mb-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,4 +32,9 @@ Route::group(['middleware' => 'auth'], function () {
       Route::post('', 'PostController@store')->name('post.store');
       Route::delete('{id}', 'PostController@destroy')->name('post.delete');
   });
+  // いいね
+  Route::group(['prefix' => 'users/{id}'],function(){
+      Route::post('follow','FollowController@store')->name('follow');
+      Route::delete('unfollow','FollowController@destroy')->name('unfollow');
+  });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,6 @@ Route::group(['middleware' => 'auth'], function () {
   // いいね
   Route::group(['prefix' => 'users/{id}'],function(){
       Route::post('follow','FollowController@store')->name('follow');
-      Route::delete('unfollow','FollowController@destroy')->name('unfollow');
+      Route::delete('unFollow','FollowController@destroy')->name('unFollow');
   });
 });


### PR DESCRIPTION
## issue
- Closes #188
## 概要
- ユーザー詳細画面でのフォロー機能
## 動作確認手順
### 下記操作を実行。  
- 登録済のユーザでログイン
- 投稿一覧画面にてログインしたユーザではないユーザの投稿されているネームリンクを押下し詳細画面へ遷移
**フォローするボタンが表示されている事を確認** 
- フォローするボタンを押下する
**adminerにてuser_follow.tableのデータを確認　１件レコードが作成されている事を確認**
**フォローするボタンがフォローをはずすボタンに変更していることを確認**
- フォローをはずすボタンを押下する
**adminerにてuser_follw.tableのデータを確認　先程作成されたレコードが削除されている事を確認**
**フォローをはずすボタンがフォローするボタンへ変更していることを確認**
- トップページに戻り　ログインしたユーザの投稿のネームリンクを押下し詳細画面へ遷移
**ユーザー詳細画面にフォローするボタンが表示されていない事を確認する**
## 考慮してほしいこと
- user_follow.tableを新規で作成しましたので  php artisan migrate:fresh --seedをお願いします。  
- フロント側のフォローボタンの配置位置などはテストアプリにもなく踏襲できなかったので調べましたがむりくり  合わせているのでいまいちですが、バックエンドの処理を早めにみていただきたいのでプルリク申請させていただきました。　
## 確認してほしいこと
　宜しくお願いいたします。 
