### PR TITLE
#752_検索機能(dera)

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -8,18 +8,12 @@ use App\User;
 
 class SearchController extends Controller
 {
-    // 投稿検索クエリ取得
+    // 投稿検索
     public function postsSearch(Request $request)
     {
         // 入力フォームから送信された検索クエリを取得
         $searchQuery = $request->input('searchQuery');
 
-        return redirect()->route('search.results', ['searchQuery' => $searchQuery]);
-    }
-
-    // 投稿検索実行・検索結果表示
-    public function postsSearchResults($searchQuery)
-    {
         // 検索クエリから投稿内容を検索
         $searchResults = Post::where('content', 'like', '%' . $searchQuery . '%')
                             ->orderBy('updated_at', 'desc')

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Post;
+use App\User;
+
+class SearchController extends Controller
+{
+    // 投稿検索クエリ取得
+    public function postsSearch(Request $request)
+    {
+        // 入力フォームから送信された検索クエリを取得
+        $searchQuery = $request->input('searchQuery');
+
+        return redirect()->route('search.results', ['searchQuery' => $searchQuery]);
+    }
+
+    // 投稿検索実行・検索結果表示
+    public function postsSearchResults($searchQuery)
+    {
+        // 検索クエリから投稿内容を検索
+        $searchResults = Post::where('content', 'like', '%' . $searchQuery . '%')
+                            ->orderBy('updated_at', 'desc')
+                            ->paginate(10);
+
+        return view('search.postsSearch', ['searchQuery' => $searchQuery, 'searchResults' => $searchResults]);
+    }
+}

--- a/database/migrations/2023_09_17_023045_create_posts_table.php
+++ b/database/migrations/2023_09_17_023045_create_posts_table.php
@@ -16,7 +16,7 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
-            $table->string('content', 140)->index();    // 140文字制限
+            $table->string('content', 140)->collation('utf8mb4_bin')->index();    // 140文字制限
             $table->timestamps();
             $table->softDeletes();
 

--- a/database/migrations/2023_09_17_023045_create_posts_table.php
+++ b/database/migrations/2023_09_17_023045_create_posts_table.php
@@ -16,7 +16,7 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
-            $table->string('content', 140);// 140文字制限
+            $table->string('content', 140)->index();    // 140文字制限
             $table->timestamps();
             $table->softDeletes();
 

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -7,10 +7,10 @@
         <div class="collapse navbar-collapse" id="nav-bar">
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
-                @if (Auth::check())
                     <form action="{{ route('posts.search') }}" method="get">
                         <input class="form-control" type="search" name="searchQuery" placeholder="検索...">
                     </form>
+                @if (Auth::check())
                     <li class="nav-item"><a href="{{ route('users.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                     <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
                 @else

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,6 +8,9 @@
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
                 @if (Auth::check())
+                    <form action="{{ route('posts.search') }}" method="get">
+                        <input class="form-control" type="search" name="searchQuery" placeholder="検索...">
+                    </form>
                     <li class="nav-item"><a href="{{ route('users.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                     <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
                 @else

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -7,7 +7,20 @@
              </div>
              <div class=""> 
                  <div class="text-left d-inline-block w-75">
-                    <p class="mb-2">{{ $post->content }}</p>
+                    @if(isset($searchResults))
+                        <!-- <p class="mb-2">{!! preg_replace(
+                            '/(' . preg_quote($searchQuery, '/') . ')/i', 
+                            '<span style="background-color: yellow;">$1</span>', 
+                            $post->content
+                        ) !!}</p> -->
+                        <p class="mb-2">{!! preg_replace(
+                            '/[' . preg_quote($searchQuery, '/') . ']/iu', 
+                            '<span style="background-color: yellow;">$0</span>', 
+                            $post->content
+                        ) !!}</p>
+                    @else
+                        <p class="mb-2">{{ $post->content }}</p>
+                    @endif
                     <p class="text-muted">{{ $post->created_at }}</p>
                 </div>
                 @if(Auth::check() && Auth::id() == $post->user_id)
@@ -33,5 +46,10 @@
         </li>
     </ul>
 @endforeach 
-      <div class="m-auto" style="width: fit-content">{{ $posts->links('pagination::bootstrap-4') }}</div>
+@if(isset($searchResults))
+    <div class="m-auto" style="width: fit-content">{{ $searchResults->appends(request()->query())->links('pagination::bootstrap-4') }}</div>
+@else
+    <div class="m-auto" style="width: fit-content">{{ $posts->links('pagination::bootstrap-4') }}</div>
+
+@endif
 </div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -8,11 +8,6 @@
              <div class=""> 
                  <div class="text-left d-inline-block w-75">
                     @if(isset($searchResults))
-                        <!-- <p class="mb-2">{!! preg_replace(
-                            '/(' . preg_quote($searchQuery, '/') . ')/i', 
-                            '<span style="background-color: yellow;">$1</span>', 
-                            $post->content
-                        ) !!}</p> -->
                         <p class="mb-2">{!! preg_replace(
                             '/[' . preg_quote($searchQuery, '/') . ']/iu', 
                             '<span style="background-color: yellow;">$0</span>', 

--- a/resources/views/search/postsSearch.blade.php
+++ b/resources/views/search/postsSearch.blade.php
@@ -1,0 +1,50 @@
+@extends('layouts.app')
+@section('content')
+    <div class="container">
+        <h1>検索結果【検索ワード： {{ $searchQuery }}】</h1>
+        @if($searchResults->count() > 0)
+            @foreach ($searchResults as $post)
+                <ul class="list-unstyled">
+                    <li class="mb-3 text-center">
+                        <div class="text-left d-inline-block w-75 mb-2">
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                                <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
+                        </div>
+                        <div class=""> 
+                            <div class="text-left d-inline-block w-75">
+                                <p class="mb-2">{!! preg_replace(
+                                    '/(' . preg_quote($searchQuery, '/') . ')/i', 
+                                    '<span style="background-color: yellow;">$1</span>', 
+                                    $post->content
+                                ) !!}</p>
+                                <p class="text-muted">{{ $post->created_at }}</p>
+                            </div>
+                            @if(Auth::check() && Auth::id() == $post->user_id)
+                                <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                                    <form method="POST" action="{{ route('post.delete', $post->id) }}" id="delete-form">
+                                        @csrf
+                                        @method('DELETE')
+                                    <button type="button" class="btn btn-danger" onclick="confirmDelete()">削除</button>
+                                    </form>
+                                        <script>
+                                            function confirmDelete() {
+                                                if (confirm('本当に削除しますか？')) {
+                                                    document.getElementById('delete-form').submit();
+                                                } else {
+                                                    return back();
+                                                }
+                                            }
+                                        </script>
+                                    <a href="{{ route('post.edit',$post->id) }}" class="btn btn-primary">編集する</a>
+                                </div>
+                            @endif
+                        </div>
+                    </li>
+                </ul>
+            @endforeach
+            <div class="m-auto" style="width: fit-content">{{ $searchResults->links('pagination::bootstrap-4') }}</div>
+        @else
+            <p>検索条件に一致する投稿は見つかりませんでした。</p>
+        @endif
+    </div>
+@endsection

--- a/resources/views/search/postsSearch.blade.php
+++ b/resources/views/search/postsSearch.blade.php
@@ -3,46 +3,7 @@
     <div class="container">
         <h1>検索結果【検索ワード： {{ $searchQuery }}】</h1>
         @if($searchResults->count() > 0)
-            @foreach ($searchResults as $post)
-                <ul class="list-unstyled">
-                    <li class="mb-3 text-center">
-                        <div class="text-left d-inline-block w-75 mb-2">
-                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                                <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
-                        </div>
-                        <div class=""> 
-                            <div class="text-left d-inline-block w-75">
-                                <p class="mb-2">{!! preg_replace(
-                                    '/(' . preg_quote($searchQuery, '/') . ')/i', 
-                                    '<span style="background-color: yellow;">$1</span>', 
-                                    $post->content
-                                ) !!}</p>
-                                <p class="text-muted">{{ $post->created_at }}</p>
-                            </div>
-                            @if(Auth::check() && Auth::id() == $post->user_id)
-                                <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                                    <form method="POST" action="{{ route('post.delete', $post->id) }}" id="delete-form">
-                                        @csrf
-                                        @method('DELETE')
-                                    <button type="button" class="btn btn-danger" onclick="confirmDelete()">削除</button>
-                                    </form>
-                                        <script>
-                                            function confirmDelete() {
-                                                if (confirm('本当に削除しますか？')) {
-                                                    document.getElementById('delete-form').submit();
-                                                } else {
-                                                    return back();
-                                                }
-                                            }
-                                        </script>
-                                    <a href="{{ route('post.edit',$post->id) }}" class="btn btn-primary">編集する</a>
-                                </div>
-                            @endif
-                        </div>
-                    </li>
-                </ul>
-            @endforeach
-            <div class="m-auto" style="width: fit-content">{{ $searchResults->links('pagination::bootstrap-4') }}</div>
+            @include('posts.posts', ['posts' => $searchResults, 'searchQuery' => $searchQuery])
         @else
             <p>検索条件に一致する投稿は見つかりませんでした。</p>
         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,4 +42,10 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('follow', 'FollowController@store')->name('follow');
         Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
     });
+    // 検索
+    Route::prefix('search')->group(function () {
+        // 投稿検索
+        Route::get('', 'SearchController@postsSearch')->name('posts.search');
+        Route::get('{searchQuery}', 'SearchController@postsSearchResults')->name('search.results');
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,5 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('search')->group(function () {
         // 投稿検索
         Route::get('', 'SearchController@postsSearch')->name('posts.search');
-        Route::get('{searchQuery}', 'SearchController@postsSearchResults')->name('search.results');
     });
 });


### PR DESCRIPTION
## issue
- Closes #752 

## 動作確認手順
- 投稿検索機能
1. [http://localhost:8080](http://localhost:8080)にアクセスし、ヘッダーに検索フォームが表示されること
2. 検索フォームに任意のワードを入力し、検索を実行すると、検索結果に画面遷移すること
　・検索ワードに合致する投稿内容がある場合は、その投稿を一覧表示（10件毎に１頁） 
　・検索ワードに合致する投稿内容がない場合、「検索条件に一致する投稿は見つかりませんでした。」へ画面遷移

## 考慮して欲しいこと
今後、X（旧. Twitter）の「高度な検索」を模倣した機能も追加できればと、考えておりましたので、
`PsotsController.php`内のメソッドではなく、`SearchController.php`を新規に作っておりました。


## 確認して欲しいこと（質問）
長々と申し訳ありませんが、３点ほどご教授いただけますでしょうか。

1. ページネーションでの検索クエリデータの引継ぎ
検索の実行 と 検索結果画面への遷移 とを一つのメソッドにて記述しておりましたが、（※下記①コード）
このコードにて動作確認すると、ページネーションされた次頁以降に、検索クエリデータが引き継がれず、
・検索結果画面が文字化けでの表示
・１頁目に戻ると、検索ワードに関係なく全投稿が表示される
といった状態になってしまったため、
２つのメソッドに分離した形にすることでエラー解消されました。（※下記②コード）
**こちらは一つのメソッドで完結させることはできないのでしょうか。**

①
```
    public function postsSearch(Request $request)
    {
        // 入力フォームから送信された検索クエリを取得
        $searchQuery = $request->input('searchQuery');

        // 検索クエリから投稿内容を検索
        $searchResults = Post::where('content', 'like', '%' . $searchQuery . '%')
                            ->orderBy('updated_at', 'desc')
                            ->paginate(10);

        return view('search.postsSearch', ['searchQuery' => $searchQuery, 'searchResults' => $searchResults]);
    }
```
②
```
    // 検索クエリ取得
    public function postsSearch(Request $request)
    {
        // 入力フォームから送信された検索クエリを取得
        $searchQuery = $request->input('searchQuery');

        return redirect()->route('search.results', ['searchQuery' => $searchQuery]);
    }

    // 投稿検索実行・検索結果表示
    public function postsSearchResults($searchQuery)
    {
        // 検索クエリから投稿内容を検索
        $searchResults = Post::where('content', 'like', '%' . $searchQuery . '%')
                            ->orderBy('updated_at', 'desc')
                            ->paginate(10);

        return view('search.postsSearch', ['searchQuery' => $searchQuery, 'searchResults' => $searchResults]);
    }
```


2. 検索結果画面での`posts.posts.blade.php`の活用方法
検索結果画面にて投稿一覧表示のview（`posts.posts.blade.php`）へ検索結果データを引き渡すことで流用、
　　`@include('posts.posts', ['posts' => $searchResults])`
と当初は考えていたのですが、
検索ワードの強調表示を追記、
```
<p class="mb-2">{!! preg_replace(
   '/(' . preg_quote($searchQuery, '/') . ')/i', 
   '<span style="background-color: yellow;">$1</span>', 
   $post->content
) !!}</p>
```
としたため、ほとんどが`posts.posts.blade.php`と同じ内容となってしまいました。
**強調表示を追記した上で、`@include('posts.posts', ['posts' => $searchResults])`のように、流用する方法はありませんでしょうか。**


3. 検索ワードの強調表示での全角半角・ひらがなカタカナの認識
現状、検索機能としては、全角半角・ひらがなカタカナは判別できていないのですが、
検索ワードの強調表示では、全角半角・ひらがなカタカナが判別されてしまっております。
**（’てすと’と検索すると、”テスト”を合致したワードとして検索結果は表示されるが、黄色の強調表示はされない。）**
いろいろと調べるとかなり面倒なようで、
今後のX（旧. Twitter）の「高度な検索」を模倣した機能追加時に対応かとも考えたのですが、
単純にコードを修正するだけの対応方法はありますでしょうか。