### PR TITLE
#352 フォロワーリストの作成(Ninomiya)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,4 +10,17 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    public function userCounts($user)
+    {
+        $countPosts = $user->posts()->count();
+        $countFollowings = $user->following()->count();
+        $countFollowers = $user->followed()->count();
+
+        return [
+            'countPosts' => $countPosts,
+            'countFollowings' => $countFollowings,
+            'countFollowers' => $countFollowers,
+        ];
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -12,7 +12,7 @@ class UsersController extends Controller
     {
         $user = User::findOrFail($id);
         $posts = $user->posts()->orderBy('id', 'desc')->paginate(10);
-        $data=[
+        $data = [
             'user' => $user,
             'posts' => $posts,
         ];
@@ -24,23 +24,23 @@ class UsersController extends Controller
     {
         $user = User::findOrFail($id);
         $followingUsers = $user->following()->orderBy('id', 'desc')->paginate(10);
-        $data=[
+        $data = [
             'user' => $user,
             'followingUsers' => $followingUsers,
         ];
         $data += $this->userCounts($user);
-        return view('users.show', $data);
+        return view('follow.following_list', $data);
     }
     
     public function showFollowedList($id)
     {
         $user = User::findOrFail($id);
         $followedUsers = $user->followed()->orderBy('id', 'desc')->paginate(10);
-        $data=[
+        $data = [
             'user' => $user,
             'followedUsers' => $followedUsers,
         ];
         $data += $this->userCounts($user);
-        return view('users.show', $data);
+        return view('follow.followed_list', $data);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -8,7 +8,6 @@ use App\Post;
 
 class UsersController extends Controller
 {
-
     public function show($id)
     {
         $user = User::findOrFail($id);
@@ -17,6 +16,31 @@ class UsersController extends Controller
             'user' => $user,
             'posts' => $posts,
         ];
+        $data += $this->userCounts($user);
+        return view('users.show', $data);
+    }
+    
+    public function showFollowingList($id)
+    {
+        $user = User::findOrFail($id);
+        $followingUsers = $user->following()->orderBy('id', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'followingUsers' => $followingUsers,
+        ];
+        $data += $this->userCounts($user);
+        return view('users.show', $data);
+    }
+    
+    public function showFollowedList($id)
+    {
+        $user = User::findOrFail($id);
+        $followedUsers = $user->followed()->orderBy('id', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'followedUsers' => $followedUsers,
+        ];
+        $data += $this->userCounts($user);
         return view('users.show', $data);
     }
 }

--- a/resources/views/commons/flash_message.blade.php
+++ b/resources/views/commons/flash_message.blade.php
@@ -1,0 +1,16 @@
+@if (session('greenMessage'))
+    <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
+        <strong>{{ session('greenMessage') }}</strong>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+@endif
+@if (session('redMessage'))
+    <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
+        <strong>{{ session('redMessage') }}</strong>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div> 
+@endif

--- a/resources/views/commons/tab.blade.php
+++ b/resources/views/commons/tab.blade.php
@@ -1,0 +1,11 @@
+<ul class="nav nav-tabs nav-justified mb-3">
+        <li class="nav-item"><a href="{{ route('user.show', $user->id) }}"
+                class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン<br><div class="badge badge-secondary">{{ $countPosts }}</div></a>
+        </li>
+        <li class="nav-item"><a href="{{ route('user.followingList', $user->id)}}" 
+                class="nav-link {{ Request::is('users/'. $user->id. '/followingList') ? 'active' : '' }}">フォロー中<br><div class="badge badge-secondary">{{ $countFollowings }}</div></a>
+        </li>
+        <li class="nav-item"><a href="{{ route('user.followedList', $user->id)}}"
+                class="nav-link  {{ Request::is('users/'. $user->id. '/followedList') ? 'active' : '' }}">フォロワー<br><div class="badge badge-secondary">{{ $countFollowers }}</div></a>
+        </li>
+</ul>

--- a/resources/views/commons/user_icon.blade.php
+++ b/resources/views/commons/user_icon.blade.php
@@ -1,0 +1,16 @@
+<div class="card bg-info">
+    <div class="card-header">
+        <h3 class="card-title text-light">{{ $user->name }}</h3>
+    </div>
+    <div class="card-body">
+        <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}"
+            alt="{{ $user->name }}アバター画像">
+        @if ($user->id === Auth::id() )
+            <div class="mt-3">
+                <a href="{{ route('edit',Auth::id()) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+            </div>
+        @else
+        @endif
+    </div>
+</div>
+@include('follow.follow_button')

--- a/resources/views/follow/followed_list.blade.php
+++ b/resources/views/follow/followed_list.blade.php
@@ -1,0 +1,16 @@
+@foreach ($followedUsers as $followedUser )
+    <ul class="list-unstyled">
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followedUser->email, 55) }}" alt="{{ $followedUser->email }}のアバター画像">
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followedUser->id) }}">{{ $followedUser->name }}</a></p>
+            </div>
+            <div class="text-left d-inline-block w-75">
+                <p class="mb-1">{{ $followedUser->posts()->latest()->first()->text }}</p>
+                <p class="text-muted">{{ $followedUser->posts()->latest()->first()->updated_at }}</p>
+            </div>         
+        </li>
+    </ul>
+@endforeach
+<div class="m-auto" style="width: fit-content"></div>
+{{ $followedUsers->links('pagination::bootstrap-4') }}

--- a/resources/views/follow/followed_list.blade.php
+++ b/resources/views/follow/followed_list.blade.php
@@ -21,4 +21,5 @@
             {{ $followedUsers->links('pagination::bootstrap-4') }}
             </div>
         </div>
+    </div>
 @endsection

--- a/resources/views/follow/followed_list.blade.php
+++ b/resources/views/follow/followed_list.blade.php
@@ -1,16 +1,24 @@
-@foreach ($followedUsers as $followedUser )
-    <ul class="list-unstyled">
-        <li class="mb-3 text-center">
-            <div class="text-left d-inline-block w-75 mb-2">
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followedUser->email, 55) }}" alt="{{ $followedUser->email }}のアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followedUser->id) }}">{{ $followedUser->name }}</a></p>
+@extends('layouts.app')
+@section('content')
+    @include('commons.flash_message')
+    <div class="row">
+        <aside class="col-sm-4 mb-5">
+            @include('commons.user_icon')
+        </aside>
+        <div class="col-sm-8">
+            @include('commons.tab')
+            @foreach ($followedUsers as $followedUser )
+                <ul class="list-unstyled">
+                    <li class="mb-3 text-center">
+                        <div class="text-left d-inline-block w-75 mb-2">
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followedUser->email, 55) }}" alt="{{ $followedUser->email }}のアバター画像">
+                            <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followedUser->id) }}">{{ $followedUser->name }}</a></p>
+                        </div>     
+                    </li>
+                </ul>
+            @endforeach
+            <div class="m-auto" style="width: fit-content">
+            {{ $followedUsers->links('pagination::bootstrap-4') }}
             </div>
-            <div class="text-left d-inline-block w-75">
-                <p class="mb-1">{{ $followedUser->posts()->latest()->first()->text }}</p>
-                <p class="text-muted">{{ $followedUser->posts()->latest()->first()->updated_at }}</p>
-            </div>         
-        </li>
-    </ul>
-@endforeach
-<div class="m-auto" style="width: fit-content"></div>
-{{ $followedUsers->links('pagination::bootstrap-4') }}
+        </div>
+@endsection

--- a/resources/views/follow/following_list.blade.php
+++ b/resources/views/follow/following_list.blade.php
@@ -1,27 +1,36 @@
-@foreach ($followingUsers as $followingUser )
-    <ul class="list-unstyled">
-        <li class="mb-3 text-center">
-            <div class="text-left d-inline-block w-75 mb-2">
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followingUser->email, 55) }}" alt="{{ $followingUser->email }}のアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followingUser->id) }}">{{ $followingUser->name }}</a></p>
+@extends('layouts.app')
+@section('content')
+    @include('commons.flash_message')
+    <div class="row">
+        <aside class="col-sm-4 mb-5">
+            @include('commons.user_icon')
+        </aside>
+        <div class="col-sm-8">
+            @include('commons.tab')
+            @foreach ($followingUsers as $followingUser )
+                <ul class="list-unstyled">
+                    <li class="mb-3 text-center">
+                        <div class="text-left d-inline-block w-75 mb-2">
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followingUser->email, 55) }}" alt="{{ $followingUser->email }}のアバター画像">
+                            <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followingUser->id) }}">{{ $followingUser->name }}</a></p>
+                        </div>
+                        @if (Auth::check() && Auth::id() === $user->id)
+                            <div class="d-inline-block w-50 mb-3">
+                                @if (Auth::user()->isFollow($followingUser->id))
+                                    <form method="POST" action="{{ route('unfollow', $followingUser->id) }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger btn-block">フォローを外す</button>
+                                    </form>
+                                @endif
+                            </div>
+                        @endif
+                    </li>
+                </ul>
+            @endforeach
+            <div class="m-auto" style="width: fit-content">
+            {{ $followingUsers->links('pagination::bootstrap-4') }}
             </div>
-            <div class="text-left d-inline-block w-75">
-                <p class="mb-1">{{ $followingUser->posts->last()->text }}</p>
-                <p class="text-muted">{{ $followingUser->posts->last()->updated_at }}</p>
-            </div>
-            @if (Auth::check() && Auth::id() === $user->id)
-                <div class="d-inline-block w-50 mb-3">
-                    @if (Auth::user()->isFollow($followingUser->id))
-                        <form method="POST" action="{{ route('unfollow', $followingUser->id) }}">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-danger btn-block">フォローを外す</button>
-                        </form>
-                    @endif
-                </div>
-            @endif
-        </li>
-    </ul>
-@endforeach
-<div class="m-auto" style="width: fit-content"></div>
-{{ $followingUsers->links('pagination::bootstrap-4') }}
+        </div>
+    </div>
+@endsection

--- a/resources/views/follow/following_list.blade.php
+++ b/resources/views/follow/following_list.blade.php
@@ -1,0 +1,27 @@
+@foreach ($followingUsers as $followingUser )
+    <ul class="list-unstyled">
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followingUser->email, 55) }}" alt="{{ $followingUser->email }}のアバター画像">
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followingUser->id) }}">{{ $followingUser->name }}</a></p>
+            </div>
+            <div class="text-left d-inline-block w-75">
+                <p class="mb-1">{{ $followingUser->posts->last()->text }}</p>
+                <p class="text-muted">{{ $followingUser->posts->last()->updated_at }}</p>
+            </div>
+            @if (Auth::check() && Auth::id() === $user->id)
+                <div class="d-inline-block w-50 mb-3">
+                    @if (Auth::user()->isFollow($followingUser->id))
+                        <form method="POST" action="{{ route('unfollow', $followingUser->id) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger btn-block">フォローを外す</button>
+                        </form>
+                    @endif
+                </div>
+            @endif
+        </li>
+    </ul>
+@endforeach
+<div class="m-auto" style="width: fit-content"></div>
+{{ $followingUsers->links('pagination::bootstrap-4') }}

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,63 +1,13 @@
 @extends('layouts.app')
 @section('content')
-@if (session('greenMessage'))
-    <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('greenMessage') }}</strong>
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div>
-@endif
-@if (session('redMessage'))
-    <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('redMessage') }}</strong>
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div> 
-@endif
+    @include('commons.flash_message')
     <div class="row">
         <aside class="col-sm-4 mb-5">
-            <div class="card bg-info">
-                <div class="card-header">
-                    <h3 class="card-title text-light">{{ $user->name }}</h3>
-                </div>
-                <div class="card-body">
-                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}"
-                        alt="{{ $user->name }}アバター画像">
-                    @if ($user->id === Auth::id() )
-                        <div class="mt-3">
-                            <a href="{{ route('edit',Auth::id()) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
-                        </div>
-                    @else
-                    @endif
-                </div>
-            </div>
-            @include('follow.follow_button')
+            @include('commons.user_icon')
         </aside>
         <div class="col-sm-8">
-            <ul class="nav nav-tabs nav-justified mb-3">
-                <li class="nav-item"><a href="{{ route('user.show', $user->id) }}"
-                        class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン<br><div class="badge badge-secondary">{{ $countPosts }}</div></a>
-                </li>
-                <li class="nav-item"><a href="{{ route('user.followingList', $user->id)}}" 
-                        class="nav-link {{ Request::is('users/'. $user->id. '/followingList') ? 'active' : '' }}">フォロー中<br><div class="badge badge-secondary">{{ $countFollowings }}</div></a>
-                </li>
-                <li class="nav-item"><a href="{{ route('user.followedList', $user->id)}}"
-                        class="nav-link  {{ Request::is('users/'. $user->id. '/followedList') ? 'active' : '' }}">フォロワー<br><div class="badge badge-secondary">{{ $countFollowers }}</div></a>
-                </li>
-            </ul>
-            <ul class="list-unstyled">
-            @if (Request::is('users/'. $user->id))
-                @include('posts.posts')
-            @elseif (Request::is('users/'. $user->id. '/followingList'))
-                @include('follow.following_list')
-            @elseif (Request::is('users/'. $user->id. '/followedList'))
-                @include('follow.followed_list')
-            @else
-                @include('posts.posts')
-            @endif
-            </ul>
+            @include('commons.tab')
+            @include('posts.posts')
         </div>
     </div>
 @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -38,15 +38,25 @@
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
                 <li class="nav-item"><a href="{{ route('user.show', $user->id) }}"
-                        class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン</a>
+                        class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン<br><div class="badge badge-secondary">{{ $countPosts }}</div></a>
                 </li>
-                <li class="nav-item"><a href="#" class="nav-link">フォロー中</a>
+                <li class="nav-item"><a href="{{ route('user.followingList', $user->id)}}" 
+                        class="nav-link {{ Request::is('users/'. $user->id. '/followingList') ? 'active' : '' }}">フォロー中<br><div class="badge badge-secondary">{{ $countFollowings }}</div></a>
                 </li>
-                <li class="nav-item"><a href="#" class="nav-link">フォロワー</a>
+                <li class="nav-item"><a href="{{ route('user.followedList', $user->id)}}"
+                        class="nav-link  {{ Request::is('users/'. $user->id. '/followedList') ? 'active' : '' }}">フォロワー<br><div class="badge badge-secondary">{{ $countFollowers }}</div></a>
                 </li>
             </ul>
             <ul class="list-unstyled">
+            @if (Request::is('users/'. $user->id))
                 @include('posts.posts')
+            @elseif (Request::is('users/'. $user->id. '/followingList'))
+                @include('follow.following_list')
+            @elseif (Request::is('users/'. $user->id. '/followedList'))
+                @include('follow.followed_list')
+            @else
+                @include('posts.posts')
+            @endif
             </ul>
         </div>
     </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,22 +6,7 @@
         </div>
     </div>
 </div>
-@if (session('greenMessage'))
-    <div class="alert alert-success alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('greenMessage') }}</strong>
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div>
-@endif
-@if (session('redMessage'))
-    <div class="alert alert-danger alert-dismissible fade show mx-auto w-75" role="alert">
-        <strong>{{ session('redMessage') }}</strong>
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-        </button>
-    </div> 
-@endif
+@include('commons.flash_message')
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
 @include('commons.new_post')
 @include('posts.posts')

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,8 @@ Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 // ユーザ詳細ページ
 Route::prefix('users')->group(function () {
     Route::get('{id}', 'UsersController@show')->name('user.show');
+    Route::get('{id}/followingList', 'UsersController@showFollowingList')->name('user.followingList');
+    Route::get('{id}/followedList', 'UsersController@showFollowedList')->name('user.followedList');
 });
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {


### PR DESCRIPTION
## issue
- Close #352 

## 動作環境手順
「ユーザ詳細画面」(http\://localhost:8080/users/{id})へ移動
- タブ「タイムライン」,「フォロー中」,「フォロワー」の下に「投稿数」,「フォロー中ユーザ数」,「フォロワー数」が
表示される。
-「フォロー中」,「フォロワー」のタグをクリック、それぞれでフォロー中、フォロワーのユーザ名,最新の投稿,
最新投稿日が表示される。10人ずつページネーションする。
- 「フォロー中」の画面で「フォローを外す」ボタンが表示されないこと

ログインした状態で「ユーザ詳細画面」のログインユーザのページ(http\://localhost:8080/users/{ログインユーザのid})へ移動
- 「フォロー中」の画面で「フォローを外す」ボタンが表示される。クリックするとフォローが外れる。

## 考慮してほしいこと
特になし
## 確認してほしいこと
より少ないコード数やすっきりした書き方があれば教えて頂きたいです。
