### PR TITLE
#703 ユーザ情報処理時のフラッシュメッセージ

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -74,7 +74,6 @@ class RegisterController extends Controller
 
     protected function registered(Request $request, $user)
     {
-        $this->guard()->logout();
-        return redirect('/')->with('register_message', 'ユーザ情報を登録しました。');
+        return redirect('/')->with('registerMessage', 'ユーザ情報を登録しました。');
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,6 +8,7 @@ use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Http\Request;
 
 class RegisterController extends Controller
 {
@@ -69,5 +70,11 @@ class RegisterController extends Controller
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    protected function registered(Request $request, $user)
+    {
+        $this->guard()->logout();
+        return redirect('/')->with('register_message', 'ユーザ情報を登録しました。');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -41,7 +41,7 @@ class UsersController extends Controller
             $user->email = $request->email;
             $user->password = bcrypt($request->password);
             $user->save();
-            return redirect()->route('user.show', $user->id);
+            return redirect()->route('user.show', $user->id)->with('update_message', 'ユーザ情報を更新しました。');
         }
     }
 
@@ -50,7 +50,7 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
         if (\Auth::id() === $user->id) {
             $user->delete();
-            return redirect('/');
+            return redirect('/')->with('delete_message', 'ユーザー情報を削除しました。');
         }
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -41,7 +41,7 @@ class UsersController extends Controller
             $user->email = $request->email;
             $user->password = bcrypt($request->password);
             $user->save();
-            return redirect()->route('user.show', $user->id)->with('update_message', 'ユーザ情報を更新しました。');
+            return redirect()->route('user.show', $user->id)->with('updateMessage', 'ユーザ情報を更新しました。');
         }
     }
 
@@ -50,7 +50,7 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
         if (\Auth::id() === $user->id) {
             $user->delete();
-            return redirect('/')->with('delete_message', 'ユーザー情報を削除しました。');
+            return redirect('/')->with('deleteMessage', 'ユーザー情報を削除しました。');
         }
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -23,7 +23,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">ログイン</button>
             </form>
-            <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
+            <div class="mt-2"><a href="{{ route('signup') }}">新規ユーザ登録する？</a></div>
         </div>
     </div>
 @endsection

--- a/resources/views/commons/success_messages.blade.php
+++ b/resources/views/commons/success_messages.blade.php
@@ -13,4 +13,19 @@
     <div class="alert alert-success w-75 m-auto">
         {{ session('editMessage') }}
     </div>
+<!-- ユーザ新規登録 -->
+@elseif (session('registerMessage'))
+    <div class="alert alert-success w-75 m-auto">
+        {{ session('registerMessage') }}
+    </div>
+<!-- ユーザ情報更新 -->
+@elseif (session('updateMessage'))
+    <div class="alert alert-success m-auto">
+        {{ session('updateMessage') }}
+    </div>
+<!-- ユーザ退会 -->
+@elseif (session('deleteMessage'))
+    <div class="alert alert-danger w-75 m-auto">
+        {{ session('deleteMessage') }}
+    </div>
 @endif

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,5 +1,5 @@
 <ul class="list-unstyled">
-        <li class="mb-3 text-center">
+        <li class="mb-3 mt-3 text-center">
             @foreach ($posts as $post)
                 <div class="text-left d-inline-block w-75 mb-2">       
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src( $post->user->email , 55) }}" alt="ユーザのアバター画像">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,6 +1,11 @@
 @extends('layouts.app')
-@section('content') 
-<div class="row">
+@section('content')
+@if (session('update_message'))
+<div class="alert alert-success">
+    {{ session('update_message') }}
+</div>
+@endif
+<div class="row mt-3">
     <aside class="col-sm-4 mb-5">
         <div class="card bg-info">
             <div class="card-header">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,10 +1,6 @@
 @extends('layouts.app')
 @section('content')
-@if (session('updateMessage'))
-    <div class="alert alert-success">
-        {{ session('updateMessage') }}
-    </div>
-@endif
+@include('commons.success_messages')
 <div class="row mt-3">
     <aside class="col-sm-4 mb-5">
         <div class="card bg-info">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,9 +1,9 @@
 @extends('layouts.app')
 @section('content')
-@if (session('update_message'))
-<div class="alert alert-success">
-    {{ session('update_message') }}
-</div>
+@if (session('updateMessage'))
+    <div class="alert alert-success">
+        {{ session('updateMessage') }}
+    </div>
 @endif
 <div class="row mt-3">
     <aside class="col-sm-4 mb-5">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,13 +1,13 @@
 @extends('layouts.app')
 @section('content')
-@if (session('register_message'))
-<div class="alert alert-success">
-    {{ session('register_message') }}
-</div>
-@elseif (session('delete_message'))
-<div class="alert alert-danger">
-    {{ session('delete_message') }}
-</div>
+@if (session('registerMessage'))
+    <div class="alert alert-success">
+        {{ session('registerMessage') }}
+    </div>
+@elseif (session('deleteMessage'))
+    <div class="alert alert-danger">
+        {{ session('deleteMessage') }}
+    </div>
 @endif
     <div class="center jumbotron bg-info mt-3">
         <div class="text-center text-white mt-2 pt-1">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,6 +1,15 @@
 @extends('layouts.app')
 @section('content')
-    <div class="center jumbotron bg-info">
+@if (session('register_message'))
+<div class="alert alert-success">
+    {{ session('register_message') }}
+</div>
+@elseif (session('delete_message'))
+<div class="alert alert-danger">
+    {{ session('delete_message') }}
+</div>
+@endif
+    <div class="center jumbotron bg-info mt-3">
         <div class="text-center text-white mt-2 pt-1">
             <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
         </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,23 +1,14 @@
 @extends('layouts.app')
 @section('content')
-@if (session('registerMessage'))
-    <div class="alert alert-success">
-        {{ session('registerMessage') }}
-    </div>
-@elseif (session('deleteMessage'))
-    <div class="alert alert-danger">
-        {{ session('deleteMessage') }}
-    </div>
-@endif
     <div class="center jumbotron bg-info mt-3">
         <div class="text-center text-white mt-2 pt-1">
             <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5> 
+    <div class="m-auto">@include('commons.success_messages')</div>
     @if (Auth::check()) 
     <div class="w-75 m-auto"> @include('commons.error_messages')</div>
-        @include('commons.success_messages')
         <div class="text-center mb-3 mt-3">
             <form method="POST" action="{{ route('posts.store') }}" class="d-inline-block w-75">
                 @csrf


### PR DESCRIPTION
## issue
- closes #703 
## 概要
- ユーザ情報処理時のフラッシュメッセージの実装
## 動作確認手順
- ユーザ新規登録時にトップページにリダイレクトされたときに、「ユーザ情報を登録しました。」と表示される。
- ユーザ情報更新時に、ユーザ詳細画面にリダイレクトされたときに、「ユーザ情報を更新しました。」と表示される。
- ユーザ退会時に、トップページにリダイレクトされたときに、「ユーザ情報を削除しました。」と表示される。
## 考慮してほしい事
- 特になし
## 確認してほしい事
- ログイン時やログアウト時は、ヘッダーの表示が変わるため、フラッシュメッセージの実装は行っておりませんが、実装したほうがよろしいのでしょうか。