### PR TITLE
＃563　ユーザー新規登録時エラーメッセージ表示（seiichi）

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -12,6 +12,11 @@
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
             <form method="POST" action="{{ route('signup.post') }}">
+            エラー<ul class="alert alert-danger" role="alert">
+                <li class="ml-4">名前は、必ず指定してください。</li>
+                <li class="ml-4">メールアドレスは、必ず指定してください。</li>
+                <li class="ml-4">パスワードは、必ず指定してください。</li>
+            </ul>
                 @csrf
                 <div class="form-group">
                     <label for="name">名前</label>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -12,11 +12,13 @@
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
             <form method="POST" action="{{ route('signup.post') }}">
-            エラー<ul class="alert alert-danger" role="alert">
-                <li class="ml-4">名前は、必ず指定してください。</li>
-                <li class="ml-4">メールアドレスは、必ず指定してください。</li>
-                <li class="ml-4">パスワードは、必ず指定してください。</li>
-            </ul>
+                @if (count($errors) > 0)
+                    <ul class="alert alert-danger" role="alert">
+                        @foreach ($errors->all() as $error)
+                            <li class="ml-4">{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                @endif
                 @csrf
                 <div class="form-group">
                     <label for="name">名前</label>


### PR DESCRIPTION
## issue
- Closes #563 

## 概要
- ユーザー新規登録時のエラーメッセージ表示

## 動作確認手順
- http://localhost:8080/signup
　上記ローカルホストで、名前・メールアドレス・パスワードを何も入力せずに新規登録ボタンを
押した場合にエラーメッセージが正常に表示される事を確認