### PR TITLE
投稿新規作成を実装(DAIKI)

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Post;
+use App\Http\Requests\PostRequest;
+use Illuminate\Support\Facades\DB;
 
 class PostController extends Controller
 {
@@ -15,5 +17,18 @@ class PostController extends Controller
         $posts = Post::orderBy('created_at','desc')->paginate(10);
 
         return view('posts.top', ['posts' => $posts]);
+    }
+
+    public function exePost (PostRequest $request) {
+        $inputs = $request->all();
+        DB::BeginTransaction();
+        try {
+            Post::create($inputs);
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            abort(500);
+        }
+        return redirect (route('top'));
     }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|max:140',
+        ];
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -7,6 +7,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
+    protected $fillable = [
+        'content', 'user_id',
+    ];
+
     public function user(){
         return $this->belongsTo(User::class);
     }

--- a/resources/views/posts/top.blade.php
+++ b/resources/views/posts/top.blade.php
@@ -7,11 +7,17 @@
 </div>
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
 @if (Auth::check())
-<div class="w-75 m-auto">エラーメッセージが入る場所</div>
+<div class="w-75 m-auto">
+    @if($errors->any())
+        @include('layouts.err')
+    @endif
+</div>
 <div class="text-center mb-3">
-    <form method="" action="" class="d-inline-block w-75">
+    <form method="POST" action="{{ route('post') }}" class="d-inline-block w-75">
+        @csrf
         <div class="form-group">
-            <textarea class="form-control" name="" rows=""></textarea>
+            <input type="hidden" name="user_id" value="{{ Auth::id() }}">
+            <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
             <div class="text-left mt-3">
                 <button type="submit" class="btn btn-primary">投稿する</button>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', 'PostController@showTop')->name('top');
+Route::post('/', 'PostController@exePost')->name('post');
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('loginform');
 Route::post('login', 'Auth\LoginController@login')->name('login');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');


### PR DESCRIPTION
新規投稿機能のためのルーティングとPostController内に専用のメソッドを作成
PostRequestクラスを作って投稿用のバリデーションを実装。
Postモデルのcreateメソッドを使ってDBへ登録処理を行うので、Postモデル内$fillableで可変項目を設定。
新規投稿後は、トップ画面へリダイレクトするように実装。
新規投稿の際にバリーデーションに引っかかったら、直前に入力していたテキストを表示させるように実装。
user_idを投稿フォームから送れるように、inputタグのtype属性をhiddenにしてセッションの中のidを送信できるように実装。

模範解答通りのコーディングかは自信ありませんが、とりあえずお手本のアプリ通りに動くものに仕上げてます。
確認をお願いします。