### PR TITLE
#385 フォローによるタイムライン変更2 （おおた）

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,4 +10,19 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    //ユーザー詳細のタブに件数を表示するcount関数
+    public function userCounts($user)
+    {
+        $countPosts = $user->posts()->count();
+        $countFollowings = $user->followings()->count();
+        $countFollowers = $user->followers()->count();
+
+        return [
+            'countPosts' => $countPosts,
+            'countFollowings' => $countFollowings,
+            'countFollowers' => $countFollowers,
+        ];
+    }
+
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -46,15 +46,17 @@ class UsersController extends Controller
         return redirect('/');
     }
 
+    //ユーザー詳細　paginateは他のタブに合わせて(9)から(10)に変更しました
     public function show($id)
     {
-      $user = User::findOrFail($id);
-      $posts = $user->posts()->orderBy('id', 'desc')->paginate(9);
-      $data=[
-        'user' => $user,
-        'posts' => $posts,
-      ];
-      return view('users.show',$data);
+        $user = User::findOrFail($id);
+        $posts = $user->posts()->orderBy('id', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'posts' => $posts,
+        ];
+        $data += $this->userCounts($user);
+        return view('users.show',$data);
     }
 
     //ユーザー詳細「フォロー中」
@@ -66,7 +68,9 @@ class UsersController extends Controller
             'user' => $user,
             'followings' => $followings,
         ];
+        $data += $this->userCounts($user);
         return view('follow.followings', $data);
+        
     }
 
     //ユーザー詳細「フォロワー」
@@ -78,6 +82,7 @@ class UsersController extends Controller
             'user' => $user,
             'followers' => $followers,
         ];
+        $data += $this->userCounts($user);
         return view('follow.followers', $data);
     }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -69,4 +69,16 @@ class UsersController extends Controller
         return view('follow.followings', $data);
     }
 
+    //ユーザー詳細「フォロワー」
+    public function followersShow($id)
+    {
+        $user = User::findOrFail($id);
+        $followers = $user->followers()->orderBy('created_at', 'desc')->paginate(10);
+        $data = [
+            'user' => $user,
+            'followers' => $followers,
+        ];
+        return view('follow.followers', $data);
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -43,17 +43,19 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
-
+    //フォロー中の多対多　belongsToMany関数（相手のモデル, ‘中間テーブル名’, ‘自モデルの外部キー名’, ‘相手モデルの外部キー名’)
     public function followings()
     {
         return $this->belongsToMany(User::class,'follows', 'user_id', 'followed_user_id');
     }
-    //followersは動作未確認です 
+    
+    //フォロワーの多対多　belongsToMany関数（相手のモデル, ‘中間テーブル名’, ‘自モデルの外部キー名’, ‘相手モデルの外部キー名’)
     public function followers()
     {
         return $this->belongsToMany(User::class, 'follows', 'followed_user_id', 'user_id')->withTimestamps();
     }
 
+    //フォローする
     public function follow($userId)
     {
         $exist = $this->isFollow($userId);
@@ -66,6 +68,7 @@ class User extends Authenticatable
         }
     }
 
+    //フォローを外す
     public function unFollow($userId)
     {
         $exist = $this->isFollow($userId);
@@ -80,6 +83,7 @@ class User extends Authenticatable
         }
     }
 
+    //フォロー中か否か判定
     public function isFollow($userId)
     {
         return $this->followings()->where('followed_user_id', $userId)->exists();

--- a/resources/views/follow/followers.blade.php
+++ b/resources/views/follow/followers.blade.php
@@ -22,18 +22,29 @@
             <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー</a></li>
         </ul>
         <ul class="list-unstyled">
-            @foreach ($followings as $follow)
+            @foreach ($followers as $follower)
             <li class="mb-3 text-center">
                 <div class="text-left d-inline-block w-75 mb-2">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follow->email, 55) }}" alt="ユーザのアバター画像">
-                    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show',$follow->id) }}">{{$follow->name}}</a></p>
-                    <form method="POST" action="{{ route('unFollow', $follow->id) }}" class="d-inline-block ml-4">
-                        @csrf
-                        @method('DELETE')
-                        <div class="mt-3">
-                            <button type="submit" class="btn btn-danger ">フォロ―を外す</button>
-                        </div>
-                    </form>
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="ユーザのアバター画像">
+                    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show',$follower->id) }}">{{$follower->name}}</a></p>
+                        @if (Auth::check() && Auth::id() !== $follower->id)
+                            @if (Auth::user()->isFollow($follower->id))
+                                <form method="POST" action="{{ route('unFollow', $follower->id) }}" class="d-inline-block ml-4">
+                                    @csrf
+                                    @method('DELETE')
+                                    <div class="mt-3">
+                                        <button type="submit" class="btn btn-danger">フォロ―を外す</button>
+                                    </div>
+                                </form>
+                            @else
+                                <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline-block ml-4">
+                                    @csrf
+                                    <div class="mt-3">
+                                        <button type="submit" class="btn btn-success">フォロ―する</button>
+                                    </div>
+                                </form>
+                            @endif
+                        @endif
                 </div>
             </li>
             @endforeach

--- a/resources/views/follow/followers.blade.php
+++ b/resources/views/follow/followers.blade.php
@@ -17,9 +17,15 @@
     </aside>
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">
-            <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン</a></li>
-            <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中</a></li>
-            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー</a></li>
+            <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン<br>
+                    <div class="badge badge-secondary">{{ $countPosts }}</div>
+                </a></li>
+            <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中<br>
+                    <div class="badge badge-secondary">{{ $countFollowings }}</div>
+                </a></li>
+            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー<br>
+                    <div class="badge badge-secondary">{{ $countFollowers }}</div>
+                </a></li>
         </ul>
         <ul class="list-unstyled">
             @foreach ($followers as $follower)
@@ -27,24 +33,24 @@
                 <div class="text-left d-inline-block w-75 mb-2">
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="ユーザのアバター画像">
                     <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show',$follower->id) }}">{{$follower->name}}</a></p>
-                        @if (Auth::check() && Auth::id() !== $follower->id)
-                            @if (Auth::user()->isFollow($follower->id))
-                                <form method="POST" action="{{ route('unFollow', $follower->id) }}" class="d-inline-block ml-4">
-                                    @csrf
-                                    @method('DELETE')
-                                    <div class="mt-3">
-                                        <button type="submit" class="btn btn-danger">フォロ―を外す</button>
-                                    </div>
-                                </form>
-                            @else
-                                <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline-block ml-4">
-                                    @csrf
-                                    <div class="mt-3">
-                                        <button type="submit" class="btn btn-success">フォロ―する</button>
-                                    </div>
-                                </form>
-                            @endif
+                    @if (Auth::check() && Auth::id() !== $follower->id)
+                        @if (Auth::user()->isFollow($follower->id))
+                            <form method="POST" action="{{ route('unFollow', $follower->id) }}" class="d-inline-block ml-4">
+                                @csrf
+                                @method('DELETE')
+                                <div class="mt-3">
+                                    <button type="submit" class="btn btn-danger">フォロ―を外す</button>
+                                </div>
+                            </form>
+                        @else
+                            <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline-block ml-4">
+                                @csrf
+                                <div class="mt-3">
+                                    <button type="submit" class="btn btn-success">フォロ―する</button>
+                                </div>
+                            </form>
                         @endif
+                    @endif
                 </div>
             </li>
             @endforeach

--- a/resources/views/follow/followings.blade.php
+++ b/resources/views/follow/followings.blade.php
@@ -17,9 +17,15 @@
     </aside>
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">
-            <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン</a></li>
-            <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中</a></li>
-            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー</a></li>
+            <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン<br>
+                    <div class="badge badge-secondary">{{ $countPosts }}</div>
+                </a></li>
+            <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中<br>
+                    <div class="badge badge-secondary">{{ $countFollowings }}</div>
+                </a></li>
+            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー<br>
+                    <div class="badge badge-secondary">{{ $countFollowers }}</div>
+                </a></li>
         </ul>
         <ul class="list-unstyled">
             @foreach ($followings as $follow)
@@ -27,13 +33,15 @@
                 <div class="text-left d-inline-block w-75 mb-2">
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follow->email, 55) }}" alt="ユーザのアバター画像">
                     <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show',$follow->id) }}">{{$follow->name}}</a></p>
-                    <form method="POST" action="{{ route('unFollow', $follow->id) }}" class="d-inline-block ml-4">
-                        @csrf
-                        @method('DELETE')
-                        <div class="mt-3">
-                            <button type="submit" class="btn btn-danger ">フォロ―を外す</button>
-                        </div>
-                    </form>
+                    @if (Auth::check() && Auth::id() !== $follow->id)
+                        <form method="POST" action="{{ route('unFollow', $follow->id) }}" class="d-inline-block ml-4">
+                            @csrf
+                            @method('DELETE')
+                            <div class="mt-3">
+                                <button type="submit" class="btn btn-danger">フォロ―を外す</button>
+                            </div>
+                        </form>
+                    @endif
                 </div>
             </li>
             @endforeach

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,7 +19,7 @@
         <ul class="nav nav-tabs nav-justified mb-3">
             <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン</a></li>
             <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中</a></li>
-            <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
+            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー</a></li>
         </ul>
         @include('posts.posts', ['posts' => $posts])
     </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -17,9 +17,15 @@
     </aside>
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">
-            <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン</a></li>
-            <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中</a></li>
-            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー</a></li>
+            <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン<br>
+                    <div class="badge badge-secondary">{{ $countPosts }}</div>
+                </a></li>
+            <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followings') ? 'active' : '' }}">フォロー中<br>
+                    <div class="badge badge-secondary">{{ $countFollowings }}</div>
+                </a></li>
+            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id.'/followers') ? 'active' : '' }}">フォロワー<br>
+                    <div class="badge badge-secondary">{{ $countFollowers }}</div>
+                </a></li>
         </ul>
         @include('posts.posts', ['posts' => $posts])
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,8 @@ Route::prefix('users')->group(function () {
     Route::get('{id}', 'UsersController@show')->name('user.show');
     //　ユーザー詳細「フォロー中」
     Route::get('{id}/followings', 'UsersController@followingsShow')->name('followings');
+    //　ユーザー詳細「フォワー」
+    Route::get('{id}/followers', 'UsersController@followersShow')->name('followers');
     // フォロー機能（ログイン後）
     Route::post('{id}/follow', 'FollowController@store')->name('follow');
     Route::delete('{id}/unFollow', 'FollowController@destroy')->name('unFollow');


### PR DESCRIPTION
## issue
- Closes #385

## 概要
- フォローによるタイムライン変更 2回目（フォロワーの表示、件数の表示）

## 動作確認手順
- フォロワーのタブで一覧で表示されるか（tinkerで登録して表示を確認しました）
- ３つのタブに件数が表示されるか（count関数）

## 考慮して欲しいこと
- このプルリクでOKが出れば、以下２ヶ所のファイルを共通化しようと思っております
- １、ユーザー詳細カード部分
- ２、タブ（タイムライン／フォロー中／フォロワー）

## 確認してほしいこと
- フォロワーはtinkerで登録して表示を確認しましたが、テストが大変でした。こういった場合、シーダーを作成した方が良いでしょうか？
