### PR TITLE
#431 フォロー機能修正、フォローバック追加(Ninomiya)

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,5 +14,6 @@ class DatabaseSeeder extends Seeder
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
         $this->call(CommentsTableSeeder::class);
+        $this->call(FollowersTableSeeder::class);
     }
 }

--- a/database/seeds/FollowersTableSeeder.php
+++ b/database/seeds/FollowersTableSeeder.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class FollowersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('followers')->insert([
+            'following_user_id' => 1,
+            'followed_user_id' => 2,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('followers')->insert([
+            'following_user_id' => 1,
+            'followed_user_id' => 3,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('followers')->insert([
+            'following_user_id' => 1,
+            'followed_user_id' => 4,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('followers')->insert([
+            'following_user_id' => 2,
+            'followed_user_id' => 1,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('followers')->insert([
+            'following_user_id' => 3,
+            'followed_user_id' => 2,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('followers')->insert([
+            'following_user_id' => 4,
+            'followed_user_id' => 2,
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+    }
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,9 @@
+.flex-box {
+    display: flex;
+}
+
+.follow-button{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -4,12 +4,16 @@
             <form method="POST" action="{{ route('unfollow', $user->id) }}">
                 @csrf
                 @method('DELETE')
-                <button type="submit" class="btn btn-danger btn-block">フォローを外す</button>
+                <button type="submit" class="btn btn-outline-danger btn-block">
+                    <i class="fas fa-user-minus"></i> フォロー解除
+                </button>
             </form>
         @else
             <form method="POST" action="{{ route('follow', $user->id) }}">
                 @csrf
-                <button type="submit" class="btn btn-primary btn-block">フォローする</button>
+                <button type="submit" class="btn btn-outline-primary btn-block">
+                    <i class="fas fa-user-plus"></i> フォローする
+                </button>
             </form>
         @endif
     </div>

--- a/resources/views/follow/followed_list.blade.php
+++ b/resources/views/follow/followed_list.blade.php
@@ -3,17 +3,37 @@
     @include('commons.flash_message')
     <div class="row">
         <aside class="col-sm-4 mb-5">
-            @include('commons.user_icon')
+            @include('users.user_icon')
         </aside>
         <div class="col-sm-8">
             @include('commons.tab')
             @foreach ($followedUsers as $followedUser )
                 <ul class="list-unstyled">
-                    <li class="mb-3 text-center">
+                    <li class="mb-3 text-center flex-box">
                         <div class="text-left d-inline-block w-75 mb-2">
                             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followedUser->email, 55) }}" alt="{{ $followedUser->email }}のアバター画像">
                             <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followedUser->id) }}">{{ $followedUser->name }}</a></p>
-                        </div>     
+                        </div>
+                        @if (Auth::check() && Auth::id() === $user->id)
+                            <div class="w-50 mb-2 follow-button">
+                                @if (!(Auth::user()->isFollow($followedUser->id)))
+                                    <form method="POST" action="{{ route('follow', $followedUser->id) }}">
+                                        @csrf
+                                        <button type="submit" class="btn btn-outline-primary btn-block">
+                                            <i class="fas fa-user-plus"></i> フォローバックする
+                                        </button>
+                                    </form>
+                                @else
+                                <form method="POST" action="{{ route('unfollow', $followedUser->id) }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-outline-danger btn-block">
+                                            <i class="fas fa-user-minus"></i> フォロー解除
+                                        </button>
+                                </form>                                
+                                @endif
+                            </div>
+                        @endif
                     </li>
                 </ul>
             @endforeach

--- a/resources/views/follow/following_list.blade.php
+++ b/resources/views/follow/following_list.blade.php
@@ -3,24 +3,26 @@
     @include('commons.flash_message')
     <div class="row">
         <aside class="col-sm-4 mb-5">
-            @include('commons.user_icon')
+            @include('users.user_icon')
         </aside>
         <div class="col-sm-8">
             @include('commons.tab')
             @foreach ($followingUsers as $followingUser )
                 <ul class="list-unstyled">
-                    <li class="mb-3 text-center">
+                    <li class="mb-3 text-center flex-box">
                         <div class="text-left d-inline-block w-75 mb-2">
                             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($followingUser->email, 55) }}" alt="{{ $followingUser->email }}のアバター画像">
                             <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $followingUser->id) }}">{{ $followingUser->name }}</a></p>
                         </div>
                         @if (Auth::check() && Auth::id() === $user->id)
-                            <div class="d-inline-block w-50 mb-3">
+                            <div class="w-50 mb-2 follow-button">
                                 @if (Auth::user()->isFollow($followingUser->id))
                                     <form method="POST" action="{{ route('unfollow', $followingUser->id) }}">
                                         @csrf
                                         @method('DELETE')
-                                        <button type="submit" class="btn btn-danger btn-block">フォローを外す</button>
+                                        <button type="submit" class="btn btn-outline-danger btn-block">
+                                            <i class="fas fa-user-minus"></i> フォロー解除
+                                        </button>
                                     </form>
                                 @endif
                             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
         integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <link rel="stylesheet" href="{{ asset('css/style.css') }}">
 </head>
 
 <body>


### PR DESCRIPTION
## issue
- Close #431 

## 概要
- フォロー機能をいつの間にか消してしまっていたため、復活させました。
- 「フォロワーリスト」にフォローバックする機能を追加しました。
- フォロー関連のボタンにアイコンを追加しました。

## 動作環境手順
ログイン後、「ユーザ詳細画面」に移動。
- 「フォロー中」のタブをクリック、「フォロー解除」のボタンが表示される。
- 「フォロワー」のタブをクリック、フォロー済みのユーザーには「フォロー解除」ボタンが表示され
　フォローしていないユーザーには「フォローバックする」ボタンが表示される。

## 考慮してほしいこと
- 状況に応じて下記コマンドで動作確認する必要あり。
　php artisan db:seed --class=FollowersTableSeeder
　そのあと、id=2のユーザーでログイン。
- プッシュした後に、シーダーがあった方がいいと考えてシーダーを実装、再プッシュしました。

## 確認してほしいこと
フォロー済みユーザーには「フォロー解除」ボタンが表示され、
フォローしていないユーザーには
ユーザー詳細画面、左のユーザーアイコンの下：「フォローする」が表示される。
ユーザー詳細画面の「フォロワー」タブ内：「フォローバックする」が表示される。
