### PR TITLE
#702 users（ユーザ）テーブルのマイグレーションとシーダー作成（まきの）

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -5,10 +5,12 @@ namespace App;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable
 {
     use Notifiable;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,6 +21,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        for ( $i=1; $i <= 8; $i++ ) {
+            DB::table('users')->insert([
+                'name' => 'testuser'.$i,
+                'email' => 'testuser'.$i.'@test.com',
+                'password' => bcrypt('testuser'.$i)
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## issue
-Closes #702

## 概要
- users（ユーザ）テーブルのマイグレーションとシーダー作成

## 動作確認手順
- 下記コマンドを実行。usersテーブルに属性が追加されたことをAdminerで確認。
`$ php artisan migrate`
- 下記コマンドを実行。usersテーブルに8個のデータが保存されたことをAdminerで確認。
`$ php artisan db:seed --class=UsersTableSeeder`

## 考慮して欲しいこと
- 以下のコマンドを実行していただく必要あります。
`php artisan migrate:fresh --seed`

## 確認してほしいこと
特にありません
