### PR TITLE
#754_動画投稿(Laravel応用講座 模倣)_(dera)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -10,12 +10,13 @@ use Illuminate\Http\Request;
 
 class PostsController extends Controller
 {
+    // 投稿一覧表示(ページネイト含む)
     public function index()
     {
         $posts = Post::orderBy('id', 'desc')->paginate(10);
         return view('welcome', ['posts' => $posts]);
     }
-
+    // 投稿
     public function store(PostRequest $request)
     {
         $post = new Post();
@@ -25,25 +26,30 @@ class PostsController extends Controller
         $post->save();
         return redirect('/');
     }
-
+    // 投稿編集画面遷移
     public function edit($id)
     {
         $post = Post::findOrFail($id);
+        $data =[
+            'post' => $post,
+            'id' => $id,
+        ];
         if (\Auth::id() === $post->user_id) {
-            return view('posts.edit', compact('post', 'id'));
+            return view('posts.edit', $data);
         } else {
             return redirect('/');
         }
     }
-
+    // 投稿編集
     public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
+        $post->youtube_id = $request->youtube_id;
         $post->content = $request->content;
         $post->save();
         return redirect('/');
     }
-
+    // 投稿削除
     public function destroy($id)
     {
         $post = Post::findOrFail($id);

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -25,7 +25,7 @@ class PostsController extends Controller
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
         $post->save();
-        return redirect('/');
+        return back()->with('status', '投稿しました');
     }
     // 投稿編集画面遷移
     public function edit($id)

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -19,22 +19,21 @@ class PostsController extends Controller
     public function store(PostRequest $request)
     {
         $post = new Post();
+        $post->youtube_id = $request->youtube_id;
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
         $post->save();
-        return back();
+        return redirect('/');
     }
 
     public function edit($id)
     {
         $post = Post::findOrFail($id);
         if (\Auth::id() === $post->user_id) {
-            $data=[
-                'post' => $post,
-            ];
-            return view('posts.edit', $data);
-        } 
-        return back();
+            return view('posts.edit', compact('post', 'id'));
+        } else {
+            return redirect('/');
+        }
     }
 
     public function update(PostRequest $request, $id)

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,14 +24,16 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
-            'content' => 'required|max:140'
+            'youtube_id' => 'required|max:11',
+            'content' => 'required|max:140',
         ];
     }
 
     public function attributes()
-     {
-         return[
-             'content' => '投稿',
-         ];
-     }
+    {
+        return[
+            'youtube_id' => 'YouTube動画ID',
+            'content' => '投稿',
+        ];
+    }
 }

--- a/database/migrations/2023_09_17_023045_create_posts_table.php
+++ b/database/migrations/2023_09_17_023045_create_posts_table.php
@@ -16,6 +16,7 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('youtube_id');
             $table->string('content', 140)->collation('utf8mb4_bin')->index();    // 140文字制限
             $table->timestamps();
             $table->softDeletes();

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -15,7 +15,7 @@ class PostsTableSeeder extends Seeder
             DB::table('posts')->insert([
                 'user_id' => $num,
                 'content' => 'test'.$num,
-                'youtube_id' => 'youtube_id'.$num,
+                'youtube_id' => '-bNMq1Nxn5o',
             ]);
         }
     }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -11,49 +11,12 @@ class PostsTableSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('posts')->insert([
-            'user_id' => 1,
-            'content' => 'テスト1',
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 2,
-            'content' => 'テスト2',     
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 3,
-            'content' => 'テスト3',          
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 1,
-            'content' => 'テスト4',    
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 2,
-            'content' => 'テスト5',           
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 3,
-            'content' => 'テスト6',    
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 1,
-            'content' => 'テスト7',   
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 2,
-            'content' => 'テスト8',  
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 3,
-            'content' => 'テスト9',   
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 1,
-            'content' => 'テスト10', 
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 2,
-            'content' => 'テスト11',
-        ]);
+        for ($num = 1; $num < 6; $num++){
+            DB::table('posts')->insert([
+                'user_id' => $num,
+                'content' => 'test'.$num,
+                'youtube_id' => 'youtube_id'.$num,
+            ]);
+        }
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -14,8 +14,8 @@ class UsersTableSeeder extends Seeder
         for ($num = 1; $num < 6; $num++){
             DB::table('users')->insert([
                 'name' => 'test'.$num,
-                'email' => 'test'.$num.'@test.jp',
-                'password' => bcrypt('test'.$num.'1pass')
+                'email' => 'test'.$num.'@test',
+                'password' => bcrypt('test'.$num.'pass')
             ]);
         }
     }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>旅・旅行 Topic Posts</h1>
     </div>
     <div class="text-center mt-3">
         <p class="text-left d-inline-block">ログインすると投稿で<br>コミュニケーションができるようになります。</p>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>旅・旅行 Topic Posts</h1>
     </div>
     <div class="text-center mt-3">
         <p class="text-left d-inline-block">新規ユーザ登録すると、

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,6 +1,6 @@
 <header class="mb-5">
     <nav class="navbar navbar-expand-sm navbar-dark bg-info">
-        <a class="navbar-brand" href="/">Topic Posts</a>
+        <a class="navbar-brand" href="/">旅・旅行 Topic Posts</a>
         <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="ja">
     <head>
         <meta charset="utf-8">
-        <title>Topic Posts</title>
+        <title>旅・旅行 Topic Posts</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     </head>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,13 +1,21 @@
 @extends('layouts.app')
 @section('content')
-<h2 class="mt-5">投稿を編集する</h2>
-    <form method="POST" action="{{ route('post.update', $post->id) }}">
+@include('replies.partials_show', ['post' => $post])
+<div class="text-center mb-3">
+    <div class="w-75 m-auto">
+        @include('commons.error_messages')
+    </div>
+    <form method="post" action="{{ route('post.update', ['id' => $id]) }}" class="d-inline-block w-75">
         @csrf
         @method('PUT')
-        <div class="form-group">
-            @include('commons.error_messages')
-            <textarea id="content" class="form-control" name="content" rows="6">{{  old('content', $post->content) }}</textarea>
+        <div class="form-group text-left">
+            <label for="content">投稿編集</label>
+            <p>YouTube動画のURLが<span>https://www.youtube.com/watch?v=-bNMq1Nxn5o</span>ならば、
+                <br>"v="の直後にある<span class="text-success">-bNMq1Nxn5o</span>を入力</p>
+            <input name="youtube_id" id="youtube_id" class="form-control"  required value="{{ old('youtube_id', $post->youtube_id) }}">
+            <textarea name="content" id="content" class="form-control" rows="4" required>{{ old('content', $post->content) }}</textarea>
         </div>
-        <button type="submit" class="btn btn-primary">更新する</button>
+        <button type="submit" class="btn btn-primary float-right">更新</button>
     </form>
+</div>
 @endsection

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,77 +1,83 @@
 @foreach ($posts as $post)
-<ul class="list-unstyled">
-    <li class="mb-3 text-center">
-        <div class="text-left d-inline-block w-75 mb-2">
-            @if (isset($post->user->profile_image) && $post->user->profile_image)
-                <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/profile_images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
-            @else
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-            <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
-        </div>
-        <div>
-            @if ($post->youtube_id)
-                <iframe width="290" height="163.125" src="{{ 'https://www.youtube.com/embed/'.$post->youtube_id }}?controls=1&loop=1&playlist={{ $post->youtube_id }}" frameborder="0"></iframe>
-            @else
-                <iframe width="290" height="163.125" src="https://www.youtube.com/embed/" frameborder="0"></iframe>
-            @endif
-        </div>
-        <div class="text-left d-inline-block w-50">
-            @if(isset($searchResults))  <!-- 検索結果表示 -->
-                <p class="mb-2 text-break">{!! preg_replace(
-                    '/[' . preg_quote($searchQuery, '/') . ']/iu', 
-                    '<span style="background-color: yellow;">$0</span>', 
-                    nl2br(e($post->content))
-                ) !!}</p>
-            @else   <!-- 投稿一覧表示 -->
-                <p class="mb-2 text-break">{!! nl2br(e($post->content)) !!}</p>
-            @endif
-            <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
-            @if ($post->replies->count() > 0)
-                <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
-            @endif
-            <p class="text-muted">{{ $post->created_at }}</p>
-        </div>
-        <!-- 各アイコン -->
-        <div class="d-flex justify-content-between w-50 pb-3 m-auto">
-            <!-- 「イイね」 -->
-            <a href="">
-                <i class="fa fa-thumbs-up fa-2x" style="color: black; "></i>
-            </a>
-            <!-- 「リプライ」 -->
-            <a href="{{ route('replies.create',$post) }}">
-                <i class="fa fa-comment fa-2x" style="color: black; "></i>
-            </a>
-            @if(Auth::check() && Auth::id() == $post->user_id)
-                <!-- 投稿編集 -->
-                <a href="{{ route('post.edit',$post->id) }}" >
-                    <i class="fa fa-edit fa-2x" style="color: black; "></i>
+    <ul class="list-unstyled">
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+                @if (isset($post->user->profile_image) && $post->user->profile_image)
+                    <img class="rounded-circle img-fluid" style="max-width: 70px; height: auto;" src="{{ asset('storage/profile_images/' . $post->user->profile_image) }}" alt="ユーザーのプロフィール画像">
+                @else
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                @endif
+                <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
+            </div>
+            <div>
+                @if ($post->youtube_id)
+                    <iframe width="290" height="163.125" src="{{ 'https://www.youtube.com/embed/'.$post->youtube_id }}?controls=1&loop=1&playlist={{ $post->youtube_id }}" frameborder="0"></iframe>
+                @else
+                    <iframe width="290" height="163.125" src="https://www.youtube.com/embed/" frameborder="0"></iframe>
+                @endif
+            </div>
+            <div class="text-left d-inline-block w-50">
+                @if(isset($searchResults))  <!-- 検索結果表示 -->
+                    <p class="mb-2 text-break">{!! preg_replace(
+                        '/[' . preg_quote($searchQuery, '/') . ']/iu', 
+                        '<span style="background-color: yellow;">$0</span>', 
+                        nl2br(e($post->content))
+                    ) !!}</p>
+                @else   <!-- 投稿一覧表示 -->
+                    <p class="mb-2 text-break">{!! nl2br(e($post->content)) !!}</p>
+                @endif
+                <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
+                @if ($post->replies->count() > 0)
+                    <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
+                @endif
+                <p class="text-muted">{{ $post->created_at }}</p>
+            </div>
+            <!-- 各アイコン -->
+            <div class="d-flex justify-content-between w-50 pb-3 m-auto">
+                <!-- 「イイね」 -->
+                <a href="">
+                    <i class="fa fa-thumbs-up fa-2x" style="color: black; "></i>
                 </a>
-                <!-- 投稿削除 -->
-                <form id="delete-form">
-                    <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" data-toggle="modal" data-target="#postDeleteConfirmModal"></i>
-                </form>
-                <div class="modal fade" id="postDeleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h4>確認</h4>
-                            </div>
-                            <div class="modal-body">
-                                <label>本当に削除しますか？</label>
-                            </div>
-                            <div class="modal-footer d-flex justify-content-between">
-                                <form method="POST" action="{{ route('post.delete', $post->id) }}"> 
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-danger">削除する</button>
-                                </form>
-                                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                <!-- 「リプライ」 -->
+                <a href="{{ route('replies.create',$post) }}">
+                    <i class="fa fa-comment fa-2x" style="color: black; "></i>
+                </a>
+                @if(Auth::check() && Auth::id() == $post->user_id)
+                    <!-- 投稿編集 -->
+                    <a href="{{ route('post.edit',$post->id) }}" >
+                        <i class="fa fa-edit fa-2x" style="color: black; "></i>
+                    </a>
+                    <!-- 投稿削除 -->
+                    <form id="delete-form">
+                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" data-toggle="modal" data-target="#postDeleteConfirmModal"></i>
+                    </form>
+                    <div class="modal fade" id="postDeleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h4>確認</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <label>本当に削除しますか？</label>
+                                </div>
+                                <div class="modal-footer d-flex justify-content-between">
+                                    <form method="POST" action="{{ route('post.delete', $post->id) }}"> 
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger">削除する</button>
+                                    </form>
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-            @endif
-        </div>
-    </li>
-</ul>
+                @endif
+            </div>
+        </li>
+    </ul>
 @endforeach
+@if(isset($searchResults))
+    <div class="m-auto" style="width: fit-content">{{ $searchResults->appends(request()->query())->links('pagination::bootstrap-4') }}</div>
+@else
+    <div class="m-auto" style="width: fit-content">{{ $posts->links('pagination::bootstrap-4') }}</div>
+@endif

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -17,10 +17,10 @@
                 <p class="mb-2 text-break">{!! preg_replace(
                     '/[' . preg_quote($searchQuery, '/') . ']/iu', 
                     '<span style="background-color: yellow;">$0</span>', 
-                    $post->content
+                    nl2br(e($post->content))
                 ) !!}</p>
             @else   <!-- 投稿一覧表示 -->
-                <p class="mb-2 text-break">{{ $post->content }}</p>
+                <p class="mb-2 text-break">{!! nl2br(e($post->content)) !!}</p>
             @endif
             <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
             @if ($post->replies->count() > 0)

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -5,64 +5,69 @@
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
             <p class="mt-3 mb-0 d-inline-block"><a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a></p>
         </div>
-        <div class=""> 
-            <div class="text-left d-inline-block w-75">
-                @if(isset($searchResults))  <!-- 検索結果表示 -->
-                    <p class="mb-2 text-break">{!! preg_replace(
-                        '/[' . preg_quote($searchQuery, '/') . ']/iu', 
-                        '<span style="background-color: yellow;">$0</span>', 
-                        $post->content
-                    ) !!}</p>
-                @else   <!-- 投稿一覧表示 -->
-                    <p class="mb-2 text-break">{{ $post->content }}</p>
-                @endif
-                <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
-                @if ($post->replies->count() > 0)
-                    <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
-                @endif
-                <p class="text-muted">{{ $post->created_at }}</p>
-            </div>
-            <!-- 各アイコン -->
-            <div class="d-flex justify-content-between w-50 pb-3 m-auto">
-                <!-- 「イイね」 -->
-                <a href="">
-                    <i class="fa fa-thumbs-up fa-2x" style="color: black; "></i>
+        <div>
+            @if ($post->youtube_id)
+                <iframe width="290" height="163.125" src="{{ 'https://www.youtube.com/embed/'.$post->youtube_id }}?controls=1&loop=1&playlist={{ $post->youtube_id }}" frameborder="0"></iframe>
+            @else
+                <iframe width="290" height="163.125" src="https://www.youtube.com/embed/" frameborder="0"></iframe>
+            @endif
+        </div>
+        <div class="text-left d-inline-block w-50">
+            @if(isset($searchResults))  <!-- 検索結果表示 -->
+                <p class="mb-2 text-break">{!! preg_replace(
+                    '/[' . preg_quote($searchQuery, '/') . ']/iu', 
+                    '<span style="background-color: yellow;">$0</span>', 
+                    $post->content
+                ) !!}</p>
+            @else   <!-- 投稿一覧表示 -->
+                <p class="mb-2 text-break">{{ $post->content }}</p>
+            @endif
+            <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
+            @if ($post->replies->count() > 0)
+                <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
+            @endif
+            <p class="text-muted">{{ $post->created_at }}</p>
+        </div>
+        <!-- 各アイコン -->
+        <div class="d-flex justify-content-between w-50 pb-3 m-auto">
+            <!-- 「イイね」 -->
+            <a href="">
+                <i class="fa fa-thumbs-up fa-2x" style="color: black; "></i>
+            </a>
+            <!-- 「リプライ」 -->
+            <a href="{{ route('replies.create',$post) }}">
+                <i class="fa fa-comment fa-2x" style="color: black; "></i>
+            </a>
+            @if(Auth::check() && Auth::id() == $post->user_id)
+                <!-- 投稿編集 -->
+                <a href="{{ route('post.edit',$post->id) }}" >
+                    <i class="fa fa-edit fa-2x" style="color: black; "></i>
                 </a>
-                <!-- 「リプライ」 -->
-                <a href="{{ route('replies.create',$post) }}">
-                    <i class="fa fa-comment fa-2x" style="color: black; "></i>
-                </a>
-                @if(Auth::check() && Auth::id() == $post->user_id)
-                    <!-- 投稿編集 -->
-                    <a href="{{ route('post.edit',$post->id) }}" >
-                        <i class="fa fa-edit fa-2x" style="color: black; "></i>
-                    </a>
-                    <!-- 投稿削除 -->
-                    <form id="delete-form">
-                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" data-toggle="modal" data-target="#postDeleteConfirmModal"></i>
-                    </form>
-                    <div class="modal fade" id="postDeleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h4>確認</h4>
-                                </div>
-                                <div class="modal-body">
-                                    <label>本当に削除しますか？</label>
-                                </div>
-                                <div class="modal-footer d-flex justify-content-between">
-                                    <form method="POST" action="{{ route('post.delete', $post->id) }}"> 
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="btn btn-danger">削除する</button>
-                                    </form>
-                                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-                                </div>
+                <!-- 投稿削除 -->
+                <form id="delete-form">
+                    <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" data-toggle="modal" data-target="#postDeleteConfirmModal"></i>
+                </form>
+                <div class="modal fade" id="postDeleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h4>確認</h4>
+                            </div>
+                            <div class="modal-body">
+                                <label>本当に削除しますか？</label>
+                            </div>
+                            <div class="modal-footer d-flex justify-content-between">
+                                <form method="POST" action="{{ route('post.delete', $post->id) }}"> 
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-danger">削除する</button>
+                                </form>
+                                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
                             </div>
                         </div>
                     </div>
-                @endif
-            </div>
+                </div>
+            @endif
         </div>
     </li>
 </ul>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -38,20 +38,29 @@
                         <i class="fa fa-edit fa-2x" style="color: black; "></i>
                     </a>
                     <!-- 投稿削除 -->
-                    <form method="POST" action="{{ route('post.delete', $post->id) }}" id="delete-form">
-                        @csrf
-                        @method('DELETE')
-                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete()"></i>
+                    <form id="delete-form">
+                        <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" data-toggle="modal" data-target="#postDeleteConfirmModal"></i>
                     </form>
-                    <script>
-                    function confirmDelete() {
-                        if (confirm('本当に削除しますか？')) {
-                            document.getElementById('delete-form').submit();
-                        } else {
-                            return back();
-                        }
-                    }
-                    </script>
+                    <div class="modal fade" id="postDeleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h4>確認</h4>
+                                </div>
+                                <div class="modal-body">
+                                    <label>本当に削除しますか？</label>
+                                </div>
+                                <div class="modal-footer d-flex justify-content-between">
+                                    <form method="POST" action="{{ route('post.delete', $post->id) }}"> 
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger">削除する</button>
+                                    </form>
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 @endif
             </div>
         </div>

--- a/resources/views/replies/create.blade.php
+++ b/resources/views/replies/create.blade.php
@@ -1,16 +1,16 @@
 @extends('layouts.app')
 @section('content')
-    @include('replies.partials_show', ['post' => $post])
-    <div class="text-center mb-3">
+@include('replies.partials_show', ['post' => $post])
+<div class="text-center mb-3">
     <div class="w-75 m-auto">
         @include('commons.error_messages')
     </div>
-        <form method="post" action="{{ route('replies.store', $post) }}" class="d-inline-block w-75">
-            @csrf
-            <div class="form-group">
-                <textarea name="content" id="content" class="form-control" rows="4" required placeholder="リプライを入力">{{  old('content') }}</textarea>
-            </div>
-            <button type="submit" class="btn btn-primary float-right">投稿</button>
-        </form>
-    </div>
+    <form method="post" action="{{ route('replies.store', $post) }}" class="d-inline-block w-75">
+        @csrf
+        <div class="form-group">
+            <textarea name="content" id="content" class="form-control" rows="4" required placeholder="リプライを入力">{{  old('content') }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary float-right">リプライ</button>
+    </form>
+</div>
 @endsection

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -1,18 +1,18 @@
 @extends('layouts.app')
 @section('content')
-    @include('replies.partials_show', ['post' => $post, 'replyId' => $replyId])
-    <div class="text-center mb-3">
-        <div class="w-75 m-auto">
-            @include('commons.error_messages')
-        </div>
-        <form method="post" action="{{ route('replies.update', ['postId' => $postId, 'replyId' => $replyId]) }}" class="d-inline-block w-75">
-            @csrf
-            @method('PUT')
-            <div class="form-group text-left ">
-                <label for="content">リプライ編集</label>
-                <textarea name="content" id="content" class="form-control" rows="4" required>{{  old('content', $reply->content) }}</textarea>
-            </div>
-            <button type="submit" class="btn btn-primary float-right">更新</button>
-        </form>
+@include('replies.partials_show', ['post' => $post, 'replyId' => $replyId])
+<div class="text-center mb-3">
+    <div class="w-75 m-auto">
+        @include('commons.error_messages')
     </div>
+    <form method="post" action="{{ route('replies.update', ['postId' => $postId, 'replyId' => $replyId]) }}" class="d-inline-block w-75">
+        @csrf
+        @method('PUT')
+        <div class="form-group text-left ">
+            <label for="content">リプライ編集</label>
+            <textarea name="content" id="content" class="form-control" rows="4" required>{{  old('content', $reply->content) }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary float-right">更新</button>
+    </form>
+</div>
 @endsection

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -20,7 +20,7 @@
             @endif
         </div>
         <div class="text-left d-inline-block w-75">
-            <p class="mb-2 text-break">{{ $post->content }}</p>
+            <p class="mb-2 text-break">{!! nl2br(e($post->content)) !!}</p>
             <p class="text-muted">{{ $post->created_at }}</p>
             <div class="container">
                 <label for="content">リプライ一覧</label>
@@ -29,28 +29,20 @@
                         <li class="mb-3">
                             <div class="d-flex">
                                 <div class="mr-2">
-                                @if (isset($reply->user->profile_image) && $reply->user->profile_image)
+                                    @if (isset($reply->user->profile_image) && $reply->user->profile_image)
                                     <img class="rounded-circle" style="max-width: 55px; height: auto;" src="{{ asset('storage/profile_images/' . $reply->user->profile_image) }}" alt="ユーザーのプロフィール画像">
-                                @else
+                                    @else
                                     <img class="rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
-                                @endif                                
+                                    @endif                                
                                 </div>
                                 <div>
                                     <p class="mt-2 mb-2">
                                         <a href="{{ route('users.show', $reply->user->id) }}">{{ $reply->user->name }}</a>
                                         <span class="text-muted ml-2">{{ $reply->created_at }}</span>
                                     </p>
-                                    <p class="mt-0 ml-2">{{ $reply->content }}</p>
+                                    <p class="mt-0 ml-2">{!! nl2br(e($reply->content)) !!}</p>
                                 </div>
                             </div>
-                            <div>
-                                <p class="mt-2 mb-2">
-                                    <a  href="{{ route('users.show',$reply->user_id) }}">{{ $reply->user->name }}</a>
-                                    <span class="text-muted ml-2">{{ $reply->created_at }}</span>
-                                </p>
-                                <p class="mt-0 ml-2">{{ $reply->content }}</p>
-                            </div>
-                        </div>
                         @if(Auth::check() && Auth::id() == $reply->user_id)
                         <div class="d-flex justify-content-between w-50 pb-3 m-auto">
                             <!-- 投稿編集 -->

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -35,20 +35,29 @@
                                 <i class="fa fa-edit fa-2x" style="color: black; "></i>
                             </a>
                             <!-- 投稿削除 -->
-                            <form method="POST" action="{{ route('replies.destroy', ['postId' => $post->id, 'replyId' => $reply->id]) }}" id="delete-form">
-                                @csrf
-                                @method('DELETE')
-                                <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" onclick="confirmDelete()"></i>
+                            <form id="delete-form">
+                                <i class="fa fa-trash fa-2x" style="color: red; cursor: pointer;" data-toggle="modal" data-target="#replyDeleteConfirmModal"></i>
                             </form>
-                            <script>
-                                function confirmDelete() {
-                                    if (confirm('本当に削除しますか？')) {
-                                        document.getElementById('delete-form').submit();
-                                    } else {
-                                        return back();
-                                    }
-                                }
-                            </script>
+                            <div class="modal fade" id="replyDeleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h4>確認</h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <label>本当に削除しますか？</label>
+                                        </div>
+                                        <div class="modal-footer d-flex justify-content-between">
+                                            <form method="POST" action="{{ route('replies.destroy', ['postId' => $post->id, 'replyId' => $reply->id]) }}"> 
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-danger">削除する</button>
+                                            </form>
+                                            <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         @endif    
                     </li>

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -8,6 +8,13 @@
             <a href="{{ route('users.show', $post->user_id) }}">{{ $post->user->name }}</a>
          </p>
         </div>
+        <div>
+            @if ($post->youtube_id)
+                <iframe width="290" height="163.125" src="{{ 'https://www.youtube.com/embed/'.$post->youtube_id }}?controls=1&loop=1&playlist={{ $post->youtube_id }}" frameborder="0"></iframe>
+            @else
+                <iframe width="290" height="163.125" src="https://www.youtube.com/embed/" frameborder="0"></iframe>
+            @endif
+        </div>
         <div class="text-left d-inline-block w-75">
          <p class="mb-2 text-break">{{ $post->content }}</p>
          <p class="text-muted">{{ $post->created_at }}</p>

--- a/resources/views/replies/partials_show.blade.php
+++ b/resources/views/replies/partials_show.blade.php
@@ -6,7 +6,15 @@
                 <a  href="{{ route('users.show',$post->user_id) }}">{{ $post->user->name }}</a>
              </p>
             </div>
+            <div>
+                @if ($post->youtube_id)
+                    <iframe width="290" height="163.125" src="{{ 'https://www.youtube.com/embed/'.$post->youtube_id }}?controls=1&loop=1&playlist={{ $post->youtube_id }}" frameborder="0"></iframe>
+                @else
+                    <iframe width="290" height="163.125" src="https://www.youtube.com/embed/" frameborder="0"></iframe>
+                @endif
+            </div>
             <div class="text-left d-inline-block w-75">
+                <p class="mb-2 text-break">{{ $post->content }}</p>
                 @if ($post->replies->count() > 0)   <!-- リプライが１つ以上の場合、リプライ一覧表示へのリンクを表示 -->
                     <a href="{{ route('replies.index', $post->id) }}">リプライ{{ $post->replies->count() }}件をすべて見る</a>
                 @endif

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -5,7 +5,6 @@
     <form method="POST" action="{{ route('users.update', Auth::user()->id) }}">
         @csrf
         @method('PUT')
-        <!-- <input type="hidden" name="id" value="{{ Auth::user()->id }}" /> -->
         <div class="form-group">
             <label for="name">ユーザ名</label>
             <input class="form-control" value="{{ $errors->any() ? old('name') : Auth::user()->name }}" name="name" />

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,25 +2,27 @@
 @section('content')
 <div class="center jumbotron bg-info">
     <div class="text-center text-white mt-2 pt-1">
-        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>旅・旅行 Topic Posts</h1>
     </div>
 </div>
-<h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+<h3 class="text-center mb-3">旅行の思い出や計画を140字でシェアしよう！</h3>
 @if (Auth::check())
-    <div class="w-75 m-auto">
+<div class="w-75 m-auto">
         @include('commons.error_messages')
+</div>
+
+<form method="POST" action="{{ route('post.store') }}">
+    @csrf
+    <div class="form-group mt-5 mb-5">
+        <p>YouTube動画のURLが<span>https://www.youtube.com/watch?v=-bNMq1Nxn5o</span>ならば、<br>"v="の直後にある<span class="text-success">-bNMq1Nxn5o</span>を入力</p>
+        <input name="youtube_id" id="youtube_id" class="form-control"  required value="{{ old('youtube_id') }}" placeholder="シェアしたいYouTube動画 ”ID”">
+        <textarea class="form-control mt-3" name="content" rows="4"  required placeholder="旅行の思い出や計画を140字でシェアしよう！"></textarea>
+        <button type="submit" class="btn btn-primary mt-3 float-right">
+            <i class="fab fa-telegram fa-2x"></i>
+        </button>
     </div>
-    <div class="text-center mb-3">
-        <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
-            @csrf
-            <div class="form-group">
-                <textarea class="form-control" name="content" rows="4"></textarea>
-                <div class="text-left mt-3">
-                    <button type="submit" class="btn btn-primary">投稿する</button>
-                </div>
-            </div>
-        </form>
-    </div>
+</form>
+
 @endif
 
 @include('posts.posts', ['posts' => $posts])

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -16,7 +16,7 @@
     <div class="form-group mt-5 mb-5">
         <p>YouTube動画のURLが<span>https://www.youtube.com/watch?v=-bNMq1Nxn5o</span>ならば、<br>"v="の直後にある<span class="text-success">-bNMq1Nxn5o</span>を入力</p>
         <input name="youtube_id" id="youtube_id" class="form-control"  required value="{{ old('youtube_id') }}" placeholder="シェアしたいYouTube動画 ”ID”">
-        <textarea class="form-control mt-3" name="content" rows="4"  required placeholder="旅行の思い出や計画を140字でシェアしよう！"></textarea>
+        <textarea class="form-control mt-3" name="content" rows="4"  required placeholder="旅行の思い出や計画を140字でシェアしよう！">{{ old('content') }}</textarea>
         <button type="submit" class="btn btn-primary mt-3 float-right">
             <i class="fab fa-telegram fa-2x"></i>
         </button>


### PR DESCRIPTION
## issue
- Closes #754 

## 動作確認手順

- ログアウト状態
1. 投稿一覧表示　　　：投稿の一覧表示にて動画投稿(YouTube動画ID 共有)も反映されている
2. リプライ投稿　　　：投稿に対してリプライ不可（ログインページへ遷移）
3. リプライ編集　　　：アクセス不可（URLへルーティングを直接入力するとログインページへ遷移）
4. リプライ削除　　　：アクセス不可（URLへルーティングを直接入力するとログインページへ遷移）


- ログイン状態
1. リプライ投稿
動画投稿(Laravel応用講座 模倣)のフォームが表示され、動画投稿(YouTube動画ID 共有)が可能となっていること
2. リプライ編集
投稿一覧表示にて自身投稿の下部に表示された「編集」アイコンをクリックすることで、投稿編集画面へ遷移し、編集可能となる
3. リプライ削除
投稿一覧表示にて自身投稿の下部に表示された「削除」アイコンをクリックすることで、投稿削除画面へ遷移し、削除可能となる
  
## 考慮して欲しいこと
「いいね」機能をじゅんやさんが作業中のため、「いいね」アイコンはルーティング未入力として作成しておりました。