### PR TITLE
投稿削除（あめみや）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -25,4 +25,14 @@ class PostsController extends Controller
         $post->save();
         return back();
     }
+
+    public function destroy($id)
+    {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $Post->user_id) {
+            $Post->delete();
+        }
+        return back();
+    }
+
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -29,8 +29,8 @@ class PostsController extends Controller
     public function destroy($id)
     {
         $post = Post::findOrFail($id);
-        if (\Auth::id() === $Post->user_id) {
-            $Post->delete();
+        if (\Auth::id() === $post->user_id) {
+            $post->delete();
         }
         return back();
     }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -17,7 +17,9 @@
                 </div>
                 @if ($post->user->id === Auth::id() )
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        <form method="" action="">
+                        <form method="POST" action="{{ route('post.delete', $post->id) }}">
+                            @csrf
+                            @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
                         <a href="" class="btn btn-primary">編集する</a>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -13,7 +13,6 @@
                     <div class="mt-3">
                         <a href="{{ route('edit',Auth::id()) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                     </div>
-                @else
                 @endif
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::prefix('users')->group(function () {
 Route::group(['middleware' => 'auth'], function () {
     // 投稿
     Route::post('posts', 'PostsController@store')->name('post.store');
+    Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     //ユーザー編集
     Route::prefix('users')->group(function () {
         Route::get('{id}/edit', 'EditUserController@edit')->name('edit'); 


### PR DESCRIPTION
## issue
- Close #322

## 概要
- 投稿削除の実装

## 動作確認手順
- 削除ボタンを実行する
ユーザログインをする。
ログインユーザ自身の投稿のみに表示される削除ボタンを実行する。
結果、投稿が削除される。

## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認をする必要あり。
php artisan migrate:fresh --seed

## 確認してほしいこと
- 特になし