### PR TITLE
#336 フォロー機能(Ninomiya)

### DIFF
--- a/app/Http/Controllers/FollowersController.php
+++ b/app/Http/Controllers/FollowersController.php
@@ -19,5 +19,4 @@ class FollowersController extends Controller
         \Auth::user()->unfollow($id);
         return back();
     }
-
 }

--- a/app/Http/Controllers/FollowersController.php
+++ b/app/Http/Controllers/FollowersController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class FollowersController extends Controller
+
+{
+    public function store($id)
+    {
+        \Auth::user()->follow($id);
+        return back();
+    }
+
+    public function destroy($id)
+    {
+        \Auth::user()->unfollow($id);
+        return back();
+    }
+
+}

--- a/app/User.php
+++ b/app/User.php
@@ -57,36 +57,30 @@ class User extends Authenticatable
         return $this->belongsToMany(User::class, 'followers', 'following_user_id', 'followed_user_id')->withTimestamps();
     }
     
-    public function followed()
+    public function isFollow($userId)
     {
-        return $this->belongsToMany(User::class, 'followers', 'followed_user_id', 'following_user_id')->withTimestamps();
+        return $this->following()->where('followed_user_id', $userId)->exists();
     }
 
-    public function isFollow($followed_user_id)
+    public function follow($userId)
     {
-        return $this->following()->where('followed_user_id', $followed_user_id)->exists();
-    }
-
-    public function follow($followed_user_id)
-    {
-        $exist = $this->isFollow($followed_user_id);
+        $exist = $this->isFollow($userId);
         if ($exist) {
             return false;
         } else {
-            $this->following()->attach($followed_user_id);
+            $this->following()->attach($userId);
             return true;
         }
     } 
 
-    public function unfollow($followed_user_id)
+    public function unfollow($userId)
     {
-        $exist = $this->isFollow($followed_user_id);
+        $exist = $this->isFollow($userId);
         if ($exist) {
-            $this->following()->detach($followed_user_id);
+            $this->following()->detach($userId);
             return true;
         } else {
             return false;
         }
     }
 }
-

--- a/app/User.php
+++ b/app/User.php
@@ -51,4 +51,42 @@ class User extends Authenticatable
             $user->posts()->delete();
         });
     }
+
+    public function following()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'following_user_id', 'followed_user_id')->withTimestamps();
+    }
+    
+    public function followed()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'followed_user_id', 'following_user_id')->withTimestamps();
+    }
+
+    public function isFollow($followed_user_id)
+    {
+        return $this->following()->where('followed_user_id', $followed_user_id)->exists();
+    }
+
+    public function follow($followed_user_id)
+    {
+        $exist = $this->isFollow($followed_user_id);
+        if ($exist) {
+            return false;
+        } else {
+            $this->following()->attach($followed_user_id);
+            return true;
+        }
+    } 
+
+    public function unfollow($followed_user_id)
+    {
+        $exist = $this->isFollow($followed_user_id);
+        if ($exist) {
+            $this->following()->detach($followed_user_id);
+            return true;
+        } else {
+            return false;
+        }
+    }
 }
+

--- a/app/User.php
+++ b/app/User.php
@@ -56,6 +56,11 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(User::class, 'followers', 'following_user_id', 'followed_user_id')->withTimestamps();
     }
+
+    public function followed()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'followed_user_id', 'following_user_id')->withTimestamps();
+    }
     
     public function isFollow($userId)
     {

--- a/database/migrations/2023_05_31_224216_create_followers_table.php
+++ b/database/migrations/2023_05_31_224216_create_followers_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('followers', function (Blueprint $table)
+        {
+            $table->bigIncrements('id');
+            $table->bigInteger('following_user_id')->unsigned()->index();
+            $table->bigInteger('followed_user_id')->unsigned()->index();
+            $table->timestamps();
+            $table->foreign('following_user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('followed_user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['following_user_id', 'followed_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('followers');
+    }
+}

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,0 +1,16 @@
+@if (Auth::check() && Auth::id() !== $user->id)
+    <div class="mt-3 w-75 mx-auto">
+        @if (Auth::user()->isFollow($user->id))
+            <form method="POST" action="{{ route('unfollow', $user->id) }}">
+                @csrf
+                @method('DELETE')
+                <button type="submit" class="btn btn-danger btn-block">フォローを外す</button>
+            </form>
+        @else
+            <form method="POST" action="{{ route('follow', $user->id) }}">
+                @csrf
+                <button type="submit" class="btn btn-primary btn-block">フォローする</button>
+            </form>
+        @endif
+    </div>
+@endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -10,13 +10,14 @@
                 <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}"
                     alt="{{ $user->name }}アバター画像">
                 @if ($user->id === Auth::id() )
-                    <div class="mt-3">
-                        <a href="{{ route('edit',Auth::id()) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
-                    </div>
+                <div class="mt-3">
+                    <a href="{{ route('edit',Auth::id()) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                </div>
                 @else
                 @endif
             </div>
         </div>
+        @include('follow.follow_button')
     </aside>
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,8 @@
 |
 */
 
+use App\Http\Controllers\FollowersController;
+
 Route::get('/', 'PostsController@index');
 // ログイン
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
@@ -29,9 +31,14 @@ Route::group(['middleware' => 'auth'], function () {
     // 投稿
     Route::post('posts', 'PostsController@store')->name('post.store');
     //ユーザー編集
+    Route::prefix('users/{id}')->group(function () {
+        Route::get('edit', 'EditUserController@edit')->name('edit'); 
+        Route::put('', 'EditUserController@update')->name('update');
+        Route::delete('', 'EditUserController@destroy')->name('user.delete');
+    });
+    //フォロー機能
     Route::prefix('users')->group(function () {
-        Route::get('{id}/edit', 'EditUserController@edit')->name('edit'); 
-        Route::put('{id}', 'EditUserController@update')->name('update');
-        Route::delete('{id}', 'EditUserController@destroy')->name('user.delete');
+        Route::post('follow/{id}', 'FollowersController@store')->name('follow');
+        Route::delete('unfollow/{id}', 'FollowersController@destroy')->name('unfollow');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,13 +36,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('edit', 'EditUserController@edit')->name('edit'); 
         Route::put('', 'EditUserController@update')->name('update');
         Route::delete('', 'EditUserController@destroy')->name('user.delete');
-    });
     //フォロー機能
-    Route::prefix('users')->group(function () {
-        Route::post('{id}/follow', 'FollowersController@store')->name('follow');
-        Route::delete('{id}/unfollow', 'FollowersController@destroy')->name('unfollow');
-
-        // Route::post('follow/{id}', 'FollowersController@store')->name('follow');
-        // Route::delete('unfollow/{id}', 'FollowersController@destroy')->name('unfollow');
+        Route::post('follow', 'FollowersController@store')->name('follow');
+        Route::delete('unfollow', 'FollowersController@destroy')->name('unfollow');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,7 +39,10 @@ Route::group(['middleware' => 'auth'], function () {
     });
     //フォロー機能
     Route::prefix('users')->group(function () {
-        Route::post('follow/{id}', 'FollowersController@store')->name('follow');
-        Route::delete('unfollow/{id}', 'FollowersController@destroy')->name('unfollow');
+        Route::post('{id}/follow', 'FollowersController@store')->name('follow');
+        Route::delete('{id}/unfollow', 'FollowersController@destroy')->name('unfollow');
+
+        // Route::post('follow/{id}', 'FollowersController@store')->name('follow');
+        // Route::delete('unfollow/{id}', 'FollowersController@destroy')->name('unfollow');
     });
 });


### PR DESCRIPTION
## issue
- Close #336 

## 動作環境手順
ログイン後、「ユーザ詳細画面」にて「フォローする/を外す」ボタンが出ていないことを確認。
ログインid以外のidで次のURLへ移動「`http://localhost:8080/users/{id}`」。
「フォローする」ボタンが表示される。ボタンをクリックするとfollowersテーブルに記録されるため
adminerのfollowersテーブルを確認する。
クリック後、同じ画面でボタンが「フォローする」から「フォローを外す」に切り替わっている事を確認。
「フォローを外す」をクリックするとfollowersテーブルの記録が物理削除されるため
adminerのfollowersテーブルにて物理削除されたことを確認する。
同じ画面でボタンが「フォローを外す」から「フォローする」に切り替わっている事を確認。

## 考慮してほしいこと
特にありません。

## 確認してほしいこと
- 問題のあるコードがないか、 不必要に長いコードになっていないかどうか
よりすっきりとした書き方があれば教えていただきたいです。

- ルートの記載を最初１にしておりましたが
```
１　Route::post('{id}/follow', 'FollowersController@store')
２　Route::post('follow/{id}', 'FollowersController@store')
```
URL：「`http://localhost:8080/users/{id}`」へ移動し404エラーとなりました。
２に変更したところ、うまくいったのですが、1だとうまくいかない理由を教えていただきたいです。
よろしくお願いします。

