### PR TITLE
不要項目削除_ユーザ名横FontAwesome（あめみや）

### DIFF
--- a/resources/views/comments/comment_list.blade.php
+++ b/resources/views/comments/comment_list.blade.php
@@ -11,7 +11,7 @@
                 @endif
                 <p class="mt-1 mb-1 d-inline-block">
                     <a href="{{ route('user.show', $comment->user->id) }}">
-                        <i class="fas fa-user-alt"></i> {{$comment->user->name}}
+                        {{$comment->user->name}}
                     </a>
                 </p>
                 {{ $comment->updated_at->format('Y年m月d日H時i分') }}

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -15,7 +15,7 @@
                     <p class="mt-3 mb-0 d-inline-block">
                         <strong>
                             <a href="{{ route('user.show', $post->user->id) }}">
-                                <i class="fas fa-user-alt"></i> {{$post->user->name}}
+                                {{$post->user->name}}
                             </a>
                         </strong>
                         {{ $post->updated_at->format('Y年m月d日H時i分') }}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -13,7 +13,7 @@
                     <p class="mt-3 mb-0 d-inline-block">
                         <strong>
                             <a href="{{ route('user.show', $post->user->id) }}">
-                                <i class="fas fa-user-alt"></i> {{$post->user->name}}
+                                {{$post->user->name}}
                             </a>
                         </strong>
                         {{ $post->updated_at->format('Y年m月d日H時i分') }}
@@ -127,7 +127,7 @@
                                             @endif
                                             <p class="mt-1 mb-1 d-inline-block">
                                                 <a href="{{ route('user.show', $comment->user->id) }}">
-                                                    <i class="fas fa-user-alt"></i> {{$comment->user->name}}
+                                                    {{$comment->user->name}}
                                                 </a>
                                             </p>
                                             {{ $comment->updated_at->format('Y年m月d日H時i分') }}


### PR DESCRIPTION
## issue
- Close #444

## 概要
- ユーザ名横のFontAwesome削除
画像のアイコンがある部分のみ削除しました。
画像のアイコンが無い部分のFontAwesomeは残しております。

## 動作確認手順
- 下記ページにてFontAwesomeが無くなっていることを確認
・トップページ
http://localhost:8080/
・コメントページ
http://localhost:8080/comments/〇

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし