### PR TITLE
1枚だけなら画像投稿できるように実装(DAIKI)

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -30,8 +30,17 @@ class PostController extends Controller
         $inputs = $request->all();
         DB::BeginTransaction();
         try {
-            Post::create($inputs);
+            $post = Post::create([
+                'content' => $inputs['content'],
+                'user_id' => $inputs['user_id'],      
+            ]);
             DB::commit();
+            if ($request->post_img) {
+                if ($request->post_img->extension() === 'gif' || $request->post_img->extension() === 'jpeg' || $request->post_img->extension() === 'jpg' || $request->post_img->extension() === 'png') {
+                    $post->post_img = $request->file('post_img')->storeAs('public/post_img',$post->id . '.' . $request->post_img->extension());
+                }
+            }
+            $post->save();
         } catch (\Throwable $e) {
             DB::rollBack();
             abort(500);

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -4,9 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Post;
 use App\Http\Requests\PostRequest;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\File\UploadedFile as FileUploadedFile;
 
 class PostController extends Controller
 {
@@ -37,7 +40,8 @@ class PostController extends Controller
             DB::commit();
             if ($request->post_img) {
                 if ($request->post_img->extension() === 'gif' || $request->post_img->extension() === 'jpeg' || $request->post_img->extension() === 'jpg' || $request->post_img->extension() === 'png') {
-                    $post->post_img = $request->file('post_img')->storeAs('public/post_img',$post->id . '.' . $request->post_img->extension());
+                    $post->post_img = $request->file('post_img')->storeAs('public/post_img', $post->id . '.' . $request->post_img->extension());
+                    $post->img_name = $post->id . '.' . $request->post_img->extension();
                 }
             }
             $post->save();
@@ -62,11 +66,15 @@ class PostController extends Controller
                 foreach ($users as $user) {
                     $post->users()->detach($user->id);
                 }
+                
+                if ($post->post_img) {
+                    Storage::disk('public')->delete('post_img/' . $post->img_name);
+                }
                 $post->delete();
                 Session::flash('msg_danger', '投稿を削除しました！');
                 return back();
             } catch (\Throwable $th) {
-                abort(500);
+                // abort(500);
             }
         }
         abort(404);
@@ -96,7 +104,13 @@ class PostController extends Controller
         if (Auth::id() === $post->user_id) {
             DB::BeginTransaction();
             try {
-                $post->content = $request->content;
+                $post->content = $request->content; 
+                if ($request->post_img) {
+                    if ($request->post_img->extension() === 'gif' || $request->post_img->extension() === 'jpeg' || $request->post_img->extension() === 'jpg' || $request->post_img->extension() === 'png') {
+                        $post->post_img = $request->file('post_img')->storeAs('public/post_img', $post->id . '.' . $request->post_img->extension());
+                        $post->img_name = $post->id . '.' . $request->post_img->extension();
+                    }
+                }
                 $post->save();
                 DB::commit();
             } catch (\Throwable $e) {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -9,6 +9,7 @@ use App\User;
 use App\Post;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Storage;
 
 class UserController extends Controller
 {
@@ -76,6 +77,9 @@ class UserController extends Controller
             try {
                 $posts = $user->posts()->get();
                 foreach ($posts as $post) {
+                    if ($post->post_img) {
+                        Storage::disk('public')->delete('post_img/' . $post->img_name);
+                    }
                     foreach ($post->users()->get() as $liker) {
                         $post->users()->detach($liker->id);
                     }

--- a/app/Post.php
+++ b/app/Post.php
@@ -11,7 +11,7 @@ class Post extends Model
     use SoftDeletes;
 
     protected $fillable = [
-        'content', 'user_id',
+        'content', 'user_id', 'post_img',
     ];
 
     public function user(){

--- a/database/migrations/2023_07_22_023155_create_posts_table.php
+++ b/database/migrations/2023_07_22_023155_create_posts_table.php
@@ -18,6 +18,7 @@ class CreatePostsTable extends Migration
             $table->string('content',140);
             $table->unsignedBiginteger('user_id');
             $table->string('post_img')->nullable(true);
+            $table->string('img_name')->nullable(true);
             $table->timestamps();
             $table->softDeletes();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');

--- a/database/migrations/2023_07_22_023155_create_posts_table.php
+++ b/database/migrations/2023_07_22_023155_create_posts_table.php
@@ -17,6 +17,7 @@ class CreatePostsTable extends Migration
             $table->bigIncrements('id');
             $table->string('content',140);
             $table->unsignedBiginteger('user_id');
+            $table->string('post_img')->nullable(true);
             $table->timestamps();
             $table->softDeletes();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');

--- a/resources/views/layouts/image.blade.php
+++ b/resources/views/layouts/image.blade.php
@@ -1,0 +1,9 @@
+<div class="text-left">
+    <label>
+        <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-file-earmark-image" viewBox="0 0 16 16">
+            <path d="M6.502 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/>
+            <path d="M14 14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5V14zM4 1a1 1 0 0 0-1 1v10l2.224-2.224a.5.5 0 0 1 .61-.075L8 11l2.157-3.02a.5.5 0 0 1 .76-.063L13 10V4.5h-2A1.5 1.5 0 0 1 9.5 3V1H4z"/>
+        </svg>
+        <input type="file" name="post_img" class="d-none">
+    </label>
+</div>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -4,11 +4,12 @@
 @if($errors->any())
     @include('layouts.err')
 @endif
-<form method="POST" action="{{ route('posts.update', $post->id) }}">
+<form method="POST" action="{{ route('posts.update', $post->id) }}" enctype="multipart/form-data">
     @method('PUT')
     @csrf
     <div class="form-group">
         <textarea id="content" class="form-control" name="content" rows="4">{{ $errors->any() ? old('content') : $post->content }}</textarea>
+        @include('layouts.image')
     </div>
     <button type="submit" class="btn btn-success">更新する</button>
 </form>

--- a/resources/views/posts/top.blade.php
+++ b/resources/views/posts/top.blade.php
@@ -14,11 +14,20 @@
     @endif
 </div>
 <div class="text-center mb-3">
-    <form method="POST" action="{{ route('post') }}" class="d-inline-block w-75">
+    <form method="POST" action="{{ route('post') }}" class="d-inline-block w-75" enctype="multipart/form-data">
         @csrf
         <div class="form-group">
             <input type="hidden" name="user_id" value="{{ Auth::id() }}">
             <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
+            <div class="text-left">
+                <label>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-file-earmark-image" viewBox="0 0 16 16">
+                        <path d="M6.502 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/>
+                        <path d="M14 14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5V14zM4 1a1 1 0 0 0-1 1v10l2.224-2.224a.5.5 0 0 1 .61-.075L8 11l2.157-3.02a.5.5 0 0 1 .76-.063L13 10V4.5h-2A1.5 1.5 0 0 1 9.5 3V1H4z"/>
+                    </svg>
+                    <input type="file" name="post_img" class="d-none">
+                </label>
+                </div>
             <div class="text-left mt-3">
                 <button type="submit" class="btn btn-success">投稿する</button>
             </div>
@@ -37,6 +46,15 @@
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{ $post->content }}</p>
                     <p class="text-muted">{{ $post->created_at }}</p>
+                    @if(file_exists(public_path().'/storage/post_img/'. $post->id .'.jpg'))
+                        <img src="/storage/post_img/{{ $post->id }}.jpg" width="500px">
+                    @elseif(file_exists(public_path().'/storage/post_img/'. $post->id .'.jpeg'))
+                        <img src="/storage/post_img/{{ $post->id }}.jpeg" width="500px">
+                    @elseif(file_exists(public_path().'/storage/post_img/'. $post->id .'.png'))
+                        <img src="/storage/post_img/{{ $post->id }}.png" width="500px">
+                    @elseif(file_exists(public_path().'/storage/post_img/'. $post->id .'.gif'))
+                        <img src="/storage/post_img/{{ $post->id }}.gif" width="500px">
+                    @endif
                     @include('layouts.like')
                 </div>
                 @if (Auth::id() === $post->user_id)

--- a/resources/views/posts/top.blade.php
+++ b/resources/views/posts/top.blade.php
@@ -19,15 +19,7 @@
         <div class="form-group">
             <input type="hidden" name="user_id" value="{{ Auth::id() }}">
             <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
-            <div class="text-left">
-                <label>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-file-earmark-image" viewBox="0 0 16 16">
-                        <path d="M6.502 7a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"/>
-                        <path d="M14 14a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2a2 2 0 0 1 2-2h5.5L14 4.5V14zM4 1a1 1 0 0 0-1 1v10l2.224-2.224a.5.5 0 0 1 .61-.075L8 11l2.157-3.02a.5.5 0 0 1 .76-.063L13 10V4.5h-2A1.5 1.5 0 0 1 9.5 3V1H4z"/>
-                    </svg>
-                    <input type="file" name="post_img" class="d-none">
-                </label>
-                </div>
+            @include('layouts.image')
             <div class="text-left mt-3">
                 <button type="submit" class="btn btn-success">投稿する</button>
             </div>


### PR DESCRIPTION
    画像を一枚だけ選択してアップロードする機能を実装。複数ファイルは無理。
    画像を1枚だけなら再度選択して編集・更新も可能にした。
    画像選択するHTML部分を部品化した。
    投稿を削除するとフォルダに保存されていた画像も一緒に削除されるように実装。
    ユーザーが退会したら、そのユーザーがアップロードしていた画像も一緒に削除されるように実装
    画像の名前も一緒にテーブルに保存できるようにマイグレーションファイルを修正して専用のカラムを追加。