### PR TITLE
投稿に改行反映（あめみや）

### DIFF
--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -13,67 +13,67 @@ class PostsTableSeeder extends Seeder
     {
         DB::table('posts')->insert([
             'user_id' => 1,
-            'text' => 'テスト投稿ユーザー1',
+            'text' => "テスト\n投稿1\nユーザ1",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 2,
-            'text' => 'テスト投稿ユーザー2',
+            'text' => "テスト\n投稿2\nユーザ2",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 3,
-            'text' => 'テスト投稿ユーザー3',
+            'text' => "テスト\n投稿3\nユーザ3",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 4,
-            'text' => 'テスト投稿ユーザー4',
+            'text' => "テスト\n投稿4\nユーザ4",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 1,
-            'text' => 'テストtext5',
+            'text' => "テスト\n投稿5\nユーザ1",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 1,
-            'text' => 'text6',
+            'text' => "テスト\n投稿6\nユーザ1",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 2,
-            'text' => 'text7',
+            'text' => "テスト\n投稿7\nユーザ2",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 2,
-            'text' => 'text8',
+            'text' => "テスト\n投稿8\nユーザ2",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 3,
-            'text' => 'text9',
+            'text' => "テスト\n投稿9\nユーザ3",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 3,
-            'text' => 'text10',
+            'text' => "テスト\n投稿10\nユーザ3",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
         DB::table('posts')->insert([
             'user_id' => 4,
-            'text' => 'text11',
+            'text' => "テスト\n投稿11\nユーザ4",
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -15,7 +15,7 @@
             <div class="">
                 <div class="text-left d-inline-block w-75">
                     <strong>
-                        <p class="mb-2">{{ $post->text }}</p>
+                        <p class="mb-2">{!!nl2br(e($post->text))!!}</p>
                     </strong>
                     <p class="text-muted">{{ $post->updated_at }}</p>
                 </div>


### PR DESCRIPTION
## issue
- Close #381

## 概要
- 投稿に改行の反映が可能に変更

## 動作確認手順
- 下記コマンドを実行
php artisan migrate --seed
- Adminerでpostsテーブルに11個のレコードが保存されていることを確認
### 下記ページにて改行の反映を確認
* http://localhost:8080/
* http://localhost:8080/users/〇

## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認をする必要あり。
php artisan migrate:fresh --seed

## 確認してほしいこと
今まで投稿部分は改行入力しても、
表示には改行が反映されていませんでした。
コメントのみ改行が反映されている状態だったため、
投稿にも改行が反映されるように、シーダー部分も合わせて変更しました。