### PR TITLE
#405 投稿・ユーザーカウント機能

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -23,6 +23,7 @@ class UsersController extends Controller
             'user' => $user,
             'posts' => $posts,
         ];
+        $data += $this->counts($user);
         return view('users.show', $data);
    } 
 
@@ -68,24 +69,37 @@ class UsersController extends Controller
 
    public function showFollowingList($id)
    {
-       $user = User::findOrFail($id);
-       $followings = $user->followings()->orderBy('created_at', 'desc')->paginate(10);
-       $data=[
-        'user' => $user,
-        'followings' => $followings,
-       ];
+        $user = User::findOrFail($id);
+        $followings = $user->followings()->orderBy('created_at', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'followings' => $followings,
+        ];
+        $data += $this->counts($user);
         return view('users.followings', $data);
    }
 
    public function showFollowerList($id)
    {
-       $user = User::findOrFail($id);
-       $followers = $user->followers()->orderBy('created_at', 'desc')->paginate(10);
-       $data=[
-        'user' => $user,
-        'followers' => $followers,
-       ];
+        $user = User::findOrFail($id);
+        $followers = $user->followers()->orderBy('created_at', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'followers' => $followers,
+        ];
+        $data += $this->counts($user);
         return view('users.follower', $data);
    }
 
+   public function counts($user)
+   {
+        $countPosts = $user->posts()->count();
+        $countFollowings = $user->followings()->count();
+        $countFollower = $user->followers()->count();
+        return [
+            'countPosts' => $countPosts,
+            'countFollowings' => $countFollowings,
+            'countFollower' => $countFollower,
+        ];
+   }
 }

--- a/resources/views/users/nav_tabs.blade.php
+++ b/resources/views/users/nav_tabs.blade.php
@@ -1,5 +1,5 @@
 <ul class="nav nav-tabs nav-justified mb-3">
-    <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">タイムライン</a></li>
-    <li class="nav-item"><a href="{{ route('user.following', $user->id) }}" class="nav-link {{ Request::routeIs('user.following') ? 'active' : '' }}">フォロー中</a></li>
-    <li class="nav-item"><a href="{{ route('user.follower', $user->id) }}" class="nav-link {{ Request::routeIs('user.follower') ? 'active' : '' }}">フォロワー</a></li>
+    <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">タイムライン&nbsp;<span class="badge rounded-pill badge-info">{{ $countPosts }}</span></a></li>
+    <li class="nav-item"><a href="{{ route('user.following', $user->id) }}" class="nav-link {{ Request::routeIs('user.following') ? 'active' : '' }}">フォロー中&nbsp;<span class="badge rounded-pill badge-info">{{ $countFollowings }}</span></a></li>
+    <li class="nav-item"><a href="{{ route('user.follower', $user->id) }}" class="nav-link {{ Request::routeIs('user.follower') ? 'active' : '' }}">フォロワー&nbsp;<span class="badge rounded-pill badge-info">{{ $countFollower }}</span></a></li>
 </ul>


### PR DESCRIPTION
## issue
- Closes #374  

## 概要
- 投稿・ユーザーカウント機能

## 動作確認手順  

1. http://localhost:8080/　に遷移
2. (投稿・フォロー中・フォロワーが存在する)任意のユーザー名をクリックしてユーザー詳細ページに遷移する。
3. 「タイムライン」・「フォロー中」・「フォロワー」それぞれのタブに投稿数/ユーザー数が表示されている。
4. 2.で確認に使用したユーザーでログインし、3.と同じく投稿数/ユーザー数が表示されている。
5. フォロー中に表示されている任意のユーザーの「フォローを解除する」ボタンをクリックする。
6. フォロー中タブに表示されているユーザー数が1減っている。

## 考慮して欲しいこと
必要に応じて、UsersTableSeeder等を利用し、テスト対象のユーザーに投稿・フォロー中・フォロワーが存在する状態を作る必要があります。

## 確認して欲しいこと
表示は問題ないが、表示させるロジックが間違っていないか。