### PR TITLE
#440 コメント（ボケ）へのいいね機能

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -23,4 +23,9 @@ class Comment extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function favoriteUsers()
+    {
+        return $this->belongsToMany(User::class, 'favorites_comment', 'comment_id', 'user_id')->withTimestamps();
+    }
+
 }

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -45,7 +45,6 @@ class CommentController extends Controller
         if ($isOwner) {
             $comment = Comment::findOrFail($commentId);
             $comment->delete();
-            $post = Post::findOrFail($postId);
             return back()->with('withdraw_message', '削除しました！');
         } else {
             return view('errors.404');

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -18,11 +18,14 @@ class Controller extends BaseController
         $countFollowings = $user->followings()->count();
         $countFollowers = $user->followers()->count();
         $countFavorites = $user->favorites()->count();
+        $countFavoritesComments = $user->commentFavorites()->count();
         return [
             'countPosts' => $countPosts,
             'countFollowings' => $countFollowings,
             'countFollowers' => $countFollowers,
             'countFavorites' => $countFavorites,
+            'countFavoritesComments' => $countFavoritesComments,
+
         ];
     }
 }

--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -17,4 +17,18 @@ class FavoriteController extends Controller
         \Auth::user()->unfavorite($id);
         return back();
     }
+
+    //コメントへのいいね
+    public function commentStore($commentId)
+    {
+        \Auth::user()->commentFavorite($commentId);
+        return back();
+    }
+
+    public function commentDestroy($commentId)
+    {
+        \Auth::user()->commentUnfavorite($commentId);
+        return back();
+    }
+
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -98,4 +98,16 @@ class UsersController extends Controller
         return view('users.show',$data);
     }
 
+    public function favoritesComments($id)
+    {
+        $user = User::findOrFail($id);
+        $comments = $user->commentFavorites()->orderBy('created_at', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'comments' => $comments,
+        ];
+        $data += $this->userCounts($user);
+        return view('comments.favorites', $data);
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -155,4 +155,37 @@ private function isPostOwner($postId)
         }
     }
 
+    //コメントへのいいね機能
+    public function commentFavorites()
+    {
+        return $this->belongsToMany(Comment::class, 'favorites_comment', 'user_id', 'comment_id')->withTimestamps();
+    }
+
+    public function commentFavorite($commentId)
+    {
+        $exist = $this->isCommentFavorite($commentId);
+        if ($exist) {
+            return false;
+        } else {
+            $this->commentFavorites()->attach($commentId);
+            return true;
+        }
+    }
+
+    public function commentUnFavorite($commentId)
+    {
+        $exist = $this->isCommentFavorite($commentId);
+        if ($exist) {
+            $this->commentFavorites()->detach($commentId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function isCommentFavorite($commentId)
+    {
+        return $this->commentFavorites()->where('comment_id', $commentId)->exists();
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -155,16 +155,18 @@ private function isPostOwner($postId)
         }
     }
 
-    //コメントへのいいね機能
+    //コメントへのいいね機能の多対多（相手のモデル, ‘中間テーブル名’, ‘自モデルの外部キー名’, ‘相手モデルの外部キー名’)
     public function commentFavorites()
     {
         return $this->belongsToMany(Comment::class, 'favorites_comment', 'user_id', 'comment_id')->withTimestamps();
     }
 
+    //コメントへのいいね
     public function commentFavorite($commentId)
     {
         $exist = $this->isCommentFavorite($commentId);
-        if ($exist) {
+        $itsMe = $this->id === $commentId;
+        if ($exist || $itsMe) {
             return false;
         } else {
             $this->commentFavorites()->attach($commentId);
@@ -172,10 +174,12 @@ private function isPostOwner($postId)
         }
     }
 
+    //コメントへのいいねを外す
     public function commentUnFavorite($commentId)
     {
         $exist = $this->isCommentFavorite($commentId);
-        if ($exist) {
+        $itsMe = $this->id === $commentId;
+        if ($exist || $itsMe) {
             $this->commentFavorites()->detach($commentId);
             return true;
         } else {
@@ -183,6 +187,7 @@ private function isPostOwner($postId)
         }
     }
 
+    //コメントへいいねしているか判定
     public function isCommentFavorite($commentId)
     {
         return $this->commentFavorites()->where('comment_id', $commentId)->exists();

--- a/database/migrations/2023_06_30_234119_create_favorites_comment_table.php
+++ b/database/migrations/2023_06_30_234119_create_favorites_comment_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFavoritesCommentTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('favorites_comment', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('comment_id')->unsigned()->index();
+            $table->timestamps();
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('comment_id')->references('id')->on('comments')->onDelete('cascade');
+            $table->unique(['user_id','comment_id']);
+        });
+    }
+    
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('favorites_comment');
+    }
+}

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -35,6 +35,7 @@
                     <p class="text-center mb-2 h4">{{$posts->text}}</p>
                     <p class="text-center text-muted mb-2 h3">{{$comment->body}}</p>
                 </div>
+                @include('favorite.comment_favorite_button', ['comment' => $comment])
                 @if (Auth::id() === $comment->user_id)
                 <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                     <form method="" action="">

--- a/resources/views/comments/favorites.blade.php
+++ b/resources/views/comments/favorites.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.app')
+@section('content')
+<div class="row">
+    <aside class="col-sm-4 mb-5">
+        @include('users.user_card')
+    </aside>
+    <div class="col-sm-8">
+        @include('users.user_tab')
+        <ul class="list-unstyled">
+            @foreach ($comments as $comment)
+            <li class="mb-3 text-center">
+                <div class="text-left d-inline-block w-75 mb-2">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($comment->user->email, 35) }}" alt="ユーザのアバター画像">
+                    <p class="mt-3 mb-0 d-inline-block">回答：<a href="{{ route('user.show', $comment->user->id) }}">{{$comment->user->name}}</a>さん</p>
+                    <p class="text-muted d-inline-block ml-4">{{$comment->created_at}}</p>
+                </div>
+                <div class="">
+                    <div class="text-left d-inline-block w-75">
+                        @if ($comment->post)
+                        <p class="text-center mb-2 h4">{{$comment->post->text}}</p>
+                        <p class="text-center text-muted mb-2 h3">{{$comment->body}}</p>
+                        @endif
+                    </div>
+                    @include('favorite.comment_favorite_button', ['comment' => $comment])
+                    @if (Auth::id() === $comment->user_id)
+                    <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                        <form method="" action="">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">削除</button>
+                        </form>
+                        <a href="" class="btn btn-primary">編集する</a>
+                    </div>
+                    @endif
+                </div>
+            </li>
+            @endforeach
+        </ul>
+    </div>
+</div>
+@endsection

--- a/resources/views/comments/index.blade.php
+++ b/resources/views/comments/index.blade.php
@@ -22,6 +22,7 @@
                 <p class="text-center text-muted mb-2 h3">{{$comment->body}}</p>
                 @endif
             </div>
+            @include('favorite.comment_favorite_button', ['comment' => $comment])
             @if (Auth::id() === $comment->user_id)
             <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                 <form method="" action="">

--- a/resources/views/favorite/comment_favorite_button.blade.php
+++ b/resources/views/favorite/comment_favorite_button.blade.php
@@ -1,0 +1,20 @@
+<div class="text-center mb-1">
+    @php
+    $countFavoriteUsers = $comment->favoriteUsers()->count();
+    @endphp
+    <span class="badge badge-pill badge-secondary">{{ $countFavoriteUsers }}w</span>
+</div>
+@if (Auth::check() && Auth::id() !== $comment->user_id)
+    @if (Auth::user()->isCommentFavorite($comment->id))
+        <form action="{{ route('comment.unfavorite', $comment->id) }}" method="POST">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-outline-danger btn-sm">ワロタwを外す</button>
+        </form>
+    @else
+        <form action="{{ route('comment.favorite', $comment->id) }}" method="POST">
+            @csrf
+            <button type="submit" class="btn btn-outline-success btn-sm">ワロタw</button>
+        </form>
+    @endif
+@endif

--- a/resources/views/users/user_tab.blade.php
+++ b/resources/views/users/user_tab.blade.php
@@ -1,6 +1,6 @@
 <ul class="nav nav-tabs nav-justified mb-3">
     <li class="nav-item">
-        <a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">タイムライン<br>
+        <a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">投稿したお題<br>
             <div class="badge badge-secondary">{{ $countPosts }}</div>
         </a>
     </li>
@@ -14,6 +14,12 @@
             <div class="badge badge-secondary">{{ $countFollowers }}</div>
         </a>
     </li>
-    <li class="nav-item nav-link"><a href="{{ route('favorites', $user->id) }}" class="{{ Request::is('users/'. $user->id. 'favorites'. $user->id) ? 'active' : '' }}">いいね<span class="ml-2 badge badge-success">{{ $countFavorites }}</span></a></li>        </ul>
+    <li class="nav-item nav-link"><a href="{{ route('favorites', $user->id) }}" class="{{ Request::is('users/'. $user->id. 'favorites'. $user->id) ? 'active' : '' }}">いいね<span class="ml-2 badge badge-success">{{ $countFavorites }}</span></a></li>
+    <li class="nav-item">
+        <a href="{{ route('comment.favorites', $user->id) }}" class="nav-link {{ Request::routeIs('comment.favorites') ? 'active' : '' }}">ワロタ<br>
+            <div class="badge badge-secondary">{{ $countFavoritesComments }}</div>
+        </a>
+    </li>
+</ul>
 
 </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,8 @@ Route::prefix('users/{id}')->group(function () {
 
     //ユーザー詳細イイね
     Route::get('favorites', 'UsersController@favorites')->name('favorites');
+    //ユーザー詳細コメントへのイイね（ワロタ）
+    Route::get('comment_favorites', 'UsersController@favoritesComments')->name('comment.favorites');
 });
 
 // ログイン後
@@ -62,6 +64,11 @@ Route::group(['middleware' => 'auth'], function () {
     Route::group(['prefix' => 'posts/{id}'],function(){
         Route::post('favorite', 'FavoriteController@store')->name('favorite');
         Route::delete('unfavorite', 'FavoriteController@destroy')->name('unfavorite');
+    });
+    //コメントのイイね
+    Route::group(['prefix' => 'comments/{commentId}'], function () {
+        Route::post('favorite', 'FavoriteController@commentStore')->name('comment.favorite');
+        Route::delete('unfavorite', 'FavoriteController@commentDestroy')->name('comment.unfavorite');
     });
 });
 


### PR DESCRIPTION
## issue
- Closes #440

## 概要
- コメント（ボケ）へのいいね機能

## 動作確認手順

＜いいね数（ワロタ）の表示＞
ログイン前
- コメント（ボケ）の下に、ワロタ数が表示されている
- /posts/{id}
- /comments

ログイン後
- コメント（ボケ）の下に、いいね数が表示されている
- /users/{id}/comment_favorites

＜いいね（ワロタ）機能＞
ログイン後
/posts/{id}、/comments　共通
- 各お題のボケ回答ページで、いいね（ワロタ）ボタンを押下するとワロタ数が増える。ボタンが外すボタンに変わる
- ワロタを外すボタンを押下するとワロタ数が減る。ボタンが元に戻る
- /users/{id}/comment_favorites　ユーザー詳細ページのワロタタブにワロタしたコメントが一覧で表示される

＜いいね（ワロタ）編集更新・削除＞
/posts/{id}、/comments　共通
- ログイン後、コメントの編集更新・削除ができる

## 考慮して欲しいこと
- 特にありません

## 確認してほしいこと
- 各メソッドの名称に違和感がないかご確認いただければありがたいです
