### PR TITLE
#366 フォローによるタイムライン変更（おおた）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -57,4 +57,16 @@ class UsersController extends Controller
       return view('users.show',$data);
     }
 
+    //ユーザー詳細「フォロー中」
+    public function followingsShow($id)
+    {
+        $user = User::findOrFail($id);
+        $followings = $user->followings()->orderBy('created_at', 'desc')->paginate(10);
+        $data = [
+            'user' => $user,
+            'followings' => $followings,
+        ];
+        return view('follow.followings', $data);
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -72,7 +72,7 @@ class User extends Authenticatable
         $itsMe = $this->id === $userId;
         if ($itsMe) {
             return false;
-        }elseif ($exist) {
+        } elseif ($exist) {
             $this->followings()->detach($userId);
             return true;
         } else {

--- a/resources/views/follow/followings.blade.php
+++ b/resources/views/follow/followings.blade.php
@@ -21,7 +21,16 @@
             <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中</a></li>
             <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
         </ul>
-        @include('posts.posts', ['posts' => $posts])
+        <ul class="list-unstyled">
+            @foreach ($followings as $follow)
+            <li class="mb-3 text-center">
+                <div class="text-left d-inline-block w-75 mb-2">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follow->email, 55) }}" alt="ユーザのアバター画像">
+                    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show',$follow->id) }}">{{$follow->name}}</a></p>
+                </div>
+            </li>
+            @endforeach
+        </ul>
     </div>
 </div>
 @endsection

--- a/resources/views/follow/followings.blade.php
+++ b/resources/views/follow/followings.blade.php
@@ -27,6 +27,13 @@
                 <div class="text-left d-inline-block w-75 mb-2">
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follow->email, 55) }}" alt="ユーザのアバター画像">
                     <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show',$follow->id) }}">{{$follow->name}}</a></p>
+                    <form method="POST" action="{{ route('unFollow', $follow->id) }}">
+                        @csrf
+                        @method('DELETE')
+                        <div class="mt-3">
+                            <button type="submit" class="btn btn-danger ">フォロ―を外す</button>
+                        </div>
+                    </form>
                 </div>
             </li>
             @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,8 @@ Route::group(['middleware' => 'auth'], function ()
 // ユーザ
 Route::prefix('users')->group(function () {
     Route::get('{id}', 'UsersController@show')->name('user.show');
+    //　ユーザー詳細「フォロー中」
+    Route::get('{id}/followings', 'UsersController@followingsShow')->name('followings');
     // フォロー機能（ログイン後）
     Route::post('{id}/follow', 'FollowController@store')->name('follow');
     Route::delete('{id}/unFollow', 'FollowController@destroy')->name('unFollow');


### PR DESCRIPTION
## issue
- Closes #366 

## 概要
- フォローによるタイムライン変更　のうち、
　「フォロー中タブ」に切り替えた際の一覧表示まで実装しました。

　今後は以下を実装したいと考えています
　・「フォロワータブ」の一覧表示
　・「フォロー中タブ」に、フォロー中の人数を表示
　・「フォロワータブ」に、フォロワーの人数を表示

## 動作確認手順
- ユーザー詳細のタブで「フォロー中」を押下し、フォロー中のユーザー名一覧が表示されるか

## 考慮して欲しいこと
- 上記の概要欄にも記載した通り、途中段階でのプルリクです。

## 確認してほしいこと
- フォロー中の一覧の記載方法で、もっとスマートな方法があれば教えていただきたいです。

現状のfollowings.blade.phpは、show.blade.phpの24行目
　`@include('posts.posts', ['posts' => $posts])`
　を
　フォロー中の一覧（以下コード）に差し替えただけの状態です。
```
        <ul class="list-unstyled">
            @foreach ($followings as $follow)
            <li class="mb-3 text-center">
                <div class="text-left d-inline-block w-75 mb-2">
                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follow->email, 55) }}" alt="ユーザのアバター画像">
                    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show',$follow->id) }}">{{$follow->name}}</a></p>
                </div>
            </li>
            @endforeach
        </ul>
```