### PR TITLE
#327 投稿新規作成(ユウキ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,15 +4,25 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Post;
+use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller
 {
     public function index()
-   {
+    {
         $posts = Post::orderBy('created_at', 'desc')->paginate(10);
         return view('welcome', [
             'posts' => $posts,
         ]);
-   }
+    }
+
+    public function store(PostRequest $request)
+    {
+        $post = new Post;
+        $post->content = $request->content;
+        $post->user_id = \Auth::id();
+        $post->save();
+        return back();
+    }
 
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|max:140',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'content' => '投稿',
+        ];
+    }
+}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,21 +5,20 @@
             <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
         </div>
     </div>
-    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>        
-    <div class="w-75 m-auto">@include('commons.error_messages')</div>
+    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+    @if (Auth::check())        
+        <div class="w-75 m-auto">@include('commons.error_messages')</div>
         <div class="text-center mb-3">
-            @if (Auth::check())
-                <form method="POST" action="{{route('post.store')}}" class="d-inline-block w-75">
-                    @csrf
-                    <div class="form-group">
-                        <textarea class="form-control" name="content" rows="4"></textarea>
-                        <div class="text-left mt-3">
-                            <button type="submit" class="btn btn-primary">投稿する</button>
-                        </div>
+            <form method="POST" action="{{route('post.store')}}" class="d-inline-block w-75">
+                @csrf
+                <div class="form-group">
+                    <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
+                    <div class="text-left mt-3">
+                        <button type="submit" class="btn btn-primary">投稿する</button>
                     </div>
-                </form>
-            @endif   
-        </form>
-        @include('posts.posts', ['posts' => $posts])
-    </div>        
+                </div>
+            </form>
+        </div>
+    @endif   
+    @include('posts.posts', ['posts' => $posts])      
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,14 +5,20 @@
             <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
         </div>
     </div>
-    <h5 class="text-center mb-3">"〇〇"について140字以内で会話しよう！</h5>        
-    <div class="container">                  
-        @include('commons.error_messages')
-    </div>                  
-    <div class="text-center mb-3">
-        <form method="" action="" class="d-inline-block w-75">
-            <div class="form-group">                  
-            </div>         
+    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>        
+    <div class="w-75 m-auto">@include('commons.error_messages')</div>
+        <div class="text-center mb-3">
+            @if (Auth::check())
+                <form method="POST" action="{{route('post.store')}}" class="d-inline-block w-75">
+                    @csrf
+                    <div class="form-group">
+                        <textarea class="form-control" name="content" rows="4"></textarea>
+                        <div class="text-left mt-3">
+                            <button type="submit" class="btn btn-primary">投稿する</button>
+                        </div>
+                    </div>
+                </form>
+            @endif   
         </form>
         @include('posts.posts', ['posts' => $posts])
     </div>        

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,3 +21,11 @@ Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 // トップページ表示
 Route::get('/', 'PostsController@index');
+
+// ログイン後
+Route::group(['middleware' => 'auth'], function () {
+    Route::prefix('posts')->group(function () {
+        //新規投稿
+        Route::post('', 'PostsController@store')->name('post.store');
+    });
+});


### PR DESCRIPTION
## issue
- Closes #327 

## 概要
- 投稿新規作成

## 動作確認手順  
- http://localhost:8080/　に移動
- ログイン前の状態でテキストボックスおよび「投稿する」のボタンが表示されていない
- ログイン後にテキストボックスおよび「投稿する」のボタンが表示される
- テキストボックスに何も入力せずに「投稿する」をクリックすると、「投稿は、必ず指定してください。」とエラーメッセージが表示される
- テキストボックスに141文字以上の内容を入力し、「投稿する」をクリックすると、「投稿は、140文字以下にしてください。」とエラーメッセージが表示される
- テキストボックスに140文字以内の内容を入力し、「投稿する」をクリックすると、エラーの表示がなく、投稿の１番上に内容が表示される
- Adminerのpostsテーブルのdataを確認し、入力した内容が反映されている

## 考慮して欲しいこと
特になし

## 確認して欲しいこと
確認漏れがないか