### PR TITLE
new_post.bladeのold関数修正（あめみや）

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -29,10 +29,18 @@ class PostRequest extends FormRequest
         ];
     }
 
+    public function attributes()
+    {
+        return [
+            'text' => '投稿',
+            'img_path' => '画像',
+        ];
+    }
+
     public function messages()
     {
-            return [
-                'text.required_without_all' => 'テキストもしくは画像のいずれかの投稿は必須です',
-            ];
-        }
+        return [
+            'text.required_without_all' => 'テキストもしくは画像のいずれかの投稿は必須です',
+        ];
+    }
 }

--- a/resources/views/posts/new_post.blade.php
+++ b/resources/views/posts/new_post.blade.php
@@ -8,7 +8,7 @@
             <input type="hidden" name="posts">
             <div class="form-group">
                 <div class ="mb-3">
-                    <textarea class="form-control @error('text') is-invalid @enderror" name="text" rows="4" value="{{ old('text') }}"></textarea>
+                    <textarea class="form-control @error('text') is-invalid @enderror" name="text" rows="4" placeholder="140字以内で投稿しよう ...">{{ old('text') }}</textarea>
                 </div>
                 <div>
                     <i class="far fa-image"></i>


### PR DESCRIPTION
## issue
- Close #457

## 概要
- new_post.bladeの修正
・old関数の記述に誤りがあり、表示されていなかった事の修正
- バリデーションの修正
・textを「投稿」に、img_pathを「画像」と表示されるよう修正
- ついでに投稿フォームに`placeholder="140字以内で投稿しよう ..."`も追加しました。

## 動作確認手順
- 投稿フォームにてエラーが出た際に、エラーの出てしまった文字が残ったままになることを確認
- エラーが出た際に、エラー文が「投稿」や「画像」と表示されることを確認

## 考慮してほしいこと
- 特になし

## 確認してほしいこと
- 特になし