### PR TITLE
#328 ユーザ退会（Ninomiya）

### DIFF
--- a/app/Http/Controllers/EditUserController.php
+++ b/app/Http/Controllers/EditUserController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\User; 
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
 
 class EditUserController extends Controller
 {
@@ -26,5 +27,16 @@ class EditUserController extends Controller
         $user->password = Hash::make($request->password);
         $user->save();
         return redirect()->route('user.show', $user->id);
+    }
+
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if ($user->id === \Auth::id() ) {
+            $user->delete();
+            Auth::logout();
+            return redirect('/');
+        }
+        return back();
     }
 }

--- a/app/Http/Controllers/EditUserController.php
+++ b/app/Http/Controllers/EditUserController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use App\User; 
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Auth;
 
 class EditUserController extends Controller
 {
@@ -34,7 +33,6 @@ class EditUserController extends Controller
         $user = User::findOrFail($id);
         if ($user->id === \Auth::id() ) {
             $user->delete();
-            Auth::logout();
             return redirect('/');
         }
         return back();

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -24,5 +24,4 @@ class UsersController extends Controller
         ];
         return view('users.show', $data);
     }
-
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -29,5 +29,4 @@ class UserRequest extends FormRequest
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ];
     }
-
 }

--- a/app/User.php
+++ b/app/User.php
@@ -44,4 +44,12 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    // postsテーブル実装後
+    // public static function boot()
+    // {
+    //     parent::boot();
+    //     static::deleted(function ($user) {
+    //         $user->posts()->delete();
+    //     });
+    // }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -44,12 +44,11 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
-    // postsテーブル実装後
-    // public static function boot()
-    // {
-    //     parent::boot();
-    //     static::deleted(function ($user) {
-    //         $user->posts()->delete();
-    //     });
-    // }
+    public static function boot()
+    {
+        parent::boot();
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -18,7 +18,6 @@
         <div class="form-group">
             <label for="password">パスワード</label>
             <input id="password" input class="form-control" type="password" value="{{ old('password') }}" name="password" />
-
         </div>
 
         <div class="form-group">
@@ -27,7 +26,29 @@
         </div>
 
         <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form method="POST" action="{{ route('user.delete', \Auth::user()->id) }}" >
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,5 +31,6 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('users')->group(function () {
         Route::get('{id}/edit', 'EditUserController@edit')->name('edit'); 
         Route::put('{id}', 'EditUserController@update')->name('update');
+        Route::delete('{id}', 'EditUserController@destroy')->name('user.delete');
     });
 });


### PR DESCRIPTION
## issue
- Close #328 

## 動作環境手順
ログイン状態で「ユーザ詳細ページ」の「ユーザ情報の編集」ボタンをクリック。
「ユーザ編集ページ」左下の「退会する」ボタンをクリック。ポップアップが表示されるので
「退会する」ボタンをクリックする。ログアウト状態でトップページへ遷移される。
adminerから論理削除できていることを確認する。

## 考慮してほしいこと
物理削除ではなく論理削除にて実装しました。また、本来であればユーザーに紐づく投稿も削除する必要があるのですが
postsテーブルがまだないため、User.phpにコメントアウトして記述しております。
postsテーブル実装後、改めて確認予定です。

## 確認してほしいこと
- 問題なくページ遷移できる事。
- 論理削除できる事。
- 適切なコードで記載できているかどうか。
を確認してほしいです。
