### PR TITLE
#453,#454 投稿画像編集機能、コメント編集機能(Ninomiya)

### DIFF
--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -30,7 +30,7 @@ class CommentsController extends Controller
         $comment->save();
         $img = $request->file('img_path');
         if ($img) {
-            $path = $img->storeAs('public/comment.img', $comment->id . '.' . $request->img_path->extension());
+            $path = $img->storeAs('public/comment.img', $comment->id . '.' . time() . '.' . $request->img_path->extension());
             $comment->img_path = $path;
             $comment->save();
         }
@@ -44,5 +44,33 @@ class CommentsController extends Controller
             $comment->delete();
         }
         return back()->with('redMessage', 'コメント削除しました');
+    }
+
+    public function edit($id)
+    {
+        $user = \Auth::user();
+        $comment = Comment::findOrFail($id);
+        $data=[
+            'user' => $user,
+            'comment' => $comment,
+        ];
+        if ($comment->user_id === \Auth::id()) {
+            return view('comments.edit', $data);
+        }
+        abort(404);
+    }
+
+    public function update(CommentRequest $request, $id)
+    {
+        $comment = Comment::findOrFail($id);
+        $comment->comment = $request->input('comment.' . $request->post_id) ?? '';
+        $img = $request->file('img_path');
+        if ($img) {
+            $path = $img->storeAs('public/comment.img', $comment->id . '.' . time() . '.' . $request->img_path->extension());
+            $comment->img_path = $path;
+            $comment->save();
+        }
+        $comment->save();
+        return redirect('/')->with('greenMessage', '更新しました');
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -30,7 +30,7 @@ class PostsController extends Controller
         $post->save();
         $img = $request->file('img_path');
         if ($img) {
-            $path = $img->storeAs('public/img', $post->id . '.' . $request->img_path->extension());
+            $path = $img->storeAs('public/img', $post->id . '.' . time() . '.' . $request->img_path->extension());
             $post->img_path = $path;
             $post->save();
         }
@@ -81,11 +81,17 @@ class PostsController extends Controller
         abort(404);
     }
 
-    public function update(postRequest $request, $id)
+    public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
-        $post->text = $request->text;
+        $post->text = $request->input('text') ?? '';
         $post->user_id = $request->user()->id;
+        $img = $request->file('img_path');
+        if ($img) {
+            $path = $img->storeAs('public/img', $post->id . '.' . time() . '.' . $request->img_path->extension());
+            $post->img_path = $path;
+            $post->save();
+        }
         $post->save();
         return redirect('/')->with('greenMessage', '更新しました');
     }

--- a/resources/views/comments/comment_list.blade.php
+++ b/resources/views/comments/comment_list.blade.php
@@ -1,5 +1,5 @@
 @foreach($comments as $comment)
-    <div class="text-left d-inline-block w-75 mb-2">
+    <div class="text-left d-inline-block w-100 mb-2">
         <span>
             @if($comment->user->email)
                 @if ($comment->user->profile_image === null)

--- a/resources/views/comments/comment_list.blade.php
+++ b/resources/views/comments/comment_list.blade.php
@@ -54,13 +54,16 @@
             </p>
         </div>
         @if ($comment->user->id === Auth::id())
-            <form method="POST" action="{{ route('comment.delete', $comment->id) }}">
-                @csrf
-                @method('DELETE')
-                <button type="submit" class="btn btn-danger my-2">
-                    <i class="fas fa-trash-alt"></i> コメント削除
-                </button>
-            </form>
+            <div class="d-flex justify-content-between">
+                <form method="POST" action="{{ route('comment.delete', $comment->id) }}">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger my-2">
+                        <i class="fas fa-trash-alt"></i> コメント削除
+                    </button>
+                </form>
+                <a href="{{ route('comment.edit', $comment->id) }}" class="btn btn-success my-2"><i class="fas fa-edit"></i> 編集する</a>
+            </div>
         @endif
     </div>
 @endforeach

--- a/resources/views/comments/comments.blade.php
+++ b/resources/views/comments/comments.blade.php
@@ -79,7 +79,7 @@
                                 <i class="fas fa-trash-alt"></i> 削除
                             </button>
                         </form>
-                        <a href="" class="btn btn-success"><i class="fas fa-edit"></i> 編集する</a>
+                        <a href="{{ route('post.edit', $post->id) }}" class="btn btn-success"><i class="fas fa-edit"></i> 編集する</a>
                     </div>
                 @endif
                 <div class="card text-left d-inline-block w-75 mb-2">
@@ -109,11 +109,12 @@
                                             placeholder="コメントを投稿する ..." autocomplete="off" type="text"
                                             name="comment[{{ $post->id }}]" rows="2"
                                             cols="40">{{ old('comment.'. $post->id) }}</textarea><br>
-                                            <div>
-                                                <i class="far fa-image"></i>
-                                                <input type="file" name="img_path" placeholder="画像投稿">
-                                            </div>
-                                        <div class="text-left mt-5">
+                                        <div>
+                                            <i class="far fa-image"></i>
+                                            <input type="file" name="img_path" placeholder="画像投稿">
+                                        </div>
+                                        <p class="h6 text-secondary ml-3 ">※画像サイズは最大1MB</p>
+                                        <div class="text-left mt-4">
                                             <button type="submit" class="btn btn-primary">
                                                 <i class="fas fa-reply"></i> コメントする
                                             </button>

--- a/resources/views/comments/edit.blade.php
+++ b/resources/views/comments/edit.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+@section('title', 'コメント編集ページ')
+@section('description', 'コメントした内容の編集ができます。')
+@section('content')
+<h2 class="mt-5">コメントを編集する</h2>
+@include('commons.error_messages')
+<form method="POST" action="{{ route('comment.update', $comment->id) }}" enctype="multipart/form-data">
+    @csrf
+    @method('PUT')
+    <div class="form-group">
+        <input value="{{ $comment->post_id }}" type="hidden" name="post_id" />
+        <div class="form-group">
+            <textarea id="text" class="form-control @error('comment.'. $comment->post_id) is-invalid @enderror" name="comment[{{ $comment->post_id }}]"
+            rows="5">{{ old('comment.' . $comment->post_id, $comment->comment) }}</textarea>
+            @error('comment.' . $comment->post_id)
+            <span class="invalid-feedback text-left" role="alert">
+                <strong>{{ $message }}</strong>
+            </span>
+            @enderror
+        </div>
+    </div>
+    <div>
+        @if ($comment->img_path !== null)
+            <a href="{{ Storage::url($comment->img_path) }}" data-lightbox="comment-group_{{ $comment->id }}"
+                data-title="{!!nl2br(e($comment->comment))!!}">
+                <img class="img-fluid mb-2" src="{{ Storage::url($comment->img_path) }}" alt="" width="40%"
+                    height="auto">
+            </a>
+        @endif 
+        <div>
+            <i class="far fa-image"></i>
+            <input type="file" name="img_path" placeholder="画像投稿">
+        </div>
+    </div>
+    <div class="d-flex justify-content-between">
+        <button type="submit" class="btn btn-primary mt-5"><i class="fas fa-check-square"></i> 更新する</button>
+    </div>
+</form>
+@endsection

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -4,20 +4,35 @@
 @section('content')
 <h2 class="mt-5">投稿を編集する</h2>
 @include('commons.error_messages')
-    <form method="POST" action="{{ route('post.update', $post->id) }}">
-        @csrf
-        @method('PUT')
+<form method="POST" action="{{ route('post.update', $post->id) }}" enctype="multipart/form-data">
+    @csrf
+    @method('PUT')
+    <div class="form-group">
         <div class="form-group">
-            <div class="form-group">
-                <textarea id="text" class="form-control @error('text') is-invalid @enderror" name="text"
-                    rows="5">{{ old('text', $post->text) }}</textarea>
-                @error('text')
-                    <span class="invalid-feedback text-left" role="alert">
-                        <strong>{{ $message }}</strong>
-                    </span>
-                @enderror
-            </div>
-            <button type="submit" class="btn btn-primary"><i class="fas fa-check-square"></i> 更新する</button>
+            <textarea id="text" class="form-control @error('text') is-invalid @enderror" name="text"
+            rows="5">{{ old('text', $post->text) }}</textarea>
+            @error('text')
+            <span class="invalid-feedback text-left" role="alert">
+                <strong>{{ $message }}</strong>
+            </span>
+            @enderror
         </div>
-    </form>
+    </div>
+    <div>
+        @if ($post->img_path !== null)
+            <a href="{{ Storage::url($post->img_path) }}" data-lightbox="post-group_{{ $post->id }}"
+                data-title="{!!nl2br(e($post->text))!!}">
+                <img class="img-fluid mb-2" src="{{ Storage::url($post->img_path) }}" alt="" width="40%"
+                    height="auto">
+            </a>
+        @endif 
+        <div>
+            <i class="far fa-image"></i>
+            <input type="file" name="img_path" placeholder="画像投稿">
+        </div>
+    </div>
+    <div class="d-flex justify-content-between">
+        <button type="submit" class="btn btn-primary mt-5"><i class="fas fa-check-square"></i> 更新する</button>
+    </div>
+</form>
 @endsection

--- a/resources/views/posts/new_post.blade.php
+++ b/resources/views/posts/new_post.blade.php
@@ -19,7 +19,8 @@
                         <strong>{{ $message }}</strong>
                     </span>
                 @enderror
-                <div class="text-left mt-5">
+                <p class="h6 text-secondary ml-3 ">※画像サイズは最大1MB</p>
+                <div class="text-left mt-4">
                     <button type="submit" class="btn btn-primary">
                         <i class="fas fa-pen"></i> 投稿する
                     </button>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -180,13 +180,16 @@
                                         </p>
                                     </div>                            
                                     @if ($comment->user->id === Auth::id())
-                                        <form method="POST" action="{{ route('comment.delete', $comment->id) }}">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="submit" class="btn btn-danger my-2">
-                                                <i class="fas fa-trash-alt"></i> コメント削除
-                                            </button>
-                                        </form>
+                                        <div class="d-flex justify-content-between">
+                                            <form method="POST" action="{{ route('comment.delete', $comment->id) }}">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-danger my-2">
+                                                    <i class="fas fa-trash-alt"></i> コメント削除
+                                                </button>
+                                            </form>
+                                            <a href="{{ route('comment.edit', $comment->id) }}" class="btn btn-success my-2"><i class="fas fa-edit"></i> 編集する</a>
+                                        </div>
                                     @endif
                                 </div>
                             @endif

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -109,7 +109,8 @@
                                             <i class="far fa-image"></i>
                                             <input type="file" name="img_path" placeholder="画像投稿">
                                         </div>
-                                        <div class="text-left mt-5">
+                                        <p class="h6 text-secondary ml-3 ">※画像サイズは最大1MB</p>
+                                        <div class="text-left mt-4">
                                             <button type="submit" class="btn btn-primary">
                                                 <i class="fas fa-reply"></i> コメントする
                                             </button>
@@ -123,7 +124,7 @@
                                 $comment = $post->comments->last();
                             @endphp
                             @if ($loop->last)
-                                <div class="text-left d-inline-block w-75 mb-2">
+                                <div class="text-left d-inline-block w-100 mb-2">
                                     <span>
                                         @if($comment->user->email)
                                             @if ($comment->user->profile_image === null)
@@ -195,7 +196,7 @@
                             @endif
                         @endforeach
                         @if ($post->comments->count() > 0)
-                            <div class="text-left d-inline-block w-75 mb-2">
+                            <div class="text-left d-inline-block w-100 mb-2">
                                 <a href="{{ route('comment.show', $post->id) }}">
                                     ...さらにコメントを見る <i class="far fa-comment-dots"></i>
                                     <div class="badge badge-secondary">{{ $countComments }}件</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,9 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('comments')->group(function () {
         Route::post('', 'CommentsController@store')->name('comment.store');
         Route::delete('{id}', 'CommentsController@destroy')->name('comment.delete');
+    //コメント編集画面
+        Route::get('{id}/edit', 'CommentsController@edit')->name('comment.edit');
+        Route::put('{id}', 'CommentsController@update')->name('comment.update');
     });
     //ユーザー編集
     Route::prefix('users/{id}')->group(function () {


### PR DESCRIPTION
## issue
- Close #453
- Close #454 
## 概要
- 投稿した画像の編集機能を実装
- コメントの編集機能を実装（画像の編集を含む）
## 動作環境手順
ログイン後、
- 自分の投稿の下に編集するボタンが表示されることを確認。
　「投稿編集ページ」(http:\//localhost:8080/posts/{id}/edit)へ移動。投稿及び画像を編集後
　更新ボタンをクリック。内容が更新されていることを確認する。
- 自分のコメントの下に編集するボタンが表示されることを確認。
- 「コメント編集ページ」(http:\//localhost:8080/comments/{id}/edit)へ移動。コメント及び画像を編集後
　更新ボタンをクリック。内容が更新されていることを確認する。
## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認する必要あり。
php artisan migrate:fresh --seed
-お手数ですが各自で準備した画像で確認をお願いします。
## 確認してほしいこと
エラーがでないか、挙動がおかしくないかどうか
