### PR TITLE
#670 users（ユーザ）テーブルのマイグレーションとシーダー作成（山田直輝）

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -5,10 +5,12 @@ namespace App;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable
 {
     use Notifiable;
+    use SoftDeletes; 
 
     /**
      * The attributes that are mass assignable.

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('users')->insert([
+            'name' => 'test1',
+            'email' => 'test1@test.com',
+            'password' => bcrypt('test1')
+        ]);
+        DB::table('users')->insert([
+            'name' => 'test2',
+            'email' => 'test2@test.com',
+            'password' => bcrypt('test2')
+        ]);
+        DB::table('users')->insert([
+            'name' => 'test3',
+            'email' => 'test3@sample.com',
+            'password' => bcrypt('test3')
+        ]);
+        DB::table('users')->insert([
+            'name' => 'test4',
+            'email' => 'test4@test.com',
+            'password' => bcrypt('test4')
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
 - Closes #670 
 
## 概要
- users（ユーザ）テーブルのマイグレーションとシーダー作成

## 動作確認手順
- 下記コマンドを実行
php artisan migrate --seed
- Adminerでusersテーブルに５個のレコードが保存されていることを確認

## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認する必要あり。
php artisan migrate:fresh --seed

## 確認してほしいこと
- 動作確認手順の箇所の下記コマンドを実行が、
php artisan migrate --seedで合っていますでしょうか？