### PR TITLE
#755プロフィール画像変更②（ごめ）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -13,7 +13,8 @@ class PostsController extends Controller
     public function index()
     {
         $posts = Post::orderBy('id', 'desc')->paginate(10);
-        return view('welcome', ['posts' => $posts]);
+        $user = \Auth::user();
+        return view('welcome', ['posts' => $posts, 'user' => $user]);    
     }
 
     public function store(PostRequest $request)

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -56,7 +56,8 @@ class UsersController extends Controller
             $user->delete();
             return redirect('/');
         }
-    }        
+    }  
+
     public function followings($id)
     {
         $user = User::findOrFail($id);
@@ -86,45 +87,24 @@ class UsersController extends Controller
     }
 
     public function upload(Request $request)
-     {
-         if ($request->hasFile('image')) {
-             $request->validate([
-                 'image' => 'required|file|image|max:2048',
-             ]);
+    {
+        if ($request->hasFile('image')) {
+            $request->validate([
+                'image' => 'required|file|image|max:2048',
+            ]);
 
-             $path = $request->file('image')->store('images', 'public');
-             $filename = basename($path);
-             // これは 'storage/app/public/images' に画像を保存するコード
+            $path = $request->file('image')->store('images', 'public');
+            $filename = basename($path);
+            // これは 'storage/app/public/images' に画像を保存するコード
 
-             $user = Auth::user(); // ログイン中のユーザーを取得
-             $user->profile_image = $filename; // ファイル名をユーザーレコードに保存
-             $user->save(); // ユーザーレコードを更新
+            $user = \Auth::user(); // ログイン中のユーザーを取得
+            $user->profile_image = $filename; // ファイル名をユーザーレコードに保存
+            $user->save(); // ユーザーレコードを更新
 
-             return back()->with('path', $path);
-         } else {
-             // ファイルがアップロードされていない場合のエラーメッセージ
-             return back()->withErrors('No file was uploaded.');
-         }
-     }
-
-     public function updateProfile(Request $request, User $user)
-     {
-         $data = $request->all();
-
-         if ($request->hasFile('profile_image')) {
-             $file = $request->file('profile_image');
-             $filename = time() . '.' . $file->getClientOriginalExtension();
-
-             // 既存の画像があれば削除
-             if ($user->profile_image) {
-                 Storage::disk('public')->delete('images/' . $user->profile_image);
-             }
-
-             $file->storeAs('images', $filename, 'public');
-             $data['profile_image'] = $filename;
-         }
-
-         $user->update($data);
-         return back();
-     }
+            return back()->with('path', $path);
+        } else {
+            // ファイルがアップロードされていない場合のエラーメッセージ
+            return back()->withErrors('No file was uploaded.');
+        }
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -93,15 +93,15 @@ class UsersController extends Controller
                 'image' => 'required|file|image|max:2048',
             ]);
 
-            $path = $request->file('image')->store('images', 'public');
+            $path = $request->file('image')->store('profile_images', 'public');
             $filename = basename($path);
-            // これは 'storage/app/public/images' に画像を保存するコード
+            // これは 'storage/app/public/profile_images' に画像を保存するコード
 
             $user = \Auth::user(); // ログイン中のユーザーを取得
             $user->profile_image = $filename; // ファイル名をユーザーレコードに保存
             $user->save(); // ユーザーレコードを更新
 
-            return back()->with('path', $path);
+            return back();
         } else {
             // ファイルがアップロードされていない場合のエラーメッセージ
             return back()->withErrors('No file was uploaded.');

--- a/app/User.php
+++ b/app/User.php
@@ -20,7 +20,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password',
+        'name', 'email', 'password', 'profile_image',
     ];
 
     /**

--- a/database/migrations/2023_11_11_224642_add_profile_image_to_users_table.php
+++ b/database/migrations/2023_11_11_224642_add_profile_image_to_users_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProfileImageToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+{
+    Schema::table('users', function (Blueprint $table) {
+        
+        if (!Schema::hasColumn('users', 'profile_image')) {
+            $table->string('profile_image')->nullable();
+        }
+    });
+}
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+{
+    Schema::table('users', function (Blueprint $table) {
+        if (Schema::hasColumn('users', 'profile_image')) {
+            $table->dropColumn('profile_image');
+        }
+    });
+}
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Post</h1>
     </div>
     <div class="text-center mt-3">
         <p class="text-left d-inline-block">新規ユーザ登録すると、
@@ -12,7 +12,6 @@
     </div>
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
-        @include('commons.error_messages')
             <form method="POST" action="{{ route('signup.post') }}">
                 @csrf
                 <div class="form-group">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -3,7 +3,7 @@
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
                 @if (isset($post->user->profile_image) && $post->user->profile_image)
-                    <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                    <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/profile_images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
                 @else
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
                 @endif

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,11 +1,14 @@
 @foreach ($posts as $post)
-<ul class="list-unstyled">
-    <li class="mb-3 text-center">
-        <div class="text-left d-inline-block w-75 mb-2">
-            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-            <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
-        </div>
-        <div class=""> 
+    <ul class="list-unstyled">
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+                @if (isset($post->user->profile_image) && $post->user->profile_image)
+                    <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                @else
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                @endif
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('users.show', $post->user_id) }}">{{ $post->user->name }}</a></p>
+            </div>
             <div class="text-left d-inline-block w-75">
                 @if(isset($searchResults))  <!-- 検索結果表示 -->
                     <p class="mb-2 text-break">{!! preg_replace(
@@ -26,40 +29,43 @@
             <div class="d-flex justify-content-between w-50 pb-3 m-auto">
                 <!-- 「イイね」 -->
                 <a href="">
-                    <i class="fa fa-thumbs-up fa-2x" style="color: black; "></i>
+                    <i class="fa fa-thumbs-up fa-2x" style="color: black;"></i>
                 </a>
                 <!-- 「リプライ」 -->
-                <a href="{{ route('replies.create',$post) }}">
-                    <i class="fa fa-comment fa-2x" style="color: black; "></i>
+                <a href="{{ route('replies.create', $post) }}">
+                    <i class="fa fa-comment fa-2x" style="color: black;"></i>
                 </a>
                 @if(Auth::check() && Auth::id() == $post->user_id)
                     <!-- 投稿編集 -->
-                    <a href="{{ route('post.edit',$post->id) }}" >
-                        <i class="fa fa-edit fa-2x" style="color: black; "></i>
+                    <a href="{{ route('post.edit', $post->id) }}">
+                        <i class="fa fa-edit fa-2x" style="color: black;"></i>
                     </a>
                     <!-- 投稿削除 -->
-                    <form method="POST" action="{{ route('post.delete', $post->id) }}" id="delete-form">
+                    <form method="POST" action="{{ route('post.delete', $post->id) }}" id="delete_{{ $post->id }}">                        
                         @csrf
                         @method('DELETE')
-                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete()"></i>
+                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete({{ $post->id }})"></i>                    
                     </form>
-                    <script>
-                    function confirmDelete() {
-                        if (confirm('本当に削除しますか？')) {
-                            document.getElementById('delete-form').submit();
-                        } else {
-                            return back();
-                        }
-                    }
-                    </script>
                 @endif
             </div>
-        </div>
-    </li>
-</ul>
-@endforeach 
+        </li>
+    </ul>
+@endforeach
+
 @if(isset($searchResults))
-    <div class="m-auto" style="width: fit-content">{{ $searchResults->appends(request()->query())->links('pagination::bootstrap-4') }}</div>
+    <div class="m-auto" style="width: fit-content;">
+        {{ $searchResults->appends(request()->query())->links('pagination::bootstrap-4') }}
+    </div>
 @else
-    <div class="m-auto" style="width: fit-content">{{ $posts->links('pagination::bootstrap-4') }}</div>
+    <div class="m-auto" style="width: fit-content;">
+        {{ $posts->links('pagination::bootstrap-4') }}
+    </div>
 @endif
+
+<script>
+    function confirmDelete(postId) {
+        if (confirm('本当に削除しますか？')) {
+            document.getElementById('delete_' + postId).submit();
+        }
+    }
+</script>

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -4,7 +4,7 @@
     <li class="mb-3 text-center">
         <div class="text-left d-inline-block w-75 mb-2">
             @if (isset($post->user->profile_image) && $post->user->profile_image)
-                <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/profile_images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
             @else
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
             @endif         
@@ -23,7 +23,7 @@
                             <div class="d-flex">
                                 <div class="mr-2">
                                 @if (isset($reply->user->profile_image) && $reply->user->profile_image)
-                                    <img class="rounded-circle" style="max-width: 55px; height: auto;" src="{{ asset('storage/images/' . $reply->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                                    <img class="rounded-circle" style="max-width: 55px; height: auto;" src="{{ asset('storage/profile_images/' . $reply->user->profile_image) }}" alt="ユーザーのプロフィール画像">
                                 @else
                                     <img class="rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
                                 @endif                                

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -3,63 +3,69 @@
 <ul class="list-unstyled">
     <li class="mb-3 text-center">
         <div class="text-left d-inline-block w-75 mb-2">
-         <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-         <p class="mt-3 mb-0 d-inline-block">
-            <a href="{{ route('users.show', $post->user_id) }}">{{ $post->user->name }}</a>
-         </p>
+            @if (isset($post->user->profile_image) && $post->user->profile_image)
+                <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+            @else
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+            @endif         
+            <p class="mt-3 mb-0 d-inline-block">
+                <a href="{{ route('users.show', $post->user->id) }}">{{ $post->user->name }}</a>
+            </p>
         </div>
         <div class="text-left d-inline-block w-75">
-         <p class="mb-2 text-break">{{ $post->content }}</p>
-         <p class="text-muted">{{ $post->created_at }}</p>
+            <p class="mb-2 text-break">{{ $post->content }}</p>
+            <p class="text-muted">{{ $post->created_at }}</p>
             <div class="container">
                 <label for="content">リプライ一覧</label>
                 <ul class="list-unstyled">
                     @foreach ($replies as $reply)
-                    <li class="mb-3">
-                        <div class="d-flex">
-                            <div class="mr-2">
-                                <img class="rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
+                        <li class="mb-3">
+                            <div class="d-flex">
+                                <div class="mr-2">
+                                @if (isset($reply->user->profile_image) && $reply->user->profile_image)
+                                    <img class="rounded-circle" style="max-width: 55px; height: auto;" src="{{ asset('storage/images/' . $reply->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                                @else
+                                    <img class="rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
+                                @endif                                
+                                </div>
+                                <div>
+                                    <p class="mt-2 mb-2">
+                                        <a href="{{ route('users.show', $reply->user->id) }}">{{ $reply->user->name }}</a>
+                                        <span class="text-muted ml-2">{{ $reply->created_at }}</span>
+                                    </p>
+                                    <p class="mt-0 ml-2">{{ $reply->content }}</p>
+                                </div>
                             </div>
-                            <div>
-                                <p class="mt-2 mb-2">
-                                    <a  href="{{ route('users.show',$reply->user_id) }}">{{ $reply->user->name }}</a>
-                                    <span class="text-muted ml-2">{{ $reply->created_at }}</span>
-                                </p>
-                                <p class="mt-0 ml-2">{{ $reply->content }}</p>
-                            </div>
-                        </div>
-                        @if(Auth::check() && Auth::id() == $reply->user_id)
-                        <div class="d-flex justify-content-between w-50 pb-3 m-auto">
-                            <!-- 投稿編集 -->
-                            <a href="{{ route('replies.edit',['postId' => $post->id, 'replyId' => $reply->id]) }}" >
-                                <i class="fa fa-edit fa-2x" style="color: black; "></i>
-                            </a>
-                            <!-- 投稿削除 -->
-                            <form method="POST" action="{{ route('replies.destroy', ['postId' => $post->id, 'replyId' => $reply->id]) }}" id="delete-form">
-                                @csrf
-                                @method('DELETE')
-                                <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete()"></i>
-                            </form>
-                            <script>
-                                function confirmDelete() {
-                                    if (confirm('本当に削除しますか？')) {
-                                        document.getElementById('delete-form').submit();
-                                    } else {
-                                        return back();
-                                    }
-                                }
-                            </script>
-                        </div>
-                        @endif    
-                    </li>
+                            @if(Auth::check() && Auth::id() == $reply->user_id)
+                                <div class="d-flex justify-content-between w-50 pb-3 m-auto">
+                                    <a href="{{ route('replies.edit',['postId' => $post->id, 'replyId' => $reply->id]) }}" >
+                                        <i class="fa fa-edit fa-2x" style="color: black; "></i>
+                                    </a>
+                                    <form method="POST" action="{{ route('replies.destroy', ['postId' => $post->id, 'replyId' => $reply->id]) }}" id="delete-form">
+                                        @csrf
+                                        @method('DELETE')
+                                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete()"></i>
+                                    </form>
+                                </div>
+                            @endif    
+                        </li>
                     @endforeach
                 </ul>
             </div>
-          
         </div>
     </li>
 </ul>
 
 <div class="m-auto" style="width: fit-content">{{ $replies->links('pagination::bootstrap-4') }}</div>
+
+<script>
+    function confirmDelete() {
+        if (confirm('本当に削除しますか？')) {
+            document.getElementById('delete-form').submit();
+        } else {
+            location.reload(); // ページをリロードする
+        }
+    }
+</script>
 
 @endsection

--- a/resources/views/replies/partials_show.blade.php
+++ b/resources/views/replies/partials_show.blade.php
@@ -1,16 +1,20 @@
 <ul class="list-unstyled">
-        <li class="mb-3 text-center">
-            <div class="text-left d-inline-block w-75 mb-2">
-             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-             <p class="mt-3 mb-0 d-inline-block">
-                <a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a>
-             </p>
-            </div>
-            <div class="text-left d-inline-block w-75">
-                @if ($post->replies->count() > 0)   <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
-                    <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
-                @endif
-                <p class="text-muted">{{ $post->created_at }}</p>
-            </div>
-        </li>
+    <li class="mb-3 text-center">
+        <div class="text-left d-inline-block w-75 mb-2">
+            @if (isset($post->user->profile_image) && $post->user->profile_image)
+                <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+            @else
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+            @endif
+            <p class="mt-3 mb-0 d-inline-block">
+                <a href="{{ route('users.show', $post->user->id) }}">{{ $post->user->name }}</a>
+            </p>
+        </div>
+        <div class="text-left d-inline-block w-75">
+            @if ($post->replies->count() > 0)
+                <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
+            @endif
+            <p class="text-muted">{{ $post->created_at }}</p>
+        </div>
+    </li>
 </ul>

--- a/resources/views/replies/partials_show.blade.php
+++ b/resources/views/replies/partials_show.blade.php
@@ -2,7 +2,7 @@
     <li class="mb-3 text-center">
         <div class="text-left d-inline-block w-75 mb-2">
             @if (isset($post->user->profile_image) && $post->user->profile_image)
-                <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/profile_images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
             @else
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
             @endif

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -7,7 +7,11 @@
                 <h3 class="card-title text-light">{{ $user->name }}</h3>
             </div>
             <div class="card-body">
-                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
+                @if (isset($user) && $user->profile_image)
+                    <img class="rounded-circle img-fluid" src="{{ asset('storage/images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                @else
+                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
+                @endif                
                 @if (Auth::check() && Auth::user()->id == $user->id)
                 <div class="mt-3">
                     <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -8,7 +8,7 @@
             </div>
             <div class="card-body">
                 @if (isset($user) && $user->profile_image)
-                    <img class="rounded-circle img-fluid" src="{{ asset('storage/images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                    <img class="rounded-circle img-fluid" src="{{ asset('storage/profile_images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
                 @else
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
                 @endif                

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -8,7 +8,7 @@
             </div>
             <div class="card-body">
                 @if (isset($user) && $user->profile_image)
-                    <img class="rounded-circle img-fluid" src="{{ asset('storage/images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                    <img class="rounded-circle img-fluid" src="{{ asset('storage/profile_images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
                 @else
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
                 @endif                                 

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -7,7 +7,11 @@
                 <h3 class="card-title text-light">{{ $user->name }}</h3>
             </div>
             <div class="card-body">
-                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
+                @if (isset($user) && $user->profile_image)
+                    <img class="rounded-circle img-fluid" src="{{ asset('storage/images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                @else
+                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
+                @endif                                 
                 @if (Auth::check() && Auth::user()->id == $user->id)
                 <div class="mt-3">
                     <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -8,7 +8,7 @@
             </div>
             <div class="card-body">
                 @if (isset($user) && $user->profile_image)
-                    <img class="rounded-circle img-fluid" src="{{ asset('storage/images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                    <img class="rounded-circle img-fluid" src="{{ asset('storage/profile_images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
                 @else
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
                 @endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -7,21 +7,58 @@
                 <h3 class="card-title text-light">{{ $user->name }}</h3>
             </div>
             <div class="card-body">
-                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
+                @if (isset($user) && $user->profile_image)
+                    <img class="rounded-circle img-fluid" src="{{ asset('storage/images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                @else
+                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
+                @endif
+
                 @if (Auth::check() && Auth::user()->id == $user->id)
-                <div class="mt-3">
-                    <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
-                </div>
+                    @if ($errors->any())
+                        <div class="alert alert-danger">
+                            <ul>
+                                @foreach ($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <form action="{{ route('users.upload.image', ['id' => $user->id]) }}" method="post" enctype="multipart/form-data" class="mt-2">
+                        @csrf
+                        <input type="file" name="image">
+                        <input type="submit" value="写真をアップロード">
+                    </form>
+
+                    <div class="mt-3">
+                        <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                    </div>
                 @endif
             </div>
-                @include('follows.follow_button')
+            @include('follows.follow_button')
         </div>
     </aside>
+
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">
-            <li class="nav-item"><a href="{{ route('users.show', $user->id) }}" class="nav-link {{ Request::routeIs('users.show') ? 'active' : '' }}">タイムライン<br><div class="badge badge-secondary">{{ $countPosts }}</div></a></li>
-            <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::routeIs('followings') ? 'active' : '' }}">フォロー中<br><div class="badge badge-secondary">{{ $countFollowings }}</div></a></li>
-            <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::routeIs('followers') ? 'active' : '' }}">フォロワー<br><div class="badge badge-secondary">{{ $countFollowers }}</div></a></li>
+            <li class="nav-item">
+                <a href="{{ route('users.show', $user->id) }}" class="nav-link {{ Request::routeIs('users.show') ? 'active' : '' }}">
+                    タイムライン<br>
+                    <div class="badge badge-secondary">{{ $countPosts }}</div>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::routeIs('followings') ? 'active' : '' }}">
+                    フォロー中<br>
+                    <div class="badge badge-secondary">{{ $countFollowings }}</div>
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::routeIs('followers') ? 'active' : '' }}">
+                    フォロワー<br>
+                    <div class="badge badge-secondary">{{ $countFollowers }}</div>
+                </a>
+            </li>
         </ul>
         @include('posts.posts', ['user' => $user, 'posts' => $posts])
     </div>

--- a/resources/views/users/showFollowers.blade.php
+++ b/resources/views/users/showFollowers.blade.php
@@ -1,12 +1,16 @@
 @foreach ($followers as $follower)
 <ul class="list-unstyled">
-    <li class="mb-3 text-center">
-        <div class="text-left d-inline-block w-75 mb-2">
-            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="ユーザのアバター画像">
-            <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show', $follower->id) }}">{{ $follower->name }}</a></p>
-            @include('follows.follow_button',['user'=> $follower])
-         </div>
-     </li>
-</ul>
-@endforeach
-<div class="m-auto" style="width: fit-content">{{ $followers->links('pagination::bootstrap-4') }}</div>
+      <li class="mb-3 text-center">
+          <div class="text-left d-inline-block w-75 mb-2">
+              @if (isset($follower->profile_image) && $follower->profile_image)              
+                  <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $follower->profile_image) }}" alt="ユーザーのプロフィール画像">
+              @else
+                  <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="ユーザのアバター画像">
+              @endif
+              <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show', $follower->id) }}">{{ $follower->name }}</a></p>
+              @include('follows.follow_button',['user'=> $follower])
+           </div>
+      </li>
+ </ul>
+ @endforeach
+ <div class="m-auto" style="width: fit-content">{{ $followers->links('pagination::bootstrap-4') }}</div>

--- a/resources/views/users/showFollowers.blade.php
+++ b/resources/views/users/showFollowers.blade.php
@@ -3,7 +3,7 @@
       <li class="mb-3 text-center">
           <div class="text-left d-inline-block w-75 mb-2">
               @if (isset($follower->profile_image) && $follower->profile_image)              
-                  <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $follower->profile_image) }}" alt="ユーザーのプロフィール画像">
+                  <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/profile_images/' . $follower->profile_image) }}" alt="ユーザーのプロフィール画像">
               @else
                   <img class="mr-2 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="ユーザのアバター画像">
               @endif

--- a/resources/views/users/showFollowings.blade.php
+++ b/resources/views/users/showFollowings.blade.php
@@ -3,7 +3,7 @@
       <li class="mb-3 text-center">
           <div class="text-left d-inline-block w-75 mb-2">
               @if (isset($following->profile_image) && $following->profile_image)                
-                  <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $following->profile_image) }}" alt="ユーザーのプロフィール画像">
+                  <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/profile_images/' . $following->profile_image) }}" alt="ユーザーのプロフィール画像">
               @else
                   <img class="mr-2 rounded-circle" src="{{ Gravatar::src($following->email, 55) }}" alt="ユーザのアバター画像">
               @endif            

--- a/resources/views/users/showFollowings.blade.php
+++ b/resources/views/users/showFollowings.blade.php
@@ -1,12 +1,16 @@
 @foreach ($followings as $following)
 <ul class="list-unstyled">
-    <li class="mb-3 text-center">
-        <div class="text-left d-inline-block w-75 mb-2">
-            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($following->email, 55) }}" alt="ユーザのアバター画像">
-            <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show', $following->id) }}">{{ $following->name }}</a></p>
-            @include('follows.follow_button',['user'=> $following])
-        </div>
-    </li>
-</ul>
-@endforeach
+      <li class="mb-3 text-center">
+          <div class="text-left d-inline-block w-75 mb-2">
+              @if (isset($following->profile_image) && $following->profile_image)                
+                  <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/images/' . $following->profile_image) }}" alt="ユーザーのプロフィール画像">
+              @else
+                  <img class="mr-2 rounded-circle" src="{{ Gravatar::src($following->email, 55) }}" alt="ユーザのアバター画像">
+              @endif            
+              <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show', $following->id) }}">{{ $following->name }}</a></p>
+              @include('follows.follow_button',['user'=> $following])
+          </div>
+     </li>
+ </ul>
+ @endforeach
 <div class="m-auto" style="width: fit-content">{{ $followings->links('pagination::bootstrap-4') }}</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::put('update', 'UsersController@update')->name('users.update');
         Route::post('follow', 'FollowController@store')->name('follow');
         Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
+        Route::post('upload', 'UsersController@upload')->name('users.upload.image');
+         Route::post('uploadProfile', 'UsersController@uploadProfile')->name('users.uploadProfile.image');
         Route::delete('delete', 'UsersController@destroy')->name('user.delete');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,7 +66,6 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('follow', 'FollowController@store')->name('follow');
         Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
         Route::post('upload', 'UsersController@upload')->name('users.upload.image');
-         Route::post('uploadProfile', 'UsersController@uploadProfile')->name('users.uploadProfile.image');
         Route::delete('delete', 'UsersController@destroy')->name('user.delete');
     });
 });


### PR DESCRIPTION
## issuse
- closes #755
## 概要
プロフィール画像変更機能

## 動作確認手順
下記コマンドを実行
git add .

git commit -m"プロフィール画像変更"

git push origin feature/horigome/user_profile_image２

git log


## 考慮してほしいこと
自分の書いた記述が適用されているかどうか。
一度、Usersテーブルに「profile_image」を追加するマイグレーションを作りましたが、今回commit
する際にすでに存在しますとエラーが出たため、消した状態でプルリクを出しております。

画像が円形で統一できるようにしたいと思っていたが、時間が微妙なため、フラッシュメッセージ作成後に時間があれば実装したいと思ってます。

## 確認して欲しいこと
・ログイン後、ユーザー詳細プロフィール画面で、ファイル選択後に画像の挿入ができるところ
・画像の挿入後、写真をアップロードで反映されるかの確認。（DBの[profile_image](http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=users&order%5B0%5D=profile_image)　にデータが反映されていること）
・タイムライン、フォロー、フォロワータグでしっかり画像変更が適用されているか。
・トップページに戻った際に、しっかり画像変更が適用されているか。↓
初め、トップページに行った際に画像サイズが多すぎたためstyle="max-width: 70px; を追加。また全てのアイコンに変更画像が反映してしまっていたため、$userの代わりに$post->userに変更。
以下変更した内容↓

```
@if (isset($user) && $user->profile_image)
      <img class="rounded-circle img-fluid" src="{{ asset('storage/images/' . $user->profile_image) }}" alt="ユーザーのプロフィール画像">
@else
      <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
@endi
```

・画像サイズが大きすぎたり、画像選択せずにアップロードを押した際にバリデーションエラーが出ること