### PR TITLE
#344 フォロー機能（ユウキ）

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -7,8 +7,7 @@ class FollowController extends Controller
 {
     public function store($followed_id)
     {
-        
-        if(\Auth::user()->id != $followed_id){
+        if(\Auth::id() != $followed_id){
             \Auth::user()->follow($followed_id);
         };
         return back();
@@ -16,7 +15,7 @@ class FollowController extends Controller
 
     public function destroy($followed_id)
     {
-        if(\Auth::user()->id != $followed_id){
+        if(\Auth::id() != $followed_id){
             \Auth::user()->unfollow($followed_id);
         }
         return back();

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    public function store($followed_id)
+    {
+        
+        if(\Auth::user()->id != $followed_id){
+            \Auth::user()->follow($followed_id);
+        };
+        return back();
+    }
+
+    public function destroy($followed_id)
+    {
+        if(\Auth::user()->id != $followed_id){
+            \Auth::user()->unfollow($followed_id);
+        }
+        return back();
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -42,4 +42,36 @@ class User extends Authenticatable
     {
      return $this->hasMany(Post::class);
     }
+
+    public function followers()
+    {
+        return $this->belongsToMany(User::class,'follows','follow_user_id','followed_user_id');
+    }
+
+    public function follow($followedUserId)
+    {
+        $exist = $this->isFollow($followedUserId);
+        if ($exist) {
+            return false;
+        } else {
+            $this->followers()->attach($followedUserId);
+            return true;
+        }
+    }
+
+    public function unfollow($followedUserId)
+    {
+        $exist = $this->isFollow($followedUserId);
+        if ($exist) {
+            $this->followers()->detach($followedUserId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function isFollow($followedUserId)
+    {   
+        return $this->followers()->where('followed_user_id', $followedUserId)->exists();
+    }
 }

--- a/database/migrations/2023_06_03_142109_create_follows_table.php
+++ b/database/migrations/2023_06_03_142109_create_follows_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('follow_user_id')->unsigned()->index();
+            $table->bigInteger('followed_user_id')->unsigned()->index();
+            $table->timestamps();
+            // 外部キー制約
+            $table->foreign('follow_user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('followed_user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['follow_user_id','followed_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,0 +1,15 @@
+@if (Auth::check() && Auth::id() !== $user->id)
+    <div class="d-inline-block">
+        @if (Auth::user()->isFollow($user->id))
+            <form method="POST" action="{{route('unfollow', $user->id)}}">
+                @csrf
+                <button type="submit" class="btn btn-danger">フォローを外す</button>
+            </form>
+        @else
+            <form method="POST" action="{{route('follow', $user->id)}}">
+                @csrf
+                <button type="submit" class="btn btn-info btn-sm">フォローする</button>
+            </form>
+        @endif
+    </div>
+@endif

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -4,6 +4,7 @@
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
                 <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a></p>
+                @include('follow.follow_button',['user'=> $post->user])
             </div>
             <div class="container">
                 <div class="text-left d-inline-block w-75">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -3,8 +3,11 @@
      <div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">
-             <div class="card-header">
-               <h3 class="card-title text-light">{{ $user->name }}</h3>
+             <div class="card-header d-inline-block">
+               <h3 class="card-title text-light">{{ $user->name }}
+                @include('follow.follow_button',['user'=> $user])
+               </h3>
+                
              </div>
              <div class="card-body">
                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザーアバター画像">

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,12 +18,15 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
-Route::get('/', 'UsersController@index');
 // トップページ表示
 Route::get('/', 'PostsController@index');
 //ユーザー詳細
-Route::prefix('users')->group(function(){
-    Route::get('{id}','UsersController@show')->name('user.show');
+Route::prefix('users/{id}')->group(function(){
+    Route::get('','UsersController@show')->name('user.show');
+    Route::group(['middleware' => 'auth'], function () {
+        Route::post('follow','FollowController@store')->name('follow');
+        Route::post('unfollow','FollowController@destroy')->name('unfollow');
+    });
 });
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,10 +15,6 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
-//ユーザー詳細
-Route::get('users/{id}','UsersController@show')->name('user.show');   
- 
-
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
@@ -29,6 +25,11 @@ Route::get('/', 'PostsController@index');
 Route::prefix('users/{id}')->group(function(){
     Route::get('','UsersController@show')->name('user.show');
     Route::group(['middleware' => 'auth'], function () {
+        //ユーザー編集・更新・削除
+        Route::get('edit', 'UsersController@edit')->name('user.edit');
+        Route::put('', 'UsersController@update')->name('user.update');
+        Route::delete('', 'UsersController@destroy')->name('user.delete');
+        //フォロー機能
         Route::post('follow','FollowController@store')->name('follow');
         Route::post('unfollow','FollowController@destroy')->name('unfollow');
     });
@@ -45,14 +46,6 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         //投稿更新
         Route::put('{id}', 'PostsController@update')->name('post.update');
-    });
-    Route::prefix('users/{id}')->group(function(){
-        //編集
-        Route::get('edit', 'UsersController@edit')->name('user.edit');
-        //更新
-        Route::put('', 'UsersController@update')->name('user.update');
-        //削除
-        Route::delete('', 'UsersController@destroy')->name('user.delete');
     });
 });
 


### PR DESCRIPTION
## issue
- Closes #344  

## 概要
- フォロー機能

## 動作確認手順  
1.  http://localhost:8080/　に移動
2. ログイン前の状態でトップページおよびユーザー詳細画面にて自身以外のアカウント名の右側に「フォローする(を外す)」ボタンが表示されていないこと。
3. 任意のユーザーでログインし、他ユーザーの投稿を確認する。アカウント名の右側に「フォローする(を外す)」ボタンが表示されている。
4. フォローしていないユーザーの「フォローする」をクリックする
5. フォローしたユーザーのユーザー名の右側のボタンが「フォローを外す」に表示が変わる
6. Adminerのfollowsテーブルのdataを確認し、フォローしたユーザーおよびフォロワーのidが反映されている
7. フォロー済のユーザーの右側に表示されている「フォローを外す」をクリックする。
8. フォローを外したユーザーのユーザー名の右側のボタンが「フォローする」に表示が変わる
9. Adminerのfollowsテーブルのdataを確認し、フォローを外したユーザーおよびフォローを外されたユーザーのidのデータが削除されている
10. 3.以降の操作をユーザー詳細ページで実施して同じ結果になることを確認する
11. 自身の投稿および詳細ページで アカウント名の右側に「フォローする(を外す)」ボタンが表示されていない

## 考慮して欲しいこと
ボタンを文字で表示しているためボタンが大きくなってしまっていますが、今後アイコンを使用したものに変更したいと思っています。
ユーザー詳細にて、フォローするのボタンの色が被ってしまっていますが、アイコンに変更することにより解消します。

## 確認して欲しいこと
FollowController.phpのコードおよびUser.phpのソースで似たような処理をしている部分があるので、うまくまとめられないかと考えましたが思いつきませんでした。
何か良い方法がありましたら教えていただきたいです。