### PR TITLE
#471 デプロイ時のエラー解消（大文字小文字の修正）（おおた）

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 
 // トップページ
-Route::get('/', 'postsController@index')->name('top');
+Route::get('/', 'PostsController@index')->name('top');
 // ユーザー編集、更新
 Route::group(['middleware' => 'auth'], function () 
 {  


### PR DESCRIPTION
## issue
- Closes #471

## 概要
- デプロイ時に起きたエラーの解消です。web.phpの

`Route::get('/', 'postsController@index')->name('top');
`
上記postsの「p」が小文字のためデプロイ時にエラーとなりました。
そのため、以下の通り「P」を大文字に修正しました。

`Route::get('/', 'PostsController@index')->name('top');`


## 動作確認手順
- 上記の通りの変更がされているか