### PR TITLE
投稿削除フラッシュメッセージ表示(seiichi)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -47,6 +47,6 @@ class PostsController extends Controller
         if (\Auth::id() === $post->user_id) {
             $post->delete();
         }
-        return back();
+        return redirect('/')->with('postsDestroyMessage', '投稿削除に成功しました。');
     }
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -9,13 +9,13 @@
             @include('commons.error_messages')
                 <textarea id="text" class="form-control" name="text" rows="6">{{ old('text', $post->text) }}</textarea>
             </div>
-            <div class="w-75 m-auto">
             @if (session('postsDestroyMessage'))
-            <div class="alert alert-success text-center">
-                {{ session('postsDestroyMessage') }}
-            </div> 
+                <div class="w-75 m-auto">
+                    <div class="alert alert-success text-center">
+                        {{ session('postsDestroyMessage') }}
+                    </div>
+                </div>
             @endif
-    </div>        
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -8,7 +8,14 @@
             <div class="form-group">
             @include('commons.error_messages')
                 <textarea id="text" class="form-control" name="text" rows="6">{{ old('text', $post->text) }}</textarea>
-            </div>        
+            </div>
+            <div class="w-75 m-auto">
+            @if (session('postsDestroyMessage'))
+            <div class="alert alert-success text-center">
+                {{ session('postsDestroyMessage') }}
+            </div> 
+            @endif
+    </div>        
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -14,8 +14,12 @@
                 <div class="w-75 m-auto">
                     @if (session('successMessage'))
                     <div class="alert alert-success text-center">
-                            {{ session('successMessage') }}
+                        {{ session('successMessage') }}
                     </div> 
+                    @elseif(session('postsDestroyMessage'))
+                        <div class="alert alert-success text-center">
+                            {{ session('postsDestroyMessage') }}
+                        </div> 
                     @endif
                     <div class="form-group">
                         <textarea class="form-control" name="text"  rows="4"  value="{{ old('text') }}"></textarea>


### PR DESCRIPTION
## issues
- Close 投稿削除フラッシュメッセージ

## 概要
- 投稿削除時のフラッシュメッセージ表示機能追加

## 動作確認手順
- トップページからログインした状態で、ログインユーザーの投稿を削除した時に
投稿が削除されると共に「投稿削除に成功しました」というフラッシュメッセージが
表示される事を確認
