### PR TITLE
#307　投降新規作成（おおた）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -21,7 +21,7 @@ class PostsController extends Controller
     {
         $post = new Post;
         $post->text = $request->text;
-        $post->user_id = $request->user()->id;
+        $post->user_id = \Auth::id();
         $post->save();
         return back();
     }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Post;
+use App\User;
+use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller
 {
@@ -13,5 +15,14 @@ class PostsController extends Controller
         return view('welcome', [
             'posts' => $posts,
         ]);
+    }
+
+    public function store(PostRequest $request)
+    {
+        $post = new Post;
+        $post->text = $request->text;
+        $post->user_id = $request->user()->id;
+        $post->save();
+        return back();
     }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'text' => 'required|max:140',
+        ];
+    }
+    public function attributes()
+    {
+        return [
+            'text' => '投降する文字',
+        ];
+    }
+
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -6,12 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 
 class Post extends Model
-{
-
+{    
     protected $fillable = [
         'text'
     ];
-
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
     <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
         @csrf
         <div class="form-group">
-            <textarea class="form-control" name="text" rows="4"></textarea>
+            <textarea class="form-control" name="text" rows="4">{{ old('text') }}</textarea>
             <div class="text-left mt-3">
                 <button type="submit" class="btn btn-primary">投稿する</button>
             </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,21 +1,24 @@
 @extends('layouts.app')
 @section('content')
 <div class="center jumbotron bg-info">
-        <div class="text-center text-white mt-2 pt-1">
-            <h1><i class="pr-3"></i>Topic Posts</h1>
-        </div>
+    <div class="text-center text-white mt-2 pt-1">
+        <h1><i class="pr-3"></i>Topic Posts</h1>
     </div>
-    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-    <div class="w-75 m-auto">@include('commons.error_messages')</div>
-        <div class="text-center mb-3">
-            <form method="" action="" class="d-inline-block w-75">
-                <div class="form-group">
-                    <textarea class="form-control" name="" rows=""></textarea>
-                    <div class="text-left mt-3">
-                        <button type="submit" class="btn btn-primary">投稿する</button>
-                    </div>
-                </div>
-            </form>
+</div>
+<h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+<div class="w-75 m-auto">@include('commons.error_messages')</div>
+@if (Auth::check())
+<div class="text-center mb-3">
+    <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+        @csrf
+        <div class="form-group">
+            <textarea class="form-control" name="text" rows="4"></textarea>
+            <div class="text-left mt-3">
+                <button type="submit" class="btn btn-primary">投稿する</button>
+            </div>
         </div>
-    @include('posts.posts',['posts' => $posts])
+    </form>
+</div>
+@endif
+@include('posts.posts',['posts' => $posts])
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,24 +1,24 @@
 @extends('layouts.app')
 @section('content')
-<div class="center jumbotron bg-info">
-    <div class="text-center text-white mt-2 pt-1">
-        <h1><i class="pr-3"></i>Topic Posts</h1>
-    </div>
-</div>
-<h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-<div class="w-75 m-auto">@include('commons.error_messages')</div>
-@if (Auth::check())
-<div class="text-center mb-3">
-    <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
-        @csrf
-        <div class="form-group">
-            <textarea class="form-control" name="text" rows="4">{{ old('text') }}</textarea>
-            <div class="text-left mt-3">
-                <button type="submit" class="btn btn-primary">投稿する</button>
-            </div>
+    <div class="center jumbotron bg-info">
+        <div class="text-center text-white mt-2 pt-1">
+            <h1><i class="pr-3"></i>Topic Posts</h1>
         </div>
-    </form>
-</div>
-@endif
-@include('posts.posts',['posts' => $posts])
+    </div>
+    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+    <div class="w-75 m-auto">@include('commons.error_messages')</div>
+    @if (Auth::check())
+        <div class="text-center mb-3">
+            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+                @csrf
+                <div class="form-group">
+                    <textarea class="form-control" name="text" rows="4">{{ old('text') }}</textarea>
+                    <div class="text-left mt-3">
+                        <button type="submit" class="btn btn-primary">投稿する</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    @endif
+    @include('posts.posts',['posts' => $posts])
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,3 +21,11 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // トップページ
 Route::get('/', 'postsController@index');
+
+// ログイン後
+Route::group(['middleware' => 'auth'], function () {
+    // 投稿新規作成（投降削除はこれから実装予定）
+    Route::prefix('/')->group(function () {
+        Route::post('', 'PostsController@store')->name('post.store');
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ Route::get('/', 'postsController@index');
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
     // 投稿新規作成（投降削除はこれから実装予定）
-    Route::prefix('post')->group(function () {
+    Route::prefix('posts')->group(function () {
         Route::post('', 'PostsController@store')->name('post.store');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,7 @@ Route::get('/', 'postsController@index');
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
     // 投稿新規作成（投降削除はこれから実装予定）
-    Route::prefix('/')->group(function () {
+    Route::prefix('post')->group(function () {
         Route::post('', 'PostsController@store')->name('post.store');
     });
 });


### PR DESCRIPTION
## issue
- Closes #307

## 概要
- 投降新規作成（おおた）

## 動作確認手順
- 投降フォーム（ログイン前は表示されず、ログイン後にフォームが表示される）
- 投降した文章が一番上に表示されるか
- バリデーションの動作（空欄はNG、最大140文字）

## 考慮して欲しいこと
- 投降削除、投降編集機能は未実装です

## 確認してほしいこと
- web.phpの以下コードが問題ないかご確認お願いします。

```
// ログイン後
Route::group(['middleware' => 'auth'], function () {
    // 投稿新規作成（投降削除はこれから実装予定）
    Route::prefix('/')->group(function () {
        Route::post('', 'PostsController@store')->name('post.store');
    });
});
```
