### PR TITLE
#753_replyリプライ(dera)

### DIFF
--- a/app/Http/Controllers/ReplyController.php
+++ b/app/Http/Controllers/ReplyController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ReplyRequest;
+use App\Post;
+use App\Reply;
+use App\User;
+
+class ReplyController extends Controller
+{
+    // リプライ投稿画面遷移
+    public function create($postId)
+    {
+        $post = Post::findOrFail($postId);
+        return view('replies.create', compact('post'));
+    }
+    // リプライ投稿
+    public function store($postId, ReplyRequest $request)
+    {
+        $reply = new Reply();
+        $reply->content = $request->input('content');
+        $reply->user_id = $request->user()->id;
+        $post = Post::findOrFail($postId);
+        $post->replies()->save($reply);
+        return redirect()->route('replies.index', ['id' => $post->id]);
+    }
+    // リプライ編集画面遷移
+    public function edit($postId, $replyId)
+    {
+        $post = Post::findOrFail($postId);
+        $reply = Reply::findOrFail($replyId);
+        if (\Auth::id() === $reply->user_id) {
+            return view('replies.edit', compact('post', 'reply', 'postId', 'replyId'));
+        } else {
+            return redirect('/');
+        }
+    }
+    // リプライ更新
+    public function update($postId, $replyId, ReplyRequest $request)
+    {
+        $post = Post::findOrFail($postId);
+        $reply = Reply::findOrFail($replyId);
+        if (\Auth::id() === $reply->user_id) {
+            $reply->content = $request->input('content');
+            $reply->save();
+            // リプライ更新後にリプライ一覧表示へ遷移
+            $replies =  $post->replies()->orderBy('id', 'desc')->paginate(10);
+            return view('replies.index', compact('post', 'replies'));
+        } else {
+            return redirect('/');
+        }
+    }
+    // リプライ削除
+    public function destroy($postId, $replyId)
+    {
+        $post = Post::findOrFail($postId);
+        $reply = Reply::findOrFail($replyId);
+        if (\Auth::id() === $reply->user_id) {
+            $reply->delete();
+        }
+        // リプライ削除後にリプライ一覧表示へ遷移
+        $replies =  $post->replies()->orderBy('id', 'desc')->paginate(10);
+        return view('replies.index', compact('post', 'replies'));
+    }
+    // リプライ表示
+    public function index($postId)
+    {
+        $post = Post::findOrFail($postId);
+        $replies =  $post->replies()->orderBy('id', 'desc')->paginate(10);
+        return view('replies.index', compact('post', 'replies'));
+    }
+}

--- a/app/Http/Controllers/ReplyController.php
+++ b/app/Http/Controllers/ReplyController.php
@@ -23,7 +23,7 @@ class ReplyController extends Controller
         $reply->user_id = $request->user()->id;
         $post = Post::findOrFail($postId);
         $post->replies()->save($reply);
-        return redirect()->route('replies.index', ['id' => $post->id]);
+        return redirect()->route('replies.index', $postId);
     }
     // リプライ編集画面遷移
     public function edit($postId, $replyId)
@@ -45,8 +45,7 @@ class ReplyController extends Controller
             $reply->content = $request->input('content');
             $reply->save();
             // リプライ更新後にリプライ一覧表示へ遷移
-            $replies =  $post->replies()->orderBy('id', 'desc')->paginate(10);
-            return view('replies.index', compact('post', 'replies'));
+            return redirect()->route('replies.index', $postId);
         } else {
             return redirect('/');
         }
@@ -60,8 +59,7 @@ class ReplyController extends Controller
             $reply->delete();
         }
         // リプライ削除後にリプライ一覧表示へ遷移
-        $replies =  $post->replies()->orderBy('id', 'desc')->paginate(10);
-        return view('replies.index', compact('post', 'replies'));
+        return redirect()->route('replies.index', $postId);
     }
     // リプライ表示
     public function index($postId)

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\UserRequest;
 use App\User;
 use App\Post;
@@ -27,9 +26,9 @@ class UsersController extends Controller
 
     public function edit($id)
     {
-        if ($id == Auth::id()) {
+        if ($id == \Auth::id()) {
             $data = [
-                'user' => Auth::user()->id,
+                'user' => \Auth::user()->id,
             ];
             return view('users.edit', $data);
         } else {
@@ -39,7 +38,7 @@ class UsersController extends Controller
 
     public function update(UserRequest $request, $id)
     {
-        if ($id == Auth::id()) {
+        if ($id == \Auth::id()) {
             $user = User::findOrFail($id);
             $user->name = $request->name;
             $user->email = $request->email;

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|string|max:140',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'content' => '返信(リプライ)',
+        ];
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -10,13 +10,13 @@ class Post extends Model
     use softDeletes;
 
     // リレーションメソッド
-        public function user()
-        {
-            return $this->belongsTo(User::class);
-        }
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
-        public function replies()
-        {
-            return $this->hasMany(Reply::class);
-        }
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -5,9 +5,11 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\softDeletes;
 
-class Post extends Model
+class Reply extends Model
 {
-    use softDeletes;
+    use SoftDeletes;
+
+    protected $fillable = ['content'];
 
     // リレーションメソッド
         public function user()
@@ -15,8 +17,8 @@ class Post extends Model
             return $this->belongsTo(User::class);
         }
 
-        public function replies()
+        public function post()
         {
-            return $this->hasMany(Reply::class);
+            return $this->belongsTo(Post::class);
         }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -12,13 +12,13 @@ class Reply extends Model
     protected $fillable = ['content'];
 
     // リレーションメソッド
-        public function user()
-        {
-            return $this->belongsTo(User::class);
-        }
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
-        public function post()
-        {
-            return $this->belongsTo(Post::class);
-        }
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -41,65 +41,72 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
-    public function user()
-    {
-    return $this->belongsTo(User::class, 'user_id');
-    }
+    // リレーションメソッド
+        public function user()
+        {
+            return $this->belongsTo(User::class, 'user_id');
+        }
 
-    public function posts()
-    {
-        return $this->hasMany(Post::class);
-    }
+        public function posts()
+        {
+            return $this->hasMany(Post::class);
+        }
 
-    public function followings()
-    {
-        // ユーザーがフォローしているユーザー一覧を取得
-        return $this->belongsToMany(User::class, 'follows', 'user_id', 'follow_id')->withTimestamps();
-    }
-    
-    public function followers()
-    {
-        // ユーザーをフォローしているユーザー一覧を取得
-        return $this->belongsToMany(User::class, 'follows', 'follow_id', 'user_id')->withTimestamps();
-    }
-    
-    public function follow($userId)
-    {
-        // 自分自身をフォローしようとしている場合はエラーとする
-        if ($this->id === $userId) {
-            return false;
+        public function replies()
+        {
+            return $this->hasMany(Reply::class);
         }
-    
-        // すでにフォローしているユーザーを再度フォローしようとしている場合もエラーとする
-        if ($this->isFollow($userId)) {
-            return false;
+
+    // フォローメソッド
+        public function followings()
+        {
+            // ユーザーがフォローしているユーザー一覧を取得
+            return $this->belongsToMany(User::class, 'follows', 'user_id', 'follow_id')->withTimestamps();
         }
-    
-        // フォローを実行
-        $this->followings()->attach($userId);
-        return true;
-    }
-    
-    public function unFollow($userId)
-    {
-        // 自分自身をアンフォローしようとしている場合はエラーとする
-        if ($this->id === $userId) {
-            return false;
+        
+        public function followers()
+        {
+            // ユーザーをフォローしているユーザー一覧を取得
+            return $this->belongsToMany(User::class, 'follows', 'follow_id', 'user_id')->withTimestamps();
         }
-    
-        // まだフォローしていないユーザーをアンフォローしようとしている場合はエラーとする
-        if (!$this->isFollow($userId)) {
-            return false;
+        
+        public function follow($userId)
+        {
+            // 自分自身をフォローしようとしている場合はエラーとする
+            if ($this->id === $userId) {
+                return false;
+            }
+        
+            // すでにフォローしているユーザーを再度フォローしようとしている場合もエラーとする
+            if ($this->isFollow($userId)) {
+                return false;
+            }
+        
+            // フォローを実行
+            $this->followings()->attach($userId);
+            return true;
         }
-    
-        // アンフォローを実行
-        $this->followings()->detach($userId);
-        return true;
-    }
-    
-    public function isFollow($userId)
-    {
-        // ユーザーが指定したユーザーをフォローしているかをチェック
-        return $this->followings()->where('follow_id', $userId)->exists();
-    }
+        
+        public function unFollow($userId)
+        {
+            // 自分自身をアンフォローしようとしている場合はエラーとする
+            if ($this->id === $userId) {
+                return false;
+            }
+        
+            // まだフォローしていないユーザーをアンフォローしようとしている場合はエラーとする
+            if (!$this->isFollow($userId)) {
+                return false;
+            }
+        
+            // アンフォローを実行
+            $this->followings()->detach($userId);
+            return true;
+        }
+        
+        public function isFollow($userId)
+        {
+            // ユーザーが指定したユーザーをフォローしているかをチェック
+            return $this->followings()->where('follow_id', $userId)->exists();
+        }
 } 

--- a/app/User.php
+++ b/app/User.php
@@ -42,71 +42,71 @@ class User extends Authenticatable
     ];
 
     // リレーションメソッド
-        public function user()
-        {
-            return $this->belongsTo(User::class, 'user_id');
-        }
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
 
-        public function posts()
-        {
-            return $this->hasMany(Post::class);
-        }
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 
-        public function replies()
-        {
-            return $this->hasMany(Reply::class);
-        }
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 
     // フォローメソッド
-        public function followings()
-        {
-            // ユーザーがフォローしているユーザー一覧を取得
-            return $this->belongsToMany(User::class, 'follows', 'user_id', 'follow_id')->withTimestamps();
+    public function followings()
+    {
+        // ユーザーがフォローしているユーザー一覧を取得
+        return $this->belongsToMany(User::class, 'follows', 'user_id', 'follow_id')->withTimestamps();
+    }
+    
+    public function followers()
+    {
+        // ユーザーをフォローしているユーザー一覧を取得
+        return $this->belongsToMany(User::class, 'follows', 'follow_id', 'user_id')->withTimestamps();
+    }
+    
+    public function follow($userId)
+    {
+        // 自分自身をフォローしようとしている場合はエラーとする
+        if ($this->id === $userId) {
+            return false;
         }
-        
-        public function followers()
-        {
-            // ユーザーをフォローしているユーザー一覧を取得
-            return $this->belongsToMany(User::class, 'follows', 'follow_id', 'user_id')->withTimestamps();
+    
+        // すでにフォローしているユーザーを再度フォローしようとしている場合もエラーとする
+        if ($this->isFollow($userId)) {
+            return false;
         }
-        
-        public function follow($userId)
-        {
-            // 自分自身をフォローしようとしている場合はエラーとする
-            if ($this->id === $userId) {
-                return false;
-            }
-        
-            // すでにフォローしているユーザーを再度フォローしようとしている場合もエラーとする
-            if ($this->isFollow($userId)) {
-                return false;
-            }
-        
-            // フォローを実行
-            $this->followings()->attach($userId);
-            return true;
+    
+        // フォローを実行
+        $this->followings()->attach($userId);
+        return true;
+    }
+    
+    public function unFollow($userId)
+    {
+        // 自分自身をアンフォローしようとしている場合はエラーとする
+        if ($this->id === $userId) {
+            return false;
         }
-        
-        public function unFollow($userId)
-        {
-            // 自分自身をアンフォローしようとしている場合はエラーとする
-            if ($this->id === $userId) {
-                return false;
-            }
-        
-            // まだフォローしていないユーザーをアンフォローしようとしている場合はエラーとする
-            if (!$this->isFollow($userId)) {
-                return false;
-            }
-        
-            // アンフォローを実行
-            $this->followings()->detach($userId);
-            return true;
+    
+        // まだフォローしていないユーザーをアンフォローしようとしている場合はエラーとする
+        if (!$this->isFollow($userId)) {
+            return false;
         }
-        
-        public function isFollow($userId)
-        {
-            // ユーザーが指定したユーザーをフォローしているかをチェック
-            return $this->followings()->where('follow_id', $userId)->exists();
-        }
+    
+        // アンフォローを実行
+        $this->followings()->detach($userId);
+        return true;
+    }
+    
+    public function isFollow($userId)
+    {
+        // ユーザーが指定したユーザーをフォローしているかをチェック
+        return $this->followings()->where('follow_id', $userId)->exists();
+    }
 } 

--- a/database/migrations/2023_11_03_165033_create_replies_table.php
+++ b/database/migrations/2023_11_03_165033_create_replies_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replies', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id')->index();
+            $table->unsignedBigInteger('post_id')->index();
+            $table->string('content', 140)->collation('utf8mb4_bin')->index();
+            $table->timestamps();
+            $table->softdeletes();
+
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->ondelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->ondelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replies');
+    }
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fab fa-telegram fa-lg pr-3"></i>（仮称）Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
     <div class="text-center mt-3">
         <p class="text-left d-inline-block">ログインすると投稿で<br>コミュニケーションができるようになります。</p>
@@ -11,6 +11,7 @@
     </div>
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
+        @include('commons.error_messages')
             <form method="POST" action="{{ route('login.post') }}">
                 @csrf
                 <div class="form-group">
@@ -23,7 +24,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">ログイン</button>
             </form>
-            <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
+            <div class="mt-2"><a href="{{ route('signup') }}">新規ユーザ登録する？</a></div>
         </div>
     </div>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Post</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
     <div class="text-center mt-3">
         <p class="text-left d-inline-block">新規ユーザ登録すると、
@@ -12,6 +12,7 @@
     </div>
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
+        @include('commons.error_messages')
             <form method="POST" action="{{ route('signup.post') }}">
                 @csrf
                 <div class="form-group">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,50 +1,65 @@
 @foreach ($posts as $post)
 <ul class="list-unstyled">
-         <li class="mb-3 text-center">
-            <div class="text-left d-inline-block w-75 mb-2">
-             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                 <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
-             </div>
-             <div class=""> 
-                 <div class="text-left d-inline-block w-75">
-                    @if(isset($searchResults))
-                        <p class="mb-2">{!! preg_replace(
-                            '/[' . preg_quote($searchQuery, '/') . ']/iu', 
-                            '<span style="background-color: yellow;">$0</span>', 
-                            $post->content
-                        ) !!}</p>
-                    @else
-                        <p class="mb-2">{{ $post->content }}</p>
-                    @endif
-                    <p class="text-muted">{{ $post->created_at }}</p>
-                </div>
+    <li class="mb-3 text-center">
+        <div class="text-left d-inline-block w-75 mb-2">
+            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+            <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
+        </div>
+        <div class=""> 
+            <div class="text-left d-inline-block w-75">
+                @if(isset($searchResults))  <!-- 検索結果表示 -->
+                    <p class="mb-2 text-break">{!! preg_replace(
+                        '/[' . preg_quote($searchQuery, '/') . ']/iu', 
+                        '<span style="background-color: yellow;">$0</span>', 
+                        $post->content
+                    ) !!}</p>
+                @else   <!-- 投稿一覧表示 -->
+                    <p class="mb-2 text-break">{{ $post->content }}</p>
+                @endif
+                <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
+                @if ($post->replies->count() > 0)
+                    <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
+                @endif
+                <p class="text-muted">{{ $post->created_at }}</p>
+            </div>
+            <!-- 各アイコン -->
+            <div class="d-flex justify-content-between w-50 pb-3 m-auto">
+                <!-- 「イイね」 -->
+                <a href="">
+                    <i class="fa fa-thumbs-up fa-2x" style="color: black; "></i>
+                </a>
+                <!-- 「リプライ」 -->
+                <a href="{{ route('replies.create',$post) }}">
+                    <i class="fa fa-comment fa-2x" style="color: black; "></i>
+                </a>
                 @if(Auth::check() && Auth::id() == $post->user_id)
-                <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                    <!-- 投稿編集 -->
+                    <a href="{{ route('post.edit',$post->id) }}" >
+                        <i class="fa fa-edit fa-2x" style="color: black; "></i>
+                    </a>
+                    <!-- 投稿削除 -->
                     <form method="POST" action="{{ route('post.delete', $post->id) }}" id="delete-form">
                         @csrf
                         @method('DELETE')
-                      <button type="button" class="btn btn-danger" onclick="confirmDelete()">削除</button>
+                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete()"></i>
                     </form>
                     <script>
-                        function confirmDelete() {
-                            if (confirm('本当に削除しますか？')) {
-                                document.getElementById('delete-form').submit();
-                            } else {
-                                return back();
-                            }
+                    function confirmDelete() {
+                        if (confirm('本当に削除しますか？')) {
+                            document.getElementById('delete-form').submit();
+                        } else {
+                            return back();
                         }
+                    }
                     </script>
-                    <a href="{{ route('post.edit',$post->id) }}" class="btn btn-primary">編集する</a>
-                    </div>
                 @endif
             </div>
-        </li>
-    </ul>
+        </div>
+    </li>
+</ul>
 @endforeach 
 @if(isset($searchResults))
     <div class="m-auto" style="width: fit-content">{{ $searchResults->appends(request()->query())->links('pagination::bootstrap-4') }}</div>
 @else
     <div class="m-auto" style="width: fit-content">{{ $posts->links('pagination::bootstrap-4') }}</div>
-
 @endif
-</div>

--- a/resources/views/replies/create.blade.php
+++ b/resources/views/replies/create.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('content')
+@include('replies.partials_show', ['post' => $post])
+        <form method="post" action="{{ route('replies.store', $post) }}">
+            @csrf
+            <div class="form-group">
+                <textarea name="content" id="content" class="form-control" rows="4" required placeholder="リプライを入力"></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary float-right">投稿</button>
+        </form>
+@endsection

--- a/resources/views/replies/create.blade.php
+++ b/resources/views/replies/create.blade.php
@@ -1,12 +1,16 @@
 @extends('layouts.app')
-
 @section('content')
-@include('replies.partials_show', ['post' => $post])
-        <form method="post" action="{{ route('replies.store', $post) }}">
+    @include('replies.partials_show', ['post' => $post])
+    <div class="text-center mb-3">
+    <div class="w-75 m-auto">
+        @include('commons.error_messages')
+    </div>
+        <form method="post" action="{{ route('replies.store', $post) }}" class="d-inline-block w-75">
             @csrf
             <div class="form-group">
-                <textarea name="content" id="content" class="form-control" rows="4" required placeholder="リプライを入力"></textarea>
+                <textarea name="content" id="content" class="form-control" rows="4" required placeholder="リプライを入力">{{  old('content') }}</textarea>
             </div>
             <button type="submit" class="btn btn-primary float-right">投稿</button>
         </form>
+    </div>
 @endsection

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -1,12 +1,14 @@
 @extends('layouts.app')
-
 @section('content')
-@include('replies.partials_show', ['post' => $post, 'replyId' => $replyId])
-    <div class="container">
-        <form method="post" action="{{ route('replies.update', ['postId' => $postId, 'replyId' => $replyId]) }}">
+    @include('replies.partials_show', ['post' => $post, 'replyId' => $replyId])
+    <div class="text-center mb-3">
+        <div class="w-75 m-auto">
+            @include('commons.error_messages')
+        </div>
+        <form method="post" action="{{ route('replies.update', ['postId' => $postId, 'replyId' => $replyId]) }}" class="d-inline-block w-75">
             @csrf
-            @method('put')
-            <div class="form-group">
+            @method('PUT')
+            <div class="form-group text-left ">
                 <label for="content">リプライ編集</label>
                 <textarea name="content" id="content" class="form-control" rows="4" required>{{  old('content', $reply->content) }}</textarea>
             </div>

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('content')
+@include('replies.partials_show', ['post' => $post, 'replyId' => $replyId])
+    <div class="container">
+        <form method="post" action="{{ route('replies.update', ['postId' => $postId, 'replyId' => $replyId]) }}">
+            @csrf
+            @method('put')
+            <div class="form-group">
+                <label for="content">リプライ編集</label>
+                <textarea name="content" id="content" class="form-control" rows="4" required>{{  old('content', $reply->content) }}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary float-right">更新</button>
+        </form>
+    </div>
+@endsection

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -3,14 +3,14 @@
 <ul class="list-unstyled">
     <li class="mb-3 text-center">
         <div class="text-left d-inline-block w-75 mb-2">
-            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-            <p class="mt-3 mb-0 d-inline-block">
-                <a href="{{ route('users.show', $post->user_id) }}">{{ $post->user->name }}</a>
-            </p>
+         <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+         <p class="mt-3 mb-0 d-inline-block">
+            <a href="{{ route('users.show', $post->user_id) }}">{{ $post->user->name }}</a>
+         </p>
         </div>
         <div class="text-left d-inline-block w-75">
-            <p class="mb-2 text-break">{{ $post->content }}</p>
-            <p class="text-muted">{{ $post->created_at }}</p>
+         <p class="mb-2 text-break">{{ $post->content }}</p>
+         <p class="text-muted">{{ $post->created_at }}</p>
             <div class="container">
                 <label for="content">リプライ一覧</label>
                 <ul class="list-unstyled">

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -1,0 +1,65 @@
+@extends('layouts.app')
+@section('content')
+<ul class="list-unstyled">
+    <li class="mb-3 text-center">
+        <div class="text-left d-inline-block w-75 mb-2">
+            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+            <p class="mt-3 mb-0 d-inline-block">
+                <a href="{{ route('users.show', $post->user_id) }}">{{ $post->user->name }}</a>
+            </p>
+        </div>
+        <div class="text-left d-inline-block w-75">
+            <p class="mb-2 text-break">{{ $post->content }}</p>
+            <p class="text-muted">{{ $post->created_at }}</p>
+            <div class="container">
+                <label for="content">リプライ一覧</label>
+                <ul class="list-unstyled">
+                    @foreach ($replies as $reply)
+                    <li class="mb-3">
+                        <div class="d-flex">
+                            <div class="mr-2">
+                                <img class="rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
+                            </div>
+                            <div>
+                                <p class="mt-2 mb-2">
+                                    <a  href="{{ route('users.show',$reply->user_id) }}">{{ $reply->user->name }}</a>
+                                    <span class="text-muted ml-2">{{ $reply->created_at }}</span>
+                                </p>
+                                <p class="mt-0 ml-2">{{ $reply->content }}</p>
+                            </div>
+                        </div>
+                        @if(Auth::check() && Auth::id() == $reply->user_id)
+                        <div class="d-flex justify-content-between w-50 pb-3 m-auto">
+                            <!-- 投稿編集 -->
+                            <a href="{{ route('replies.edit',['postId' => $post->id, 'replyId' => $reply->id]) }}" >
+                                <i class="fa fa-edit fa-2x" style="color: black; "></i>
+                            </a>
+                            <!-- 投稿削除 -->
+                            <form method="POST" action="{{ route('replies.destroy', ['postId' => $post->id, 'replyId' => $reply->id]) }}" id="delete-form">
+                                @csrf
+                                @method('DELETE')
+                                <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete()"></i>
+                            </form>
+                            <script>
+                                function confirmDelete() {
+                                    if (confirm('本当に削除しますか？')) {
+                                        document.getElementById('delete-form').submit();
+                                    } else {
+                                        return back();
+                                    }
+                                }
+                            </script>
+                        </div>
+                        @endif    
+                    </li>
+                    @endforeach
+                </ul>
+            </div>
+          
+        </div>
+    </li>
+</ul>
+
+<div class="m-auto" style="width: fit-content">{{ $replies->links('pagination::bootstrap-4') }}</div>
+
+@endsection

--- a/resources/views/replies/partials_show.blade.php
+++ b/resources/views/replies/partials_show.blade.php
@@ -2,21 +2,15 @@
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
              <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-             <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
+             <p class="mt-3 mb-0 d-inline-block">
+                <a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a>
+             </p>
             </div>
-            <div class=""> 
-                <div class="text-left d-inline-block w-75">
-                    @if(isset($searchResults))  <!-- 検索結果表示 -->
-                        <p class="mb-2 text-break">{!! preg_replace(
-                            '/[' . preg_quote($searchQuery, '/') . ']/iu', 
-                            '<span style="background-color: yellow;">$0</span>', 
-                            $post->content
-                        ) !!}</p>
-                    @else   <!-- 投稿一覧表示 -->
-                        <p class="mb-2 text-break">{{ $post->content }}</p>
-                    @endif
-                    <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
-                    @if ($post->replies->count() > 0)
-                        <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
-                    @endif
-                    <p class="text-muted">{{ $post->created_at }}</p>
+            <div class="text-left d-inline-block w-75">
+                @if ($post->replies->count() > 0)   <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
+                    <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
+                @endif
+                <p class="text-muted">{{ $post->created_at }}</p>
+            </div>
+        </li>
+</ul>

--- a/resources/views/replies/partials_show.blade.php
+++ b/resources/views/replies/partials_show.blade.php
@@ -1,0 +1,22 @@
+<ul class="list-unstyled">
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+             <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
+            </div>
+            <div class=""> 
+                <div class="text-left d-inline-block w-75">
+                    @if(isset($searchResults))  <!-- 検索結果表示 -->
+                        <p class="mb-2 text-break">{!! preg_replace(
+                            '/[' . preg_quote($searchQuery, '/') . ']/iu', 
+                            '<span style="background-color: yellow;">$0</span>', 
+                            $post->content
+                        ) !!}</p>
+                    @else   <!-- 投稿一覧表示 -->
+                        <p class="mb-2 text-break">{{ $post->content }}</p>
+                    @endif
+                    <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
+                    @if ($post->replies->count() > 0)
+                        <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
+                    @endif
+                    <p class="text-muted">{{ $post->created_at }}</p>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,7 +2,7 @@
 @section('content')
 <div class="center jumbotron bg-info">
     <div class="text-center text-white mt-2 pt-1">
-        <h1><i class="pr-3"></i>Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
 </div>
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@
 
 //トップページ（投稿一覧表示）
 Route::get('/', 'PostsController@index');
+Route::get('posts/{id}/replies', 'ReplyController@index')->name('replies.index');
 
 // 検索
 Route::prefix('search')->group(function () {
@@ -47,8 +48,19 @@ Route::group(['middleware' => 'auth'], function () {
         Route::put('{id}', 'PostsController@update')->name('post.update');
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
+    // リプライ
+    Route::prefix('posts/{postId}/replies')->group(function () {
+        Route::get('create', 'ReplyController@create')->name('replies.create'); // リプライ投稿画面遷移
+        Route::post('', 'ReplyController@store')->name('replies.store'); // リプライ投稿
+        // リプライ編集
+        Route::prefix('{replyId}')->group(function () {
+            Route::get('edit', 'ReplyController@edit')->name('replies.edit');   // リプライ内容編集画面遷移
+            Route::put('', 'ReplyController@update')->name('replies.update');   // リプライ内容更新
+            Route::delete('', 'ReplyController@destroy')->name('replies.destroy');  // リプライ削除
+        });
+    });
     // ユーザー編集・更新、フォロー・アンフォロー
-    Route::prefix('users/{id}')->group(function(){
+    Route::prefix('users/{id}')->group(function () {
         Route::get('edit', 'UsersController@edit')->name('users.edit');
         Route::put('update', 'UsersController@update')->name('users.update');
         Route::post('follow', 'FollowController@store')->name('follow');


### PR DESCRIPTION
## issue
- Closes #753  

## 動作確認手順

- ログアウト状態
1. リプライ一覧表示　：投稿に対するリプライ一覧が表示される
2. リプライ投稿　　　：投稿に対してリプライ不可（ログインページへ遷移）
3. リプライ編集　　　：アクセス不可（URLへルーティングを直接入力するとログインページへ遷移）
4. リプライ削除　　　：アクセス不可（URLへルーティングを直接入力するとログインページへ遷移）

- ログイン状態
1. リプライ一覧表示
投稿に対するリプライ一覧が表示され、自身のリプライの場合は下部に「編集」「削除」アイコンが表示される
2. リプライ投稿
各投稿の下部に「リプライ」アイコンが表示され、クリックすることでリプライ投稿画面へ遷移し、リプライ投稿可能となる
3. リプライ編集
リプライ一覧表示にて自身投稿のリプライ下部に表示された「編集」アイコンをクリックすることで、リプライ編集画面へ遷移し、リプライ編集可能となる
4. リプライ削除
リプライ一覧表示にて自身投稿のリプライ下部に表示された「削除」アイコンをクリックすることで、リプライ削除画面へ遷移し、リプライ削除可能となる

  
## 考慮して欲しいこと
「いいね」機能をじゅんやさんが作業中のため、「いいね」アイコンはルーティング未入力として作成しておりました。
『全体修正』に関わる部分も２つ目のPRとしてあげさせていただきました。

## 確認して欲しいこと ~~（質問）~~
指摘いただきました下記修正箇所を訂正いたしましたので、改めて確認方お願いいたします。

- インデント
Post、Reply、User　３つのモデルファイル内のインデント修正完了。

- ~~リプライ投稿入力画面~~
　~~バリデーション結果表示　`@include('commons.error_messages')`追記
　バリデーションエラー前の投稿内容の保持　`{{  old('content') }}`追記
　フッターの幅修正~~
- ~~リプライ編集画面
　バリデーション結果表示　`@include('commons.error_messages')`追記
　フッターの幅修正~~
-  ~~ReplyControllerでのPRG原則の反映
　`return redirect()->route('replies.index', $postId);`に変更~~
~~仕様を考えていた時には想定できていなかったエラーが多数発生してしまい、以下のコードが非常に煩雑に感じております。
少しでもスマートになる部分があれば、ご教授いただけますでしょうか。
`app/Http/Controllers/ReplyController.php`
`resources/views/replies`
`resources/views/posts/posts.blade.php`~~
