### PR TITLE
検索バーのレスポンシブ表示設定

### DIFF
--- a/resources/views/search/simple_search.blade.php
+++ b/resources/views/search/simple_search.blade.php
@@ -1,5 +1,5 @@
 {{-- 簡易検索（入力フォーム） --}}
-<div class="nav-item navbar-light ml-3">
+<div class="nav-item navbar-light ml-3 d-none d-md-block">
     <form class="form-inline" method="GET" action="{{ route('search.index') }}">
         @csrf
         <input type="text" name="searchContent" value="{{ $searchContent ?? '' }}" placeholder="投稿内容" class="form-control form-control-sm rounded-3 mr-sm-1">
@@ -7,6 +7,6 @@
     </form>
 </div>
 {{-- 詳細検索リンク --}}
-<div class="nav-item">
+<div class="nav-item d-none d-md-block">
     <a class="nav-link text-light" href="{{ route('search.form') }}">詳細検索</a>
 </div >


### PR DESCRIPTION
## issue
- Closes #854
## 概要
- 検索バーのレスポンシブ表示設定

## 動作確認手順
画面の幅を中サイズ以下に狭くしたときに、
ヘッダーの簡易検索バー、検索ボタン、詳細検索リンクが非表示になるよう修正しました。

## 考慮して欲しいこと
特になし