### PR TITLE
フラッシュメッセージその2（あめみや）

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
 
 class LoginController extends Controller
 {
@@ -26,10 +27,32 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected function redirectTo()
+    protected $redirectTo = '/';
+
+    /**
+     * ログイン後の処理
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $user
+     * @return \Illuminate\Http\Response
+     */
+    protected function authenticated(Request $request, $user)
     {
-        session()->flash('greenMessage', 'ログインしました');
-        return '/';
+        return redirect('/')->with('greenMessage', 'ログインしました');
+    }
+
+    /**
+     * ユーザーをログアウトさせる
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function logout(Request $request)
+    {
+        $this->guard()->logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return $this->loggedOut($request) ?: redirect('/')->with('redMessage', 'ログアウトしました');
     }
 
     /**

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -31,21 +31,14 @@ class LoginController extends Controller
 
     /**
      * ログイン後の処理
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  mixed  $user
-     * @return \Illuminate\Http\Response
      */
-    protected function authenticated(Request $request, $user)
+    protected function authenticated()
     {
         return redirect('/')->with('greenMessage', 'ログインしました');
     }
 
     /**
      * ユーザーをログアウトさせる
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
      */
     public function logout(Request $request)
     {

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -26,7 +26,11 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/';
+    protected function redirectTo()
+    {
+        session()->flash('greenMessage', 'ログインしました');
+        return '/';
+    }
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,6 +8,7 @@ use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Http\Request;
 
 class RegisterController extends Controller
 {
@@ -69,5 +70,18 @@ class RegisterController extends Controller
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    /**
+     * ユーザー登録後の処理
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  mixed  $user
+     * @return \Illuminate\Http\Response
+     */
+    protected function registered(Request $request, $user)
+    {
+        // 登録したら、そのユーザーのプロフィール・ページへ移動
+        return redirect('users/' . $user->id)->with('greenMessage', '新規登録しました');
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,7 +8,6 @@ use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Http\Request;
 
 class RegisterController extends Controller
 {
@@ -74,12 +73,8 @@ class RegisterController extends Controller
 
     /**
      * ユーザー登録後の処理
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  mixed  $user
-     * @return \Illuminate\Http\Response
      */
-    protected function registered(Request $request, $user)
+    protected function registered()
     {
         return redirect('/')->with('greenMessage', '新規登録しました');
     }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -81,7 +81,6 @@ class RegisterController extends Controller
      */
     protected function registered(Request $request, $user)
     {
-        // 登録したら、そのユーザーのプロフィール・ページへ移動
-        return redirect('users/' . $user->id)->with('greenMessage', '新規登録しました');
+        return redirect('/')->with('greenMessage', '新規登録しました');
     }
 }

--- a/app/Http/Controllers/FollowersController.php
+++ b/app/Http/Controllers/FollowersController.php
@@ -6,17 +6,16 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class FollowersController extends Controller
-
 {
     public function store($id)
     {
         \Auth::user()->follow($id);
-        return back();
+        return back()->with('greenMessage', 'フォローしました');
     }
 
     public function destroy($id)
     {
         \Auth::user()->unfollow($id);
-        return back();
+        return back()->with('redMessage', 'フォロー解除しました');
     }
 }


### PR DESCRIPTION
## issue
- Close #377

## 概要
- フラッシュメッセージの実装(その2)
下記項目にフラッシュメッセージを追加
・ユーザ新規登録
・ユーザログイン・ログアウト
・投稿編集（未実装のため次回）
・フォローする
・フォロー外す
※投稿編集のみ次回実装予定（別issue作成済み）

## 動作確認手順
- 上記箇所それぞれ動作を実行する。

## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認をする必要あり。
php artisan migrate:fresh --seed

## 確認してほしいこと
- ログアウトメッセージの記述箇所について
AuthenticatesUsers.phpに記述しております。
コミット前にgit statusをした際、表示される編集したファイルは下記しか出てきませんでした。
・modified:   app/Http/Controllers/Auth/LoginController.php
・modified:   app/Http/Controllers/Auth/RegisterController.php
・modified:   app/Http/Controllers/FollowersController.php
ログアウトのフラッシュメッセージは下記へと記述したのですが、

▼vendor\laravel\framework\src\Illuminate\Foundation\Auth\AuthenticatesUsers.php
```
    public function logout(Request $request)
    {
        $this->guard()->logout();

        $request->session()->invalidate();

        $request->session()->regenerateToken();

        return $this->loggedOut($request) ?: redirect('/')->with('redMessage', 'ログアウトしました');
    }
```
上記のようなファイルは編集すべきではないような気がしたのですが、
やはり編集してはいけないのでしょうか。
こちらのプルリク上にも表示がされておりません。
今までの講座などの中で話が出てきていたとしたら申し訳ございません。

- ログインメッセージの記述方法について
今までのフラッシュメッセージは全て、
`->with('greenMessage', '○○しました');`のような記述方式でした。
今回、上記ではエラーが出たため、ログインのみを、
`session()->flash('greenMessage', 'ログインしました');`といたしました。
検索を行ったところ、
フラッシュメッセージは３通りの記述方法があるようでしたが、
どれか１つ（今回なら`->with`）に統一するべきなのでしょうか。
（混在しているのは、何となくよろしくないような気がしたため。）