### PR TITLE
更新フラッシュメッセージ（平林）

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -45,7 +45,7 @@ class PostController extends Controller
         $post->text = $request->contents;
         $post->user_id = $request->user()->id;
         $post->save();
-        return redirect('');
+        return redirect('')->with('updateMessage', '更新しました！');
     }
     
     public function destroy($id)

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -45,7 +45,7 @@ class PostController extends Controller
         $post->text = $request->contents;
         $post->user_id = $request->user()->id;
         $post->save();
-        return redirect('')->with('updateMessage', '更新しました！');
+        return redirect('')->with('successMessage', '更新しました。');
     }
     
     public function destroy($id)

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,11 +5,7 @@
         <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Posts</h1>
     </div>
 </div>
-@if (session('updateMessage'))
-  <div class="alert alert-success text-center w-75 mx-auto">
-    {{ session('updateMessage') }}
-  </div> 
-@elseif (session('alertMessage'))
+@if (session('alertMessage'))
     <div class="alert alert-danger text-center w-75 mx-auto">
         {{ session('alertMessage') }}
     </div> 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,6 +5,11 @@
         <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Posts</h1>
     </div>
 </div>
+@if (session('updateMessage'))
+  <div class="alert alert-success text-center w-75 mx-auto">
+    {{ session('updateMessage') }}
+  </div> 
+@endif
 <h5 class="description text-center">"○○"について140字以内で会話しよう！</h5>
 @if (Auth::check())
     <div class="w-75 m-auto">@include('commons.error_messages')</div>


### PR DESCRIPTION
## 概要
- 更新のフラッシュメッセージの表示

## 動作確認手順
- 編集画面から更新ボタンを押した際にトップページに遷移し更新フラッシュメッセージが表示されることを確認。

## 確認してほしいこと
- 前回の内容にはなるんですがユーザー詳細画面の削除フラッシュメッセージをタイムラインのタブの幅で真上に持ってくるやり方を教えていただきたいです。  そのような配置でもおかしくないでしょうか？