### PR TITLE
ユーザー退会（林）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -8,6 +8,7 @@ class PostsController extends Controller
 {
     public function index()
     {
+        $user=\Auth::user();
         return view('welcome');
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -8,7 +8,6 @@ class PostsController extends Controller
 {
     public function index()
     {
-        $user=\Auth::user();
         return view('welcome');
     }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\User;
+
+class UsersController extends Controller
+{
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id) {
+            $user->delete();
+        }
+        return back();
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,14 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
+
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -45,7 +45,7 @@
                     <label>本当に退会しますか？</label>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
-                    <form action="{{route('user.delete', Auth::user()->id)}}" method="POST">
+                    <form action="{{route('user.delete', $user->id)}}" method="POST">
                         @csrf
                         @method('DELETE')
                         <button type="submit" class="btn btn-danger">退会する</button>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,31 +1,6 @@
-{{-- トップページ --}}
-
-{{-- app.blade.phpを継承 --}}
 @extends('layouts.app')
-
-{{-- 内容 --}}
 @section('content')
-    <div class="center jumbotron bg-info">
-        <div class="text-center text-white mt-2 pt-1">
-            <h1><i class="pr-3"></i>Topic Posts</h1>
-        </div>
-    </div>
-    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-
-    {{-- 投稿する --}}
-    <div class="text-center mb-3">
-        <form method="" action="" class="d-inline-block w-75">
-            <div class="form-group">
-                <textarea class="form-control" name="" rows=""></textarea>
-                <div class="text-left mt-3">
-                    <button type="submit" class="btn btn-primary">投稿する</button>
-                </div>
-            </div>
-        </form>
-    </div>
-
-    @if (Auth::check())
-    <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
     <form method="" action="">
         <input type="hidden" name="id" value="" />
         <div class="form-group">
@@ -64,7 +39,7 @@
                     <label>本当に退会しますか？</label>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
-                    <form action="{{route('user.delete', Auth::id())}}" method="POST">
+                    <form action="{{route('user.delete', Auth::user()->id)}}" method="POST">
                         @csrf
                         @method('DELETE')
                         <button type="submit" class="btn btn-danger">退会する</button>
@@ -74,8 +49,4 @@
             </div>
         </div>
     </div>
-    @else
-    @endif
 @endsection
-
-

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -23,59 +23,6 @@
             </div>
         </form>
     </div>
-
-    @if (Auth::check())
-    <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
-    <form method="" action="">
-        <input type="hidden" name="id" value="" />
-        <div class="form-group">
-            <label for="name">ユーザ名</label>
-            <input class="form-control" value="" name="name" />
-        </div>
-
-        <div class="form-group">
-            <label for="email">メールアドレス</label>
-            <input class="form-control" value="" name="" />
-        </div>
-
-        <div class="form-group">
-            <label for="password">パスワード</label>
-            <input class="form-control" type="password" name="" />
-        </div>
-
-        <div class="form-group">
-            <label for="password_confirmation">パスワードの確認</label>
-            <input class="form-control" type="password" name="" />
-        </div>
-
-        <div class="d-flex justify-content-between">
-            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-            <button type="submit" class="btn btn-primary">更新する</button>
-        </div>
-    </form>
-
-    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4>確認</h4>
-                </div>
-                <div class="modal-body">
-                    <label>本当に退会しますか？</label>
-                </div>
-                <div class="modal-footer d-flex justify-content-between">
-                    <form action="{{route('user.delete', Auth::id())}}" method="POST">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit" class="btn btn-danger">退会する</button>
-                    </form>
-                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-                </div>
-            </div>
-        </div>
-    </div>
-    @else
-    @endif
 @endsection
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,3 +18,10 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 //トップページ表示
 Route::get('/', 'PostsController@index');
+
+//ユーザー退会
+Route::group(['middleware' => 'auth'], function () {
+    Route::prefix('users')->group(function () {
+        Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
+    });
+});


### PR DESCRIPTION
## issue
・closes #823 

## 概要
ユーザー退会機能

## 動作確認
・下記でログイン
メールアドレス：test1@test.com
パスワード：test1
・下記urlにアクセス
http://localhost:8080/users/2/edit
・退会するを押す
・再度上記でログインしようとした際、認証に失敗しましたと出るか確認

## 考慮して欲しいこと
・まだユーザーの投稿を作る機能がないため、ユーザー退会した後、退会したユーザーの投稿が消えるかが不明です。

## 確認して欲しいこと
・おそらく現状で、退会したユーザーの投稿が残り続ける仕様になっていると思うので、投稿も一緒に削除するコードの書き方を教えて欲しいです。

```
//ユーザー退会
    public function destroy($id)
    {
        $user = User::findOrFail($id);
        if (\Auth::id() === $user->id) {
            $user->delete();
        }
        return back();
    }
```
こちらのコードの意味について解説いただきたいです。

