### PR TITLE
ユーザー退会処理を実装(DAIKI)

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -62,4 +62,21 @@ class UserController extends Controller
         $user = User::find($id);
         return view('users.detail', ['user' => $user]);
     }
+
+    /**
+     * ユーザーを論理削除。
+     * @param string $id
+     * @return view
+     */
+    public function deleteUser ($id) {
+        if (Auth::id() === (int)$id) {
+            try {
+                User::find($id)->delete();
+                return redirect(route('top'));
+            } catch (\Throwable $th) {
+                abort(500);
+            }
+        }
+        abort(404);
+    }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -4,9 +4,12 @@ namespace App;
 use App\User;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
+    use SoftDeletes;
+
     protected $fillable = [
         'content', 'user_id',
     ];

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,13 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public static function boot()
+    {
+        parent::boot();
+        
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
 }

--- a/database/migrations/2023_07_22_023155_create_posts_table.php
+++ b/database/migrations/2023_07_22_023155_create_posts_table.php
@@ -18,9 +18,8 @@ class CreatePostsTable extends Migration
             $table->string('content',140);
             $table->unsignedBiginteger('user_id');
             $table->timestamps();
-            //$table->softDeletes();
+            $table->softDeletes();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-
         });
     }
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -42,7 +42,8 @@
                 <label>本当に退会しますか？</label>
             </div>
             <div class="modal-footer d-flex justify-content-between">
-                <form action="" method="POST">
+                <form action="{{ route('users.delete', $user->id) }}" method="POST">
+                    @csrf
                     <button type="submit" class="btn btn-danger">退会する</button>
                 </form>
                 <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,8 +21,8 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 Route::get('users/{id}', 'UserController@showDetail')->name('users.show');
 Route::get('users/{id}/edit', 'UserController@showEdit')->name('users.edit');
 Route::post('update/user', 'UserController@updateUser')->name('users.update');
+Route::post('users/delete/{id}', 'UserController@deleteUser')->name('users.delete');
 
 // Route::get('/', function () {
 //     return view('welcome');
 // });
-


### PR DESCRIPTION
ユーザー退会処理のためのルーティングとUserController内に専用のメソッドを作成。
post用のマイグレーションファイルにsoftDeletes()を追記。
PostモデルにuseでSoftDeletesトレイトを追記し、Post.phpファイルでSoftDeletesクラスが使えるようにuseで読み込み。
 ユーザー編集フォームのactionメソッドにroute関数で削除用のルーティング名とルートパラメーターを渡すように記述。 Userモデル内にbootメソッドを作成し、リレーションメソッドでユーザーが削除されたら、そのユーザーの投稿データも削除されるように実装。

ユーザーデータが論理削除された際に、そのユーザーの投稿データも一緒に削除される仕様も、ユーザーの削除同様に論理削除を用いて実装しましたが、よろしいでしょうか？？

レビューよろしくお願いいたします。

