### PR TITLE
#833 共通ファイル & ヘッダー・フッター & トップページ表示（はいしま）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 
-class UsersController extends Controller
+class PostsController extends Controller
 {
     public function index()
     {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class UsersController extends Controller
+{
+    public function index()
+    {
+        return view('welcome');
+    }
+}

--- a/resources/views/commons/footer.blade.php
+++ b/resources/views/commons/footer.blade.php
@@ -1,0 +1,6 @@
+{{-- フッター --}}
+<footer class="mt-5">
+    <nav class="navbar navbar-dark bg-info justify-content-center">
+        <span class="navbar-brand">©Gut Familie, All rights reserved.</span>
+    </nav>
+</footer>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,0 +1,18 @@
+{{-- ヘッダー --}}
+<header class="mb-5">
+    <nav class="navbar navbar-expand-sm navbar-dark bg-info">
+        <a class="navbar-brand" href="/">Topic Posts</a>
+        <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="nav-bar">
+            <ul class="navbar-nav mr-auto"></ul>
+            <ul class="navbar-nav">
+                <li class="nav-item"><a href="" class="nav-link text-light">ログインユーザ名</a></li>
+                <li class="nav-item"><a href="" class="nav-link text-light">ログアウト</a></li>
+                <li class="nav-item"><a href="" class="nav-link text-light">ログイン</a></li>
+                <li class="nav-item"><a href="" class="nav-link text-light">新規ユーザ登録</a></li>
+            </ul>
+        </div>
+    </nav>
+</header>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,28 @@
+{{-- 共通HTML表示 --}}
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="utf-8">
+        <title>Topic Posts</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    </head>
+    <body>
+        {{-- ヘッダー表示 --}}
+        @include('commons.header')
+
+        {{-- 内容表示 --}}
+        <div class="container">
+            @yield('content')
+        </div>
+
+        {{-- フッター表示 --}}
+        @include('commons.footer')
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script defer src="https://use.fontawesome.com/releases/v5.7.2/js/all.js"></script>
+    </body>
+
+</html>
+

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,100 +1,26 @@
-<!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+{{-- トップページ --}}
 
-        <title>Laravel</title>
+{{-- app.blade.phpを継承 --}}
+@extends('layouts.app')
 
-        <!-- Fonts -->
-        <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@200;600&display=swap" rel="stylesheet">
+{{-- 内容 --}}
+@section('content')
+    <div class="center jumbotron bg-info">
+        <div class="text-center text-white mt-2 pt-1">
+            <h1><i class="pr-3"></i>Topic Posts</h1>
+        </div>
+    </div>
+    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
 
-        <!-- Styles -->
-        <style>
-            html, body {
-                background-color: #fff;
-                color: #636b6f;
-                font-family: 'Nunito', sans-serif;
-                font-weight: 200;
-                height: 100vh;
-                margin: 0;
-            }
-
-            .full-height {
-                height: 100vh;
-            }
-
-            .flex-center {
-                align-items: center;
-                display: flex;
-                justify-content: center;
-            }
-
-            .position-ref {
-                position: relative;
-            }
-
-            .top-right {
-                position: absolute;
-                right: 10px;
-                top: 18px;
-            }
-
-            .content {
-                text-align: center;
-            }
-
-            .title {
-                font-size: 84px;
-            }
-
-            .links > a {
-                color: #636b6f;
-                padding: 0 25px;
-                font-size: 13px;
-                font-weight: 600;
-                letter-spacing: .1rem;
-                text-decoration: none;
-                text-transform: uppercase;
-            }
-
-            .m-b-md {
-                margin-bottom: 30px;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="flex-center position-ref full-height">
-            @if (Route::has('login'))
-                <div class="top-right links">
-                    @auth
-                        <a href="{{ url('/home') }}">Home</a>
-                    @else
-                        <a href="{{ route('login') }}">Login</a>
-
-                        @if (Route::has('register'))
-                            <a href="{{ route('register') }}">Register</a>
-                        @endif
-                    @endauth
-                </div>
-            @endif
-
-            <div class="content">
-                <div class="title m-b-md">
-                    Laravel
-                </div>
-
-                <div class="links">
-                    <a href="https://laravel.com/docs">Docs</a>
-                    <a href="https://laracasts.com">Laracasts</a>
-                    <a href="https://laravel-news.com">News</a>
-                    <a href="https://blog.laravel.com">Blog</a>
-                    <a href="https://nova.laravel.com">Nova</a>
-                    <a href="https://forge.laravel.com">Forge</a>
-                    <a href="https://vapor.laravel.com">Vapor</a>
-                    <a href="https://github.com/laravel/laravel">GitHub</a>
+    {{-- 投稿する --}}
+    <div class="text-center mb-3">
+        <form method="" action="" class="d-inline-block w-75">
+            <div class="form-group">
+                <textarea class="form-control" name="" rows=""></textarea>
+                <div class="text-left mt-3">
+                    <button type="submit" class="btn btn-primary">投稿する</button>
                 </div>
             </div>
-        </div>
-    </body>
-</html>
+        </form>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,5 @@
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+//トップページ表示
+Route::get('/', 'UsersController@index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,4 +12,4 @@
 */
 
 //トップページ表示
-Route::get('/', 'UsersController@index');
+Route::get('/', 'PostsController@index');


### PR DESCRIPTION
## issue
- Closes #833 

## 概要
- 共通ファイル & ヘッダー・フッター & トップページ表示を作成

## 動作確認手順

- http://localhost:8080/
接続時に下記の共通ページの表示が正しく実装されているか、確認をお願いします。
1. トップページ
2. ヘッダー
3. フッター


## 考慮してほしいこと
- 前回の作業を見直していく中で、初回の作業ブランチ名を間違えて作成していたことに気づきました。
そこで今回は初回でマージ前なので、自学もかねてローカルのチームブランチを削除して最初からやり直しました。
そのため本コミット履歴には、既にリポジトリでマージされていた林さんのコミットが含まれています。
（作業ファイルが異なるため差分は発生していません）


## 確認してほしいこと
- 前回ご確認いただいた内容（ファイルの権限変更以外）について
指摘いただいた箇所を削除しました。

- ubuntu事案の大量のファイル権限変更について
コンテナ経由で作成した、新規ファイルの権限エラーは相変わらず発生しますが、
今回以降、作成したファイル（ディレクトリ）に対してのみ権限変更することにして様子を見たいと思います。
（※前回はプロジェクト全体に対して権限変更かけていたので）
教えていただいたコマンド（**git config core.filemode false**）のおかげか、
コミット前のステータス確認でも、前回の問題は出ませんでした。