### PR TITLE
投稿編集にて投稿済画像の削除

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -62,4 +62,15 @@ class PostsController extends Controller
         }
         return back()->with('messageSuccess', '投稿を削除しました');
     }
+
+    public function destroyImage($id)
+    {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() == $post->user_id) {
+            $post->image = null;
+            $post->save();
+        }
+        return back()->with('messageSuccess', '画像を削除しました');
+    }
+
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.app')
 @section('content')
+    @if (session('messageSuccess'))
+        <div class="flash_message alert alert-success text-center">
+            {{ session('messageSuccess') }}
+        </div>
+    @endif
     <h2 class="mt-5">投稿を編集する</h2>
     @include('commons.error_messages')
     <form method="POST" action="{{ route('post.update', $post->id) }}">

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -8,6 +8,11 @@
         <div class="form-group">
             <textarea id="content" class="form-control" name="text" rows="6">{{  old('text', $post->text) }}</textarea>
         </div>
+        <div>
+        @if (is_null($post->image))
+            <input type="file" name="image" class="">
+        @endif
+        </div>
         @if (isset($post->image))
             <p class="mb-2"><img src="{{ asset($post->image) }}" width="75%" height="75%"></p>
         @endif

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -8,6 +8,18 @@
         <div class="form-group">
             <textarea id="content" class="form-control" name="text" rows="6">{{  old('text', $post->text) }}</textarea>
         </div>
-        <button type="submit" class="btn btn-primary">更新する</button>
+        @if (isset($post->image))
+            <p class="mb-2"><img src="{{ asset($post->image) }}" width="75%" height="75%"></p>
+        @endif
+        <div class="d-flex justify-content-between w-75 pb-3">
+            <button type="submit" class="btn btn-primary mt-3">更新する</button>
+    </form>
+    <form method="POST" action="{{ route('post.image_delete', $post->id) }}">
+        @csrf
+        @method('DELETE')
+        @if (isset($post->image))
+            <button type="submit" class="btn btn-success mt-3">投稿済みの画像を削除する</button>
+        @endif
+        </div>
     </form>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::put('{id}', 'PostsController@update')->name('post.update');
         // 投稿の削除
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
+        // 投稿画像の削除
+        Route::delete('{id}/delete', 'PostsController@destroyImage')->name('post.image_delete');
     });
 
     Route::group(['prefix' => 'user/{id}'],function(){


### PR DESCRIPTION
# 動作確認
- 確認できました。

# 今後の方針について
- updateメソッドに画像削除などの条件分岐を含めると複雑になると考えたため、
画像データがないユーザのみが投稿編集で画像を追加できるようにします。