### PR TITLE
Feature/makino/user edit update

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -11,19 +11,25 @@ class UsersController extends Controller
     // ユーザ編集画面表示
     public function edit($id)
     {
-        $user = User::find($id);
-        return view('users.edit', ['user' => $user]);
-
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id) {
+            return view('users.edit', ['user' => $user]);
+        } else {
+            return back();
+        }
     }
 
     // ユーザ情報更新
-    public function update(UserRequest $request)
+    public function update(UserRequest $request, $id)
     {
-        $user = User::find($request->id);
-        $user->name = $request->name;
-        $user->email = $request->email;
-        $user->password = bcrypt('$request->password');
-        $user->save();
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id) {
+            $user->name = $request->name;
+            $user->email = $request->email;
+            $user->password = bcrypt($request->password);
+            $user->save();
+        }
+
         // 見本ではユーザ詳細画面に飛ばすが、まだないのでTop画面にリダイレクトする。
         return redirect('/');
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\UserRequest;
+use App\User;
+
+class UsersController extends Controller
+{
+    // ユーザ編集画面表示
+    public function edit($id)
+    {
+        $user = User::find($id);
+        return view('users.edit', ['user' => $user]);
+
+    }
+
+    // ユーザ情報更新
+    public function update(UserRequest $request)
+    {
+        $user = User::find($request->id);
+        $user->name = $request->name;
+        $user->email = $request->email;
+        $user->password = bcrypt('$request->password');
+        $user->save();
+        // 見本ではユーザ詳細画面に飛ばすが、まだないのでTop画面にリダイレクトする。
+        return redirect('/');
+    }
+}

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
 
 class UserRequest extends FormRequest
 {
@@ -25,7 +26,7 @@ class UserRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email,'.Auth::user()->email.',email'],
             'password' => ['required', 'string', 'min:8', 'confirmed']
         ];
     }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255'],
+            'password' => ['required', 'string', 'min:8', 'confirmed']
+        ];
+    }
+}

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,7 +8,7 @@
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
                 @if(Auth::check())
-                    <li class="nav-item"><a href="" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
+                    <li class="nav-item"><a href="{{ route('users.edit', Auth::user()->id) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                     <li class="nav-item"><a href="" class="nav-link text-light">ログアウト</a></li>
                 @else
                     <li class="nav-item"><a href="" class="nav-link text-light">ログイン</a></li>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,7 +8,7 @@
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
                 @if(Auth::check())
-                    <li class="nav-item"><a href="{{ route('users.edit', Auth::user()->id) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
+                    <li class="nav-item"><a href="" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                     <li class="nav-item"><a href="" class="nav-link text-light">ログアウト</a></li>
                 @else
                     <li class="nav-item"><a href="" class="nav-link text-light">ログイン</a></li>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.app')
+@section('content')
+    <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+    @include('commons.error_messages')
+    <form method="POST" action="{{ route('users.update') }}">
+        @csrf
+        @method('PUT')
+        <input type="hidden" name="id" value="{{ $user->id }}" />
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name') }}" name="name" />
+        </div>
+
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{ old('email') }}" name="email" />
+        </div>
+
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password_confirmation" />
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+    </form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="" method="POST">
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
     @include('commons.error_messages')
-    <form method="POST" action="{{ route('users.update') }}">
+    <form method="POST" action="http://localhost:8081/users/{{ $user->id }}">
         @csrf
         @method('PUT')
         <input type="hidden" name="id" value="{{ $user->id }}" />

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,5 +18,9 @@ Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('sign
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 // ユーザ編集
-Route::get('users/{id}/edit', 'UsersController@edit')->name('users.edit');
-Route::put('users/', 'UsersController@update')->name('users.update');
+Route::group(['middleware' => 'auth'], function () {
+    Route::prefix('users/{id}')->group(function () {
+        Route::get('', 'UsersController@edit')->name('users.edit');
+        Route::put('', 'UsersController@update')->name('users.update');
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,3 +17,6 @@ Route::get('/', 'PostsController@index');
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
+// ユーザ編集
+Route::get('users/{id}/edit', 'UsersController@edit')->name('users.edit');
+Route::put('users/', 'UsersController@update')->name('users.update');


### PR DESCRIPTION
### 概要
「ユーザ編集画面」機能を作成しました。

### 制約事項
見本では「ユーザ編集画面」で更新すると「ユーザ詳細画面」に遷移しますが、
まだないのでTop画面にリダイレクトするようになっています。

### 動作確認手順
- Top画面から新規ユーザ登録
- `http://localhost:8081/users/10/edit`をブラウザからたたく
　⇨ 「ユーザ情報を編集する」画面を表示
- ユーザー情報を変更し[更新する]を押下
　⇨ Admireで変更を確認
- 再度「ユーザ情報を編集する」を表示して、短いパスワードを入力
　⇨ 所定の場所にエラーが表示され、ユーザ名・メールアドレスにold()が入ることを確認

### 考慮して欲しいこと
まだログイン機能が未実装なので、確認する時は、
新規ユーザ登録をしてから`http://localhost:8081/users/{$user_id}/edit`を叩いて画面を出してください。

### 確認してほしいこと
特にありません