### PR TITLE
#706 ユーザ退会(むらい)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -26,7 +26,8 @@ class UsersController extends Controller
         if (\Auth::id() === $user->id)
         {
             $user->delete();
+            return redirect('/');
         }
-        return redirect('/');
+        abort(403, 'アクセス権がありません');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -48,8 +48,7 @@ class UsersController extends Controller
     public function destroy($id)
     {
         $user = User::findOrFail($id);
-        if (\Auth::id() === $user->id)
-        {
+        if (\Auth::id() === $user->id) {
             $user->delete();
             return redirect('/');
         }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -19,4 +19,14 @@ class UsersController extends Controller
         
         return view('users.show',$data);
     }
+
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id)
+        {
+            $user->delete();
+        }
+        return redirect('/');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -80,4 +80,12 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(User::class, 'follows', 'followed_user_id', 'user_id')->withTimestamps();
     }
+
+    public static function boot(): void
+    {
+        parent::boot();
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,51 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+<form method="POST" action="{{ route('user.update', Auth::user()->id) }}">
+        @include('commons.error_messages')
+        @csrf
+        @method('PUT')
+        <input type="hidden" name="id" value="{{ Auth::user()->id }}" />
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name', Auth::user()->name) }}" name="name" />
+        </div>
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{ old('email', Auth::user()->email) }}" name="email" />
+        </div>
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password_confirmation" />
+        </div>
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+</form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="{{ route('user.delete', Auth::user()->id) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -38,7 +38,7 @@
                     <label>本当に退会しますか？</label>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
-                    <form action="{{ route('user.destroy', Auth::user()->id) }}" method="POST">
+                    <form action="{{ route('user.delete', Auth::user()->id) }}" method="POST">
                         @csrf
                         @method('DELETE')
                         <button type="submit" class="btn btn-danger">退会する</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,4 +35,8 @@ Route::group(['middleware' => 'auth'], function() {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
     });
+
+    Route::prefix('users')->group( function () {
+        Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,6 @@
 */
 
 // ユーザ新規登録
-
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
@@ -36,8 +35,7 @@ Route::group(['middleware' => 'auth'], function() {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
     });
-
-    
+ 
     //フォロー
     Route::group(['prefix' => 'users/{id}'],function() {
         Route::post('follow','FollowController@store')->name('follow');

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,6 @@ Route::group(['middleware' => 'auth'], function() {
     Route::prefix('users')->group( function () {
         Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
         Route::put('{id}', 'UsersController@update')->name('user.update');
-        Route::delete('{id}', 'UsersController@destroy')->name('user.destroy');
+        Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
     });
 });


### PR DESCRIPTION
## issue
- closes #706 
## 概要
- ユーザ退会処理
## 動作確認手順
- ログイン後、ユーザ詳細画面からユーザ編集画面に推移し、左下にある「退会する」をクリックし、モーダルの「退会する」もクリックする
- トップページにリダイレクトされ、該当ユーザの投稿が消えており、adminer上でもusers_tableの該当のユーザのdeleted_atとposts_tableの該当のユーザの投稿のdeleted_atに削除時間が記載されているのを確認
## 考慮してほしいこと
- 特になし
## 確認してほしいこと
- UsersControllerのdestroyメソッドに、
if (\Auth::id() === $user->id)の記載をしておりますが、今回の退会処理では、ユーザ編集画面からの処理のため、UsersControllerのeditメソッドが先に必ず行われ、editメソッドの時点で、
if ($id == \Auth::id())の記載をしているため、もしかしたらdestroyメソッドにif (\Auth::id() === $user->id)の記載はいらないのではないかと思ったのですが、いかがでしょうか。