### PR TITLE
コメントのカウント表示（あめみや）

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -16,11 +16,13 @@ class Controller extends BaseController
         $countPosts = $user->posts()->count();
         $countFollowings = $user->following()->count();
         $countFollowers = $user->followed()->count();
+        $countComments = $user->post->comments()->count();
 
         return [
             'countPosts' => $countPosts,
             'countFollowings' => $countFollowings,
             'countFollowers' => $countFollowers,
+            'countComments' => $countComments,
         ];
     }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -16,12 +16,10 @@ class Controller extends BaseController
         $countPosts = $user->posts()->count();
         $countFollowings = $user->following()->count();
         $countFollowers = $user->followed()->count();
-
-
         return [
             'countPosts' => $countPosts,
             'countFollowings' => $countFollowings,
-            'countFollowers' => $countFollowers, 
+            'countFollowers' => $countFollowers,
         ];
     }
 }

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -80,7 +80,7 @@
                     <h5 class="card-header">
                         コメント
                         @php
-                        $countComments = $post->comments()->count();
+                            $countComments = $post->comments()->count();
                         @endphp
                         <div div class="badge badge-secondary">{{ $countComments }}件</div>
                     </h5>

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -25,9 +25,44 @@
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75 mb-2">
-                    <strong>
+                    @if (isset($post->img_path))
                         <p>{!!nl2br(e($post->text))!!}</p>
-                    </strong>
+                        <img src="{{ Storage::url($post->img_path) }}" class="mb-2" alt="">
+                    @else
+                        <p>{!!nl2br(e($post->text))!!}</p>
+                    @endif
+                    <div class="flex-box  adjust-center">
+                        <i class="far fa-comment-dots"></i>
+                        <p class="badge badge-pill badge-light mb-2 mr-2">
+                            @php
+                                $countComments = $post->comments()->count();
+                            @endphp
+                            <span>{{ $countComments }}件</span>
+                        </p>
+                        <i class="far fa-thumbs-up mb-2"></i>
+                        <p class="badge badge-pill badge-light mb-2 mr-2">
+                            @php
+                                $countFavoritePostUsers = $post->favoritePostUsers()->count();
+                            @endphp
+                            <span>{{ $countFavoritePostUsers }}</span>
+                        </p>
+                        <p>
+                            @if (Auth::check() && Auth::id() !== $post->user_id)
+                                @if (Auth::user()->isFavoritePosts($post->id))
+                                    <form method="POST" action="{{ route('unfavorite.post', $post->id) }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-outline-danger btn-sm mb-2">いいね！を外す</button>
+                                    </form>
+                                @else
+                                    <form method="POST" action="{{ route('favorite.post', $post->id) }}">
+                                        @csrf
+                                        <button type="submit" class="btn btn-outline-success btn-sm mb-2">いいね！を押す</button>
+                                    </form>
+                                @endif
+                            @endif
+                        </p>
+                    </div>
                 </div>
                 @if ($post->user->id === Auth::id() )
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
@@ -42,7 +77,13 @@
                     </div>
                 @endif
                 <div class="card text-left d-inline-block w-75 mb-2">
-                    <h5 class="card-header">コメント</h5>
+                    <h5 class="card-header">
+                        コメント
+                        @php
+                        $countComments = $post->comments()->count();
+                        @endphp
+                        <div div class="badge badge-secondary">{{ $countComments }}件</div>
+                    </h5>
                     <div class="card-body">
                         @if (Auth::check())
                             <div class="actions">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -30,6 +30,19 @@
                         <p>{!!nl2br(e($post->text))!!}</p>
                     @endif
                     <div class="flex-box  adjust-center">
+                        <i class="far fa-comment-dots"></i>
+                        <p class="badge badge-pill badge-light mb-2 mr-2">
+                            @php
+                                $countComments = $post->comments()->count();
+                            @endphp
+                            @if ($post->comments->count() > 0)
+                                <a href="{{ route('comment.show', $post->id) }}">
+                                    <span>{{ $countComments }}件</span>
+                                </a>
+                            @else
+                                <span>{{ $countComments }}件</span>
+                            @endif
+                        </p>
                         <i class="far fa-thumbs-up mb-2"></i>
                         <p class="badge badge-pill badge-light mb-2 mr-2">
                             @php
@@ -164,6 +177,7 @@
                             <div class="text-left d-inline-block w-75 mb-2">
                                 <a href="{{ route('comment.show', $post->id) }}">
                                     ...さらにコメントを見る <i class="far fa-comment-dots"></i>
+                                    <div class="badge badge-secondary">{{ $countComments }}件</div>
                                 </a>
                             </div>
                         @endif


### PR DESCRIPTION
## issue
- Close #439

## 概要
- コメントのカウント表示の実装

## 動作確認手順
- 各ページを確認
- トップページ
http://localhost:8080/
　投稿下部に件数表示
　コメント部分「...さらにコメントを見る」の横
　※コメントありの場合のみコメントページへのリンク
- コメントページ
http://localhost:8080/comments/〇
　投稿下部に件数表示
　card-headerのコメント文字横に件数表示

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし