### PR TITLE
トップページのレイアウト修正（あめみや）

### DIFF
--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -29,11 +29,11 @@
                         <a href="" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
-                <div class="card text-left d-inline-block w-75 mb-2 ml-5">
+                <div class="card text-left d-inline-block w-75 mb-2">
                     <h5 class="card-header">コメント</h5>
                     <div class="card-body">
                         @foreach ($post->comments as $comment)
-                            <div class="text-left d-inline-block w-75 ml-3">
+                            <div class="text-left d-inline-block w-75">
                                 <span>
                                     @if($comment->user->email)
                                         <img class="rounded-circle img-fluid" src="{{ Gravatar::src($comment->user->email, 30) }}"

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,7 +5,6 @@
             <h1><i class="pr-3"></i>Topic Posts</h1>
         </div>
     </div>
-</div>
 @if (session('greenMessage'))
     <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
         <strong>{{ session('greenMessage') }}</strong>


### PR DESCRIPTION
## issue
- Close #362

## 概要
- トップページ投稿表示部分の修正

## 動作確認手順
- 下記ページにアクセス
http://localhost:8080/

75％幅が適応されなかったのは、
`</div>`が１つ多かっただけでした。

コメント部分(カードの部分)については、
少しずらした方が、投稿とコメントで区別がつきわかりやすいかと思ったのですが、
そもそもカードで区別をつけている事、
全て揃えた方が見栄えがよかった事、
により、他と幅を揃えました。

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし