### PR TITLE
フラッシュメッセージ4か所（あめみや）

### DIFF
--- a/app/Http/Controllers/EditUserController.php
+++ b/app/Http/Controllers/EditUserController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\User; 
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Hash;
+use resources\lang\ja\flash_message; //違う？
 
 class EditUserController extends Controller
 {
@@ -25,7 +26,7 @@ class EditUserController extends Controller
         $user->email = $request->email;
         $user->password = Hash::make($request->password);
         $user->save();
-        return redirect()->route('user.show', $user->id);
+        return redirect()->route('user.show', $user->id)->with('successMessage', '更新しました');
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/EditUserController.php
+++ b/app/Http/Controllers/EditUserController.php
@@ -25,7 +25,7 @@ class EditUserController extends Controller
         $user->email = $request->email;
         $user->password = Hash::make($request->password);
         $user->save();
-        return redirect()->route('user.show', $user->id)->with('successMessage', '更新しました');
+        return redirect()->route('user.show', $user->id)->with('greenMessage', '更新しました');
     }
 
     public function destroy($id)
@@ -33,7 +33,7 @@ class EditUserController extends Controller
         $user = User::findOrFail($id);
         if ($user->id === \Auth::id() ) {
             $user->delete();
-            return redirect('/')->with('errorMessage', '退会しました');
+            return redirect('/')->with('redMessage', '退会しました');
         }
         return back();
     }

--- a/app/Http/Controllers/EditUserController.php
+++ b/app/Http/Controllers/EditUserController.php
@@ -36,6 +36,6 @@ class EditUserController extends Controller
             $user->delete();
             return redirect('/');
         }
-        return back();
+        return back()->with('errorMessage', '退会しました');
     }
 }

--- a/app/Http/Controllers/EditUserController.php
+++ b/app/Http/Controllers/EditUserController.php
@@ -34,8 +34,8 @@ class EditUserController extends Controller
         $user = User::findOrFail($id);
         if ($user->id === \Auth::id() ) {
             $user->delete();
-            return redirect('/');
+            return redirect('/')->with('errorMessage', '退会しました');
         }
-        return back()->with('errorMessage', '退会しました');
+        return back();
     }
 }

--- a/app/Http/Controllers/EditUserController.php
+++ b/app/Http/Controllers/EditUserController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use App\User; 
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Hash;
-use resources\lang\ja\flash_message; //違う？
 
 class EditUserController extends Controller
 {

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -32,7 +32,7 @@ class PostsController extends Controller
         if (\Auth::id() === $post->user_id) {
             $post->delete();
         }
-        return back();
+        return back()->with('errorMessage', '削除しました');
     }
 
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -23,6 +23,6 @@ class PostsController extends Controller
         $post->user_id = $request->user()->id;
         $post->text = $request->text;
         $post->save();
-        return back();
+        return back()->with('successMessage', '投稿しました');
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -23,7 +23,7 @@ class PostsController extends Controller
         $post->user_id = $request->user()->id;
         $post->text = $request->text;
         $post->save();
-        return back()->with('successMessage', '投稿しました');
+        return back()->with('greenMessage', '投稿しました');
     }
 
     public function destroy($id)
@@ -32,7 +32,7 @@ class PostsController extends Controller
         if (\Auth::id() === $post->user_id) {
             $post->delete();
         }
-        return back()->with('errorMessage', '削除しました');
+        return back()->with('redMessage', '削除しました');
     }
 
 }

--- a/resources/views/commons/new_post.blade.php
+++ b/resources/views/commons/new_post.blade.php
@@ -1,5 +1,10 @@
 @if (Auth::check())
     <div class="w-75 m-auto">
+        @if (session('successMessage'))
+            <div class="alert alert-success text-center">
+                {{ session('successMessage') }}
+            </div>
+        @endif
         @include('commons.error_messages')
     </div>
     <div class="text-center mb-3">

--- a/resources/views/commons/new_post.blade.php
+++ b/resources/views/commons/new_post.blade.php
@@ -1,5 +1,5 @@
 @if (Auth::check())
-    <div class="d-inline-block w-75 m-auto">
+    <div class="w-75 m-auto">
         @include('commons.error_messages')
     </div>
     <div class="text-center mb-3">

--- a/resources/views/commons/new_post.blade.php
+++ b/resources/views/commons/new_post.blade.php
@@ -1,21 +1,5 @@
 @if (Auth::check())
-    <div class="w-75 m-auto">
-        @if (session('successMessage'))
-            <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
-                <strong>{{ session('successMessage') }}</strong>
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-        @endif
-        @if (session('errorMessage'))
-            <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
-                <strong>{{ session('errorMessage') }}</strong>
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div> 
-        @endif
+    <div class="d-inline-block w-75 m-auto">
         @include('commons.error_messages')
     </div>
     <div class="text-center mb-3">

--- a/resources/views/commons/new_post.blade.php
+++ b/resources/views/commons/new_post.blade.php
@@ -1,9 +1,20 @@
 @if (Auth::check())
     <div class="w-75 m-auto">
         @if (session('successMessage'))
-            <div class="alert alert-success text-center">
-                {{ session('successMessage') }}
+            <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
+                <strong>{{ session('successMessage') }}</strong>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
             </div>
+        @endif
+        @if (session('errorMessage'))
+            <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
+                <strong>{{ session('errorMessage') }}</strong>
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div> 
         @endif
         @include('commons.error_messages')
     </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,18 +1,22 @@
 @extends('layouts.app')
 @section('content')
-
 @if (session('successMessage'))
-    <div class="alert alert-success text-center">
-        {{ session('successMessage') }}
+    <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
+        <strong>{{ session('successMessage') }}</strong>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
     </div>
 @endif
 @if (session('errorMessage'))
-    <div class="alert alert-danger text-center">
-        {{ session('errorMessage') }}
+    <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
+        <strong>{{ session('errorMessage') }}</strong>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
     </div> 
 @endif
-
-<div class="row">
+    <div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">
                 <div class="card-header">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,6 +1,18 @@
 @extends('layouts.app')
 @section('content')
-    <div class="row">
+
+@if (session('successMessage'))
+    <div class="alert alert-success text-center">
+        {{ session('successMessage') }}
+    </div>
+@endif
+@if (session('errorMessage'))
+    <div class="alert alert-danger text-center">
+        {{ session('errorMessage') }}
+    </div> 
+@endif
+
+<div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">
                 <div class="card-header">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,16 +1,16 @@
 @extends('layouts.app')
 @section('content')
-@if (session('successMessage'))
+@if (session('greenMessage'))
     <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('successMessage') }}</strong>
+        <strong>{{ session('greenMessage') }}</strong>
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>
     </div>
 @endif
-@if (session('errorMessage'))
+@if (session('redMessage'))
     <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('errorMessage') }}</strong>
+        <strong>{{ session('redMessage') }}</strong>
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,17 +6,17 @@
         </div>
     </div>
 </div>
-@if (session('successMessage'))
+@if (session('greenMessage'))
     <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('successMessage') }}</strong>
+        <strong>{{ session('greenMessage') }}</strong>
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>
     </div>
 @endif
-@if (session('errorMessage'))
+@if (session('redMessage'))
     <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('errorMessage') }}</strong>
+        <strong>{{ session('redMessage') }}</strong>
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -7,5 +7,6 @@
     </div>
 </div>
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+@include('commons.new_post')
 @include('posts.posts')
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,6 +6,22 @@
         </div>
     </div>
 </div>
+@if (session('successMessage'))
+    <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
+        <strong>{{ session('successMessage') }}</strong>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+@endif
+@if (session('errorMessage'))
+    <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
+        <strong>{{ session('errorMessage') }}</strong>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div> 
+@endif
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
 @include('commons.new_post')
 @include('posts.posts')


### PR DESCRIPTION
## issue
- Close #346 

## 概要
- フラッシュメッセージの実装
下記４か所の実装です。
（1）ユーザ更新「更新しました」緑色の背景
（2）投稿新規作成「投稿しました」緑色の背景
（3）投稿削除「削除しました」赤字の背景
（4）ユーザ退会「退会しました」赤字の背景

## 動作確認手順
- ユーザ更新
ログイン後、下記ページにアクセス
　・http://localhost:8080/users/〇/edit
　　(ユーザログイン→ユーザ詳細→ユーザ情報の編集)
情報の編集をし更新ボタンを実行する。

- 投稿新規作成
ログイン後、下記ページにアクセス
　・http://localhost:8080/
　　(トップページ)
投稿フォームより文字を入力し投稿する。

- 投稿削除
ログイン後、下記ページにアクセス
　・http://localhost:8080/
　　または、
　・http://localhost:8080/users/〇
　　(ユーザ詳細ページ)
ログインユーザ自身の投稿のみに表示される削除ボタンを実行する。

- ユーザ退会
ログイン後、下記ページにアクセス
　・http://localhost:8080/users/〇/edit
退会するボタンを実行する。

## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認をする必要あり。
php artisan migrate:fresh --seed

## 確認してほしいこと
- トップページのレイアウトについて
今回の実装とは関係ありませんが、
トップページの投稿フォームより下部分の横幅について、
幅75％(w-75)が適応されていない状態となってしまっております。
デモサイトと比較すると、あきらかに今回作成中のモノの方が横幅が長くなってしまっております。
修正しようと色々試したのですが、結果できませんでした。
今回はフラッシュメッセージのため、タスクを合わせるのもよろしくないかと思いましたので、
今後、デザイン変更のタスクの際に修正が必要かと思います。