### PR TITLE
comments（コメント）テーブルのマイグレーションとシーダーと表示（あめみや）

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    //
+}

--- a/app/Comment.php
+++ b/app/Comment.php
@@ -3,8 +3,19 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Comment extends Model
 {
-    //
+    use SoftDeletes;
+    public function post()
+    {
+        return $this->belongsTo(post::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
 }

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\post;
+use App\User;
+use App\Comment;
+use App\Http\Requests\CommentRequest;
+
+class CommentsController extends Controller
+{
+
+    public function store(CommentRequest $request)
+    {
+        //
+    }
+
+    public function destroy($id)
+    {
+        //
+    }
+
+}

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\User;
 use App\Post;
+use App\Comment;
 use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller

--- a/app/Http/Requests/CommentRequest.php
+++ b/app/Http/Requests/CommentRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'comment' => 'required|max:140',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'comment' => 'コメント',
+        ];
+    }
+
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -13,4 +13,10 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -44,6 +44,11 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
     public static function boot()
     {
         parent::boot();

--- a/database/migrations/2023_06_02_223204_create_comments_table.php
+++ b/database/migrations/2023_06_02_223204_create_comments_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/database/migrations/2023_06_02_223204_create_comments_table.php
+++ b/database/migrations/2023_06_02_223204_create_comments_table.php
@@ -15,7 +15,19 @@ class CreateCommentsTable extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->string('comment');
+            $table->bigInteger('post_id')->unsigned();
+            $table->foreign('post_id')
+                ->references('id')
+                ->on('posts')
+                ->onDelete('cascade');
+            $table->bigInteger('user_id')->unsigned();
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/database/seeds/CommentsTableSeeder.php
+++ b/database/seeds/CommentsTableSeeder.php
@@ -1,0 +1,106 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class CommentsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト1",
+            'post_id' => 1,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー2\nポスト2",
+            'post_id' => 2,
+            'user_id' => 2,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー3\nポスト3",
+            'post_id' => 3,
+            'user_id' => 3,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー4\nポスト4",
+            'post_id' => 4,
+            'user_id' => 4,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト5",
+            'post_id' => 5,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト6",
+            'post_id' => 6,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト7",
+            'post_id' => 7,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト8",
+            'post_id' => 8,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト9",
+            'post_id' => 9,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト10",
+            'post_id' => 10,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー2\nポスト10",
+            'post_id' => 10,
+            'user_id' => 2,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー1\nポスト11",
+            'post_id' => 11,
+            'user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('comments')->insert([
+            'comment' => "テストコメント\nユーザー2\nポスト11",
+            'post_id' => 11,
+            'user_id' => 2,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(CommentsTableSeeder::class);
     }
 }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,33 +1,59 @@
 @foreach ($posts as $post)
-    <ul class="list-unstyled">
-        <li class="mb-3 text-center">
-            <div class="text-left d-inline-block w-75 mb-2">
-                @if($post->user->email)
-                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($post->user->email, 55) }}"
-                        alt="{{ $post->user->name }}アバター画像">
-                    <p class="mt-3 mb-0 d-inline-block">
+<ul class="list-unstyled">
+    <li class="mb-3 text-center">
+        <div class="text-left d-inline-block w-75 mb-2">
+            @if($post->user->email)
+                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($post->user->email, 55) }}"
+                    alt="{{ $post->user->name }}アバター画像">
+                <p class="mt-3 mb-0 d-inline-block">
+                    <strong>
                         <a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a>
-                    </p>
-                @endif
-            </div>
-            <div class="">
-                <div class="text-left d-inline-block w-75">
+                    </strong>
+                </p>
+            @endif
+        </div>
+        <div class="">
+            <div class="text-left d-inline-block w-75">
+                <strong>
                     <p class="mb-2">{{ $post->text }}</p>
-                    <p class="text-muted">{{ $post->updated_at }}</p>
-                </div>
-                @if ($post->user->id === Auth::id() )
-                    <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        <form method="POST" action="{{ route('post.delete', $post->id) }}">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-danger">削除</button>
-                        </form>
-                        <a href="" class="btn btn-primary">編集する</a>
-                    </div>
-                @endif
+                </strong>
+                <p class="text-muted">{{ $post->updated_at }}</p>
             </div>
-        </li>
-    </ul>
+            @if ($post->user->id === Auth::id() )
+                <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                    <form method="POST" action="{{ route('post.delete', $post->id) }}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">削除</button>
+                    </form>
+                    <a href="" class="btn btn-primary">編集する</a>
+                </div>
+            @endif
+            <div class="card text-left d-inline-block w-75 mb-2 ml-5">
+                <h5 class="card-header">コメント</h5>
+                <div class="card-body">
+                    @foreach ($post->comments as $comment)
+                        <div class="text-left d-inline-block w-75 ml-3">
+                            <span>
+                                @if($comment->user->email)
+                                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($comment->user->email, 30) }}"
+                                        alt="{{ $comment->user->name }}アバター画像">
+                                    <p class="mt-1 mb-1 d-inline-block">
+                                        <a href="{{ route('user.show', $comment->user->id) }}">{{$comment->user->name}}</a>
+                                    </p>
+                                @endif
+                            </span><br>
+                            <span class="card-text">{!!nl2br(e($comment->comment))!!}</span>
+                            <p class="text-muted">
+                                {{ $comment->updated_at }}
+                            </p>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </li>
+</ul>
 @endforeach
 <div class="m-auto" style="width: fit-content">
     {{ $posts->links('pagination::bootstrap-4') }}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,59 +1,59 @@
 @foreach ($posts as $post)
-<ul class="list-unstyled">
-    <li class="mb-3 text-center">
-        <div class="text-left d-inline-block w-75 mb-2">
-            @if($post->user->email)
-                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($post->user->email, 55) }}"
-                    alt="{{ $post->user->name }}アバター画像">
-                <p class="mt-3 mb-0 d-inline-block">
+    <ul class="list-unstyled">
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+                @if($post->user->email)
+                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($post->user->email, 55) }}"
+                        alt="{{ $post->user->name }}アバター画像">
+                    <p class="mt-3 mb-0 d-inline-block">
+                        <strong>
+                            <a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a>
+                        </strong>
+                    </p>
+                @endif
+            </div>
+            <div class="">
+                <div class="text-left d-inline-block w-75">
                     <strong>
-                        <a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a>
+                        <p class="mb-2">{{ $post->text }}</p>
                     </strong>
-                </p>
-            @endif
-        </div>
-        <div class="">
-            <div class="text-left d-inline-block w-75">
-                <strong>
-                    <p class="mb-2">{{ $post->text }}</p>
-                </strong>
-                <p class="text-muted">{{ $post->updated_at }}</p>
-            </div>
-            @if ($post->user->id === Auth::id() )
-                <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                    <form method="POST" action="{{ route('post.delete', $post->id) }}">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit" class="btn btn-danger">削除</button>
-                    </form>
-                    <a href="" class="btn btn-primary">編集する</a>
+                    <p class="text-muted">{{ $post->updated_at }}</p>
                 </div>
-            @endif
-            <div class="card text-left d-inline-block w-75 mb-2 ml-5">
-                <h5 class="card-header">コメント</h5>
-                <div class="card-body">
-                    @foreach ($post->comments as $comment)
-                        <div class="text-left d-inline-block w-75 ml-3">
-                            <span>
-                                @if($comment->user->email)
-                                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($comment->user->email, 30) }}"
-                                        alt="{{ $comment->user->name }}アバター画像">
-                                    <p class="mt-1 mb-1 d-inline-block">
-                                        <a href="{{ route('user.show', $comment->user->id) }}">{{$comment->user->name}}</a>
-                                    </p>
-                                @endif
-                            </span><br>
-                            <span class="card-text">{!!nl2br(e($comment->comment))!!}</span>
-                            <p class="text-muted">
-                                {{ $comment->updated_at }}
-                            </p>
-                        </div>
-                    @endforeach
+                @if ($post->user->id === Auth::id() )
+                    <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                        <form method="POST" action="{{ route('post.delete', $post->id) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">削除</button>
+                        </form>
+                        <a href="" class="btn btn-primary">編集する</a>
+                    </div>
+                @endif
+                <div class="card text-left d-inline-block w-75 mb-2 ml-5">
+                    <h5 class="card-header">コメント</h5>
+                    <div class="card-body">
+                        @foreach ($post->comments as $comment)
+                            <div class="text-left d-inline-block w-75 ml-3">
+                                <span>
+                                    @if($comment->user->email)
+                                        <img class="rounded-circle img-fluid" src="{{ Gravatar::src($comment->user->email, 30) }}"
+                                            alt="{{ $comment->user->name }}アバター画像">
+                                        <p class="mt-1 mb-1 d-inline-block">
+                                            <a href="{{ route('user.show', $comment->user->id) }}">{{$comment->user->name}}</a>
+                                        </p>
+                                    @endif
+                                </span><br>
+                                <span class="card-text">{!!nl2br(e($comment->comment))!!}</span>
+                                <p class="text-muted">
+                                    {{ $comment->updated_at }}
+                                </p>
+                            </div>
+                        @endforeach
+                    </div>
                 </div>
             </div>
-        </div>
-    </li>
-</ul>
+        </li>
+    </ul>
 @endforeach
 <div class="m-auto" style="width: fit-content">
     {{ $posts->links('pagination::bootstrap-4') }}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>
-    </div>
+</div>
 @endif
 @if (session('redMessage'))
     <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
@@ -20,7 +20,7 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>
-    </div> 
+    </div>
 @endif
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
 @include('commons.new_post')

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>
-</div>
+    </div>
 @endif
 @if (session('redMessage'))
     <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,4 +35,9 @@ Route::group(['middleware' => 'auth'], function () {
         Route::put('{id}', 'EditUserController@update')->name('update');
         Route::delete('{id}', 'EditUserController@destroy')->name('user.delete');
     });
+    // コメント
+    Route::prefix('comments')->group(function () {
+        Route::post('', 'CommentsController@store')->name('comment.store');
+        Route::delete('{id}', 'CommentsController@destroy')->name('comment.delete');
+    });
 });


### PR DESCRIPTION
## issue
- Close #347

## 概要
- comments（コメント）テーブルの実装
- マイグレーションとシーダー
- サイトへのコメント表示

## 動作確認手順
- 下記コマンドを実行
php artisan migrate --seed
- Adminerでcommentsテーブルに13個のレコードが保存されていることを確認

## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認をする必要あり。
php artisan migrate:fresh --seed
- CommentRequest.phpなど先に作った状態です。
もともと、
・コメント表示
・コメント投稿
・コメント削除
を全てするものと思っていたため、
CommentRequest.phpをはじめ、
CommentsController.phpやweb.phpに記述した状態です。
web.phpについては書いたコードを削除すべきでしたでしょうか。
コメントの表示に不要なものは削除するべきだった場合、
artisanコマンドで作成をしたファイルである
リクエストやコントローラーについても
普通にファイルを削除するだけでよいのでしょうか。

## 確認してほしいこと
- PostsController.phpの記述について
8行目の`use App\Comment;`は必要なのでしょうか。