### PR TITLE
ユーザ編集画面・更新(DAIKI)

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,19 +4,57 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\DB;
 use App\user;
 use App\Post;
+use App\Http\Requests\UserRequest;
+use Illuminate\Support\Facades\Auth;
 
-use Illuminate\Http\Request;
-
-/**
- * トップページを表示。
- * @param void
- * @return view
- */
 class PostController extends Controller
 {
+    /**
+     * トップページを表示。
+     * @param void
+     * @return view
+     */
     public function showTop () {
         $posts = Post::orderBy('created_at','desc')->paginate(10);
 
         return view('posts.top', ['posts' => $posts]);
+    }
+
+    /**
+     * ユーザー編集フォームを表示。
+     * @param $id
+     * @return view
+     */
+    public function showUserEdit ($id) {
+        if (Auth::id() === (int)$id) {
+            $users = User::find($id);
+            return view('posts.edit_user', ['users' => $users]);
+        }else{
+            abort(404);
+        }
+    }
+
+    /**
+     * 更新したユーザー情報をDBへ保存。
+     * @param object $request
+     * @return view
+     */
+    public function updateUser (UserRequest $request) {
+        $inputs = $request->all();
+        DB::BeginTransaction();
+        try {
+            $user = User::find($inputs['id']);
+            $user->fill([
+                'name' => $inputs['name'],
+                'email' => $inputs['email'],
+                'password' => bcrypt($inputs['password']),
+            ]);
+            $user->save();
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            abort(500);
+        }
+        return redirect(route('top'));
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,11 +1,8 @@
 <?php
 
 namespace App\Http\Controllers;
-use Illuminate\Support\Facades\DB;
-use App\user;
+
 use App\Post;
-use App\Http\Requests\UserRequest;
-use Illuminate\Support\Facades\Auth;
 
 class PostController extends Controller
 {
@@ -18,43 +15,5 @@ class PostController extends Controller
         $posts = Post::orderBy('created_at','desc')->paginate(10);
 
         return view('posts.top', ['posts' => $posts]);
-    }
-
-    /**
-     * ユーザー編集フォームを表示。
-     * @param $id
-     * @return view
-     */
-    public function showUserEdit ($id) {
-        if (Auth::id() === (int)$id) {
-            $users = User::find($id);
-            return view('posts.edit_user', ['users' => $users]);
-        }else{
-            abort(404);
-        }
-    }
-
-    /**
-     * 更新したユーザー情報をDBへ保存。
-     * @param object $request
-     * @return view
-     */
-    public function updateUser (UserRequest $request) {
-        $inputs = $request->all();
-        DB::BeginTransaction();
-        try {
-            $user = User::find($inputs['id']);
-            $user->fill([
-                'name' => $inputs['name'],
-                'email' => $inputs['email'],
-                'password' => bcrypt($inputs['password']),
-            ]);
-            $user->save();
-            DB::commit();
-        } catch (\Throwable $e) {
-            DB::rollBack();
-            abort(500);
-        }
-        return redirect(route('top'));
     }
 }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -17,8 +17,8 @@ class UserController extends Controller
      */
     public function showEdit ($id) {
         if (Auth::id() === (int)$id) {
-            $users = User::find($id);
-            return view('posts.edit_user', ['users' => $users]);
+            $user = User::find($id);
+            return view('posts.edit_user', ['user' => $user]);
         }else{
             abort(404);
         }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\UserRequest;
+use Illuminate\Support\Facades\Auth;
+use App\user;
+use Illuminate\Support\Facades\DB;
+
+class UserController extends Controller
+{
+    /**
+     * ユーザー編集フォームを表示。
+     * @param string $id
+     * @return view
+     */
+    public function showEdit ($id) {
+        if (Auth::id() === (int)$id) {
+            $users = User::find($id);
+            return view('posts.edit_user', ['users' => $users]);
+        }else{
+            abort(404);
+        }
+    }
+
+    /**
+     * 更新したユーザー情報をDBへ保存。
+     * @param object $request
+     * @return view
+     */
+    public function updateUser (UserRequest $request) {
+        $inputs = $request->all();
+        if (Auth::id() === (int)$inputs['id']) {
+            DB::BeginTransaction();
+            try {
+                $user = User::find($inputs['id']);
+                $user->fill([
+                    'name' => $inputs['name'],
+                    'email' => $inputs['email'],
+                    'password' => bcrypt($inputs['password']),
+                ]);
+                $user->save();
+                DB::commit();
+            } catch (\Throwable $e) {
+                DB::rollBack();
+                abort(500);
+            }
+            return redirect(route('top'));
+        }else{
+            abort(404);
+        }
+    }
+}

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -25,8 +25,9 @@ class UserRequest extends FormRequest
     {
         return [
             'name' => 'required|max:255',
-            'email' => 'required|max:255',
+            'email' => 'required|max:255|email:filter,dns',
             'password' => 'required|confirmed|min:8|max:255',
         ];
     }
 }
+    

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|max:255',
+            'email' => 'required|max:255',
+            'password' => 'required|confirmed|min:8|max:255',
+        ];
+    }
+}

--- a/resources/views/posts/edit_user.blade.php
+++ b/resources/views/posts/edit_user.blade.php
@@ -4,17 +4,25 @@
 @if($errors->any())
     @include('layouts.err')
 @endif
-<form method="POST" action="{{ route('updateuser') }}">
+<form method="POST" action="{{ route('users.update') }}">
     @csrf
     <input type="hidden" name="id" value="{{ $users->id }}" />
     <div class="form-group">
         <label for="name">ユーザ名</label>
-        <input class="form-control" value="{{ $users->name }}" name="name" />
+        @if($errors->any())
+            <input class="form-control" value="{{ old('name') }}" name="name" />
+        @else
+            <input class="form-control" value="{{ $users->name }}" name="name" />
+        @endif 
     </div>
 
     <div class="form-group">
         <label for="email">メールアドレス</label>
-        <input class="form-control" value="{{ $users->email }}" name="email" />
+        @if($errors->any())
+            <input class="form-control" value="{{ old('email') }}" name="email" />
+        @else
+            <input class="form-control" value="{{ $users->email }}" name="email" />
+        @endif      
     </div>
 
     <div class="form-group">

--- a/resources/views/posts/edit_user.blade.php
+++ b/resources/views/posts/edit_user.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.layout')
+@section('content')
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+@if($errors->any())
+    @include('layouts.err')
+@endif
+<form method="POST" action="{{ route('updateuser') }}">
+    @csrf
+    <input type="hidden" name="id" value="{{ $users->id }}" />
+    <div class="form-group">
+        <label for="name">ユーザ名</label>
+        <input class="form-control" value="{{ $users->name }}" name="name" />
+    </div>
+
+    <div class="form-group">
+        <label for="email">メールアドレス</label>
+        <input class="form-control" value="{{ $users->email }}" name="email" />
+    </div>
+
+    <div class="form-group">
+        <label for="password">パスワード</label>
+        <input class="form-control" type="password" name="password" />
+    </div>
+
+    <div class="form-group">
+        <label for="password_confirmation">パスワードの確認</label>
+        <input class="form-control" type="password" name="password_confirmation" />
+    </div>
+
+    <div class="d-flex justify-content-between">
+        <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </div>
+</form>
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>確認</h4>
+            </div>
+            <div class="modal-body">
+                <label>本当に退会しますか？</label>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <form action="" method="POST">
+                    <button type="submit" class="btn btn-danger">退会する</button>
+                </form>
+                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/posts/edit_user.blade.php
+++ b/resources/views/posts/edit_user.blade.php
@@ -6,23 +6,15 @@
 @endif
 <form method="POST" action="{{ route('users.update') }}">
     @csrf
-    <input type="hidden" name="id" value="{{ $users->id }}" />
+    <input type="hidden" name="id" value="{{ $user->id }}" />
     <div class="form-group">
         <label for="name">ユーザ名</label>
-        @if($errors->any())
-            <input class="form-control" value="{{ old('name') }}" name="name" />
-        @else
-            <input class="form-control" value="{{ $users->name }}" name="name" />
-        @endif 
+        <input class="form-control" value="{{ $errors->any() ? old('name') : $user->name }}" name="name" />
     </div>
 
     <div class="form-group">
         <label for="email">メールアドレス</label>
-        @if($errors->any())
-            <input class="form-control" value="{{ old('email') }}" name="email" />
-        @else
-            <input class="form-control" value="{{ $users->email }}" name="email" />
-        @endif      
+        <input class="form-control" value="{{ $errors->any() ? old('email') : $user->email }}" name="email" />    
     </div>
 
     <div class="form-group">

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,8 @@ Route::get('/', 'PostController@showTop')->name('top');
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('loginform');
 Route::post('login', 'Auth\LoginController@login')->name('login');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
+Route::get('users/{id}/edit', 'PostController@showUserEdit')->name('editform');
+Route::post('update/user', 'PostController@updateUser')->name('updateuser');
 
 // Route::get('/', function () {
 //     return view('welcome');

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,8 +17,8 @@ Route::get('/', 'PostController@showTop')->name('top');
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('loginform');
 Route::post('login', 'Auth\LoginController@login')->name('login');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
-Route::get('users/{id}/edit', 'PostController@showUserEdit')->name('editform');
-Route::post('update/user', 'PostController@updateUser')->name('updateuser');
+Route::get('users/{id}/edit', 'UserController@showEdit')->name('users.edit');
+Route::post('update/user', 'UserController@updateUser')->name('users.update');
 
 // Route::get('/', function () {
 //     return view('welcome');


### PR DESCRIPTION
ユーザー情報編集画面作成。ユーザー情報更新のときのバリデーション作成。ユーザー情報を編集してDBへ保存する機能実装。

ユーザー情報を更新した後はユーザー情報詳細画面にリダイレクトさせる仕様になってますが、別のメンバーのタスクとなっており、実装前のため、現状は、トップ画面へ遷移させる仕様にしております。

以上、よろしくお願いいたします。