### PR TITLE
投稿表示の長文強制改行(kumiko)

### DIFF
--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -7,7 +7,7 @@
                 </div>
                 <div class="">
                     <div class="text-left d-inline-block w-75">
-                        <p class="mb-2">{{ $post->content }}</p>
+                        <p class="mb-2">{{ nl2br(e($post->content)) }}</p>
                         <p class="text-muted">{{ $post->created_at }}</p>
                     </div>
                 </div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -7,7 +7,7 @@
                 </div>
                 <div class="">
                     <div class="text-left d-inline-block w-75">
-                        <p class="mb-2">{{ nl2br(e($post->content)) }}</p>
+                        <p class="mb-2 text-break">{!! nl2br(e($post->content)) !!}</p>
                         <p class="text-muted">{{ $post->created_at }}</p>
                     </div>
                 </div>


### PR DESCRIPTION
## 概要
- 投稿表示の長文強制改行

## 動作確認手順
- 長文の投稿の場合に改行されて表示されている

## 考慮して欲しいこと
- 他の部分も微調整しようと思いましたがひとまずタスクの部分を加筆しています。

## 確認して欲しいこと
- 特にありません。