### PR TITLE
#337 投稿削除(ユウキ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -25,4 +25,13 @@ class PostsController extends Controller
         return back();
     }
 
+    public function destroy($id)
+    {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
+            $post->delete();
+        }
+        return back();
+    }
+
 }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -12,7 +12,9 @@
                 </div>
                 @if (Auth::check() && Auth::id() === $post->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        <form method="" action="">
+                        <form method="POST" action="{{route('post.delete', $post->id)}}">
+                            @csrf
+                            @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
                         <a href="" class="btn btn-primary">編集する</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,5 +27,7 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
         //新規投稿
         Route::post('', 'PostsController@store')->name('post.store');
+        //投稿削除
+        Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
 });


### PR DESCRIPTION
## issue
- Closes #337 

## 概要
- 投稿削除

## 動作確認手順  
- トップページ（http://localhost:8080/）に移動
- 任意のユーザーでログイン
- ログインユーザーで投稿をしていなければ任意の内容で投稿
- ログインユーザーが投稿したものの「削除」ボタンをクリック
- 画面が更新され、トップページが表示される
- 「削除」ボタンを押した投稿の表示が消えている
- AdminerのPostsテーブルから該当のデータが削除されている

## 考慮して欲しいこと
特になし

## 確認して欲しいこと
確認漏れがないか