### PR TITLE
#676_投稿削除(dera)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -44,4 +44,13 @@ class PostsController extends Controller
         $post->save();
         return redirect('/');
     }
+
+    public function destroy($id)
+    {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
+            $post->delete();
+        }
+        return back();
+    }
 }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -12,9 +12,20 @@
                 </div>
                 @if(Auth::check() && Auth::id() == $post->user_id)
                 <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                    <form method="" action="">
-                      <button type="submit" class="btn btn-danger">削除</button>
+                    <form method="POST" action="{{ route('post.delete', $post->id) }}" id="delete-form">
+                        @csrf
+                        @method('DELETE')
+                      <button type="button" class="btn btn-danger" onclick="confirmDelete()">削除</button>
                     </form>
+                    <script>
+                        function confirmDelete() {
+                            if (confirm('本当に削除しますか？')) {
+                                document.getElementById('delete-form').submit();
+                            } else {
+                                return back();
+                            }
+                        }
+                    </script>
                     <a href="{{ route('post.edit',$post->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('', 'PostsController@store')->name('post.store');
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
+        Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
     // ユーザー編集・更新、フォロー・アンフォロー
     Route::prefix('users/{id}')->group(function(){


### PR DESCRIPTION
## issue
Closes #676 

## 動作確認手順
[http://localhost:8080](http://localhost:8080)にてログイン、１つ以上投稿した状態にて投稿表示の「削除」ボタンを押下することで、自身の投稿を削除できることを確認

## 考慮して欲しいこと
[お手本サイト](https://laravel-fly2.fly.dev/)では、「削除」ボタン押下後、そのまま投稿削除が実行されるようでしたが、
【本当に削除しますか？】という確認ダイアログを表示するようにしておりました。
また、全体修正以降の追加作業として、『投稿削除確認画面』を考えておりました。

## 確認して欲しいこと（質問）
- Authの記述方法
`use Illuminate\Support\Facades\Auth;`と記述した上で、`Auth::id()`と使用するのと、
`use Illuminate\Support\Facades\Auth;`を記述せずに、`\Auth::id()`を使用するのは
どちらが一般的でしょうか。その各人の好み？というところでしょうか。