### PR TITLE
Feature/makino/user withdrawal ✨#690「ユーザ退会 」機能を追加（まきの）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -45,4 +45,15 @@ class UsersController extends Controller
         ];
         return view('users.show', $data);
     }
+
+    // ユーザ退会
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id ) {
+            $user->delete();
+        }
+        return redirect('/');
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -42,4 +42,14 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
+
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -42,7 +42,9 @@
                     <label>本当に退会しますか？</label>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
-                    <form action="" method="POST">
+                    <form action="{{ route('users.delete', $user->id) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
                         <button type="submit" class="btn btn-danger">退会する</button>
                     </form>
                     <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('users/{id}')->group(function () {
         Route::get('edit', 'UsersController@edit')->name('users.edit');
         Route::put('', 'UsersController@update')->name('users.update');
+        Route::delete('', 'UsersController@destroy')->name('users.delete');
     });
     // コメントポスト
     Route::post('posts', 'PostsController@post')->name('posts.post');


### PR DESCRIPTION
### 概要
#690「ユーザ退会 」機能を追加しました。

### 動作確認手順
「ユーザ編集画面」から「退会する」ボタンを押下し、以下を確認

1.  usersテーブルのdeleted_atに日時が入ること
2.  postsテーブルで、削除したuser_idのdeleted_atに日時が入ること
3.  トップ画面が表示されること

### 考慮して欲しいこと
操作上、特に考慮することはありません

### 確認してほしいこと
ユーザ削除した時に、連動してpostテーブルから削除したユーザIDのpostを削除するようにしましたので、その実装方法を確認願います。

今回
https://yaba-blog.com/larave-soft-delete/
の①を参考にしましたが、`boot() `で `$user->posts()->delete();` で連動して、削除したユーザの投稿を削除できるのであれば、migration ファイルの` ->onDelete('cascade'); `はなくてもいいのではと思いましたが、違いますでしょうか。
push 後試しにmigration ファイルの` ->onDelete('cascade'); `を削除してユーザ削除してみたら、上記の「動作確認手順」で記載したのと同じ結果が得られました。

よろしくお願いいたします。