### PR TITLE
#710 ユーザ編集画面・更新(むらい)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -5,6 +5,9 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\User;
 use App\Post;
+use App\Http\Requests\UserRequest;
+use Illuminate\Support\Facades\Auth;
+
 
 class UsersController extends Controller
 {
@@ -18,5 +21,27 @@ class UsersController extends Controller
         ];
         
         return view('users.show',$data);
+    }
+
+    public function edit($id)
+    {
+        if($id == \Auth::id()) {
+            $user = \Auth::user();
+            return view('users.edit', $user);
+        } else {
+            abort(403, 'アクセス権がありません'); 
+        }
+    }
+
+    public function update(UserRequest $request, $id)
+    {
+        if($id == \Auth::id()) {
+            $user = \Auth::user();
+            $user->name = $request->name;
+            $user->email = $request->email;
+            $user->password = bcrypt($request->password);
+            $user->save();
+            return redirect()->route('user.show', $user->id);
+        }
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -27,7 +27,7 @@ class UsersController extends Controller
     {
         if ($id == \Auth::id()) {
             $user = \Auth::user();
-            return view('users.edit', $user);
+            return view('users.edit', ['user' => $user]);
         } 
         abort(403, 'アクセス権がありません'); 
         

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -25,17 +25,17 @@ class UsersController extends Controller
 
     public function edit($id)
     {
-        if($id == \Auth::id()) {
+        if ($id == \Auth::id()) {
             $user = \Auth::user();
             return view('users.edit', $user);
-        } else {
-            abort(403, 'アクセス権がありません'); 
-        }
+        } 
+        abort(403, 'アクセス権がありません'); 
+        
     }
 
     public function update(UserRequest $request, $id)
     {
-        if($id == \Auth::id()) {
+        if ($id == \Auth::id()) {
             $user = \Auth::user();
             $user->name = $request->name;
             $user->email = $request->email;

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Support\Facades\Auth;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore(Auth::id())],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+}
+

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,6 +8,7 @@
     </head>
     <body>
         @include('commons.header')
+        @include('commons.error_messages')
         <div class="container">
             @yield('content')
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,7 +8,6 @@
     </head>
     <body>
         @include('commons.header')
-        @include('commons.error_messages')
         <div class="container">
             @yield('content')
         </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -2,6 +2,7 @@
 @section('content')
 <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
 <form method="POST" action="{{ route('user.update', Auth::user()->id) }}">
+        @include('commons.error_messages')
         @csrf
         @method('PUT')
         <input type="hidden" name="id" value="{{ Auth::user()->id }}" />

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+<form method="POST" action="{{ route('user.update', Auth::user()->id) }}">
+        @csrf
+        @method('PUT')
+        <input type="hidden" name="id" value="{{ Auth::user()->id }}" />
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name', Auth::user()->name) }}" name="name" />
+        </div>
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{ old('email', Auth::user()->email) }}" name="email" />
+        </div>
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password_confirmation" />
+        </div>
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+</form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="" method="POST">
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -8,9 +8,9 @@
             </div>
             <div class="card-body">
                 <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 500) }}" alt="ユーザのアバター画像">
-                @if (Auth::id() === $user->user_id)
+                @if (Auth::id() === $user->id)
                     <div class="mt-3">
-                        <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                        <a href="{{ route('user.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                     </div>
                 @endif
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@
 */
 
 // ユーザ新規登録
+
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
@@ -32,5 +33,11 @@ Route::group(['middleware' => 'auth'], function(){
     //投稿
     Route::prefix('posts')->group( function () {
         Route::post('', 'PostsController@store')->name('posts.store');
+    });
+
+    // ユーザ編集
+    Route::prefix('users')->group( function () {
+        Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
+        Route::put('{id}', 'UsersController@update')->name('user.update');
     });
 });


### PR DESCRIPTION
## issue
- #710 
##  概要
- ユーザ編集画面・更新
## 動作確認手順
- ユーザ詳細画面の【ユーザ情報の編集】をクリックすることでユーザ編集画面に遷移
- 各カラム入力後、【更新する】をクリックすることでユーザ情報が更新され、ユーザ詳細画面に推移する
- バリデーションに抵触する内容にて【更新する】をクリックすると、エラーメッセージが表示される
- ログインしているユーザとは異なる、IDのユーザのユーザ詳細画面では 【ユーザ情報の編集】が表示されない
- URLに直接入力(ログインID：4にて、/users/3/editへアクセス)すると、abort(403)へ遷移　※アクセス権無し
- いったんログアウトし、ユーザ情報を変更したユーザでログインを試みたところ、ログインに成功
## 考慮してほしいこと
- 特になし
## 確認してほしいこと
- 特になし
