### PR TITLE
いいね機能（はいしま）

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -18,22 +18,11 @@ class Controller extends BaseController
         $totalFavorites = 0;
         foreach ($posts as $post){
             $totalFavorites += $post->favoriteUsers()->count();
-            $countFavoriteUsers = $post->favoriteUsers()->count();
         }
-        // dd($totalFavorites);
         return [
             'countPosts'=>$countPosts,
             'countFavorites'=>$countFavorites,
             'totalFavorites'=>$totalFavorites,
-        ];
-    }
-
-    public function postCounts($post)
-    {
-        $countFavoriteUsers = $post->favoriteUsers()->count();
-        // dd($totalFavorites);
-        return [
-            'countFavoriteUsers'=>$countFavoriteUsers,
         ];
     }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -13,8 +13,8 @@ class Controller extends BaseController
     public function userCounts($user)
     {
         $countPosts = $user->posts()->count();
-        $countFollowing = $user->following()->count();
-        $countFollower = $user->follower()->count();
+        $countFollowings = $user->following()->count();
+        $countFollowers = $user->follower()->count();
 
         $countFavorites = $user->favorites()->count();
         $posts = $user->posts()->get();
@@ -24,8 +24,8 @@ class Controller extends BaseController
         }
         return [
             'countPosts' => $countPosts,
-            'countFollowing' => $countFollowing,
-            'countFollower' => $countFollower,
+            'countFollowings' => $countFollowings,
+            'countFollowers' => $countFollowers,
             'countFavorites' => $countFavorites,
             'totalFavorites' => $totalFavorites
         ];

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -13,6 +13,9 @@ class Controller extends BaseController
     public function userCounts($user)
     {
         $countPosts = $user->posts()->count();
+        $countFollowing = $user->following()->count();
+        $countFollower = $user->follower()->count();
+
         $countFavorites = $user->favorites()->count();
         $posts = $user->posts()->get();
         $totalFavorites = 0;
@@ -20,9 +23,11 @@ class Controller extends BaseController
             $totalFavorites += $post->favoriteUsers()->count();
         }
         return [
-            'countPosts'=>$countPosts,
-            'countFavorites'=>$countFavorites,
-            'totalFavorites'=>$totalFavorites,
+            'countPosts' => $countPosts,
+            'countFollowing' => $countFollowing,
+            'countFollower' => $countFollower,
+            'countFavorites' => $countFavorites,
+            'totalFavorites' => $totalFavorites
         ];
     }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,4 +10,30 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+    public function userCounts($user)
+    {
+        $countPosts = $user->posts()->count();
+        $countFavorites = $user->favorites()->count();
+        $posts = $user->posts()->get();
+        $totalFavorites = 0;
+        foreach ($posts as $post){
+            $totalFavorites += $post->favoriteUsers()->count();
+            $countFavoriteUsers = $post->favoriteUsers()->count();
+        }
+        // dd($totalFavorites);
+        return [
+            'countPosts'=>$countPosts,
+            'countFavorites'=>$countFavorites,
+            'totalFavorites'=>$totalFavorites,
+        ];
+    }
+
+    public function postCounts($post)
+    {
+        $countFavoriteUsers = $post->favoriteUsers()->count();
+        // dd($totalFavorites);
+        return [
+            'countFavoriteUsers'=>$countFavoriteUsers,
+        ];
+    }
 }

--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FavoriteController extends Controller
+{
+    //いいねする
+    public function store($id)
+    {
+        \Auth::user()->favorite($id);
+        return back();
+    }
+    //いいねを外す
+    public function destroy($id)
+    {
+        \Auth::user()->unfavorite($id);
+        return back();
+    }
+}

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -77,17 +77,4 @@ class PostsController extends Controller
         $post->save();
         return redirect('/');
     }
-
-    // public function favorites($id)
-    // {
-    //     $user = User::findOrFail($id);
-    //     $posts = $user->favorites()->paginate(20);
-    //     $data = [
-    //         'user'=>$user,
-    //         'posts'=>$posts
-    //     ];
-
-    //     $data += $this->postCounts($post);
-    //     return view('posts.index',$data);
-    // }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -53,7 +53,7 @@ class PostsController extends Controller
         $post->save();
         return redirect('/');
     }
- 
+
     //投稿作成
 
     public function store(PostRequest $request)
@@ -75,8 +75,19 @@ class PostsController extends Controller
         }
 
         $post->save();
-
-
         return redirect('/');
     }
+
+    // public function favorites($id)
+    // {
+    //     $user = User::findOrFail($id);
+    //     $posts = $user->favorites()->paginate(20);
+    //     $data = [
+    //         'user'=>$user,
+    //         'posts'=>$posts
+    //     ];
+
+    //     $data += $this->postCounts($post);
+    //     return view('posts.index',$data);
+    // }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -79,7 +79,7 @@ class UsersController extends Controller
     public function favorites($id)
     {
         $user = User::findOrFail($id);
-        $posts = $user->favorites()->paginate(20);
+        $posts = $user->favorites()->paginate(9);
         $data = [
             'user'=>$user,
             'posts'=>$posts

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -18,7 +18,6 @@ class UsersController extends Controller
             'posts' => $posts,
         ];
         $data += $this->userCounts($user);
-        // dd($data);
         return view('users.show', $data);
     }
 
@@ -63,7 +62,6 @@ class UsersController extends Controller
             'followings' => $followings,
         ];
         $data += $this->userCounts($user);
-        // dd($data);
         return view('users.show', $data);
     }
 
@@ -77,7 +75,6 @@ class UsersController extends Controller
             'followers' => $followers,
         ];
         $data += $this->userCounts($user);
-        // dd($data);
         return view('users.show', $data);
     }
 
@@ -86,8 +83,9 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
         $posts = $user->favorites()->paginate(9);
         $data = [
-            'user'=>$user,
-            'posts'=>$posts
+            'user' => $user,
+            'posts' => $posts,
+            'favorites' => $posts //お気に入り判定用
         ];
         $data += $this->userCounts($user);
         return view('users.show',$data);

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -18,7 +18,8 @@ class UsersController extends Controller
             'posts' => $posts,
         ];
         $data += $this->userCounts($user);
-        return view('users.show',$data);
+        // dd($data);
+        return view('users.show', $data);
     }
 
     // ユーザ編集画面_表示
@@ -61,6 +62,8 @@ class UsersController extends Controller
             'user' => $user,
             'followings' => $followings,
         ];
+        $data += $this->userCounts($user);
+        // dd($data);
         return view('users.show', $data);
     }
 
@@ -73,6 +76,8 @@ class UsersController extends Controller
             'user' => $user,
             'followers' => $followers,
         ];
+        $data += $this->userCounts($user);
+        // dd($data);
         return view('users.show', $data);
     }
 
@@ -87,4 +92,5 @@ class UsersController extends Controller
         $data += $this->userCounts($user);
         return view('users.show',$data);
     }
+
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -17,6 +17,7 @@ class UsersController extends Controller
             'user' => $user,
             'posts' => $posts,
         ];
+        $data += $this->userCounts($user);
         return view('users.show',$data);
     }
 
@@ -73,5 +74,18 @@ class UsersController extends Controller
             'followers' => $followers,
         ];
         return view('users.show', $data);
+    }
+
+    public function favorites($id)
+    {
+        $user = User::findOrFail($id);
+        $posts = $user->favorites()->paginate(20);
+        $data = [
+            'user'=>$user,
+            'posts'=>$posts
+        ];
+        $data += $this->userCounts($user);
+        // dd($data['totalFavorites']);
+        return view('users.show',$data);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -85,7 +85,6 @@ class UsersController extends Controller
             'posts'=>$posts
         ];
         $data += $this->userCounts($user);
-        // dd($data['totalFavorites']);
         return view('users.show',$data);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -82,7 +82,7 @@ class UsersController extends Controller
     public function favorites($id)
     {
         $user = User::findOrFail($id);
-        $favorites = $user->favorites()->paginate(9);
+        $favorites = $user->favorites()->orderBy('id', 'desc')->paginate(9);
         $data = [
             'user' => $user,
             'favorites' => $favorites

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -78,14 +78,14 @@ class UsersController extends Controller
         return view('users.show', $data);
     }
 
+    // お気に入りの投稿
     public function favorites($id)
     {
         $user = User::findOrFail($id);
-        $posts = $user->favorites()->paginate(9);
+        $favorites = $user->favorites()->paginate(9);
         $data = [
             'user' => $user,
-            'posts' => $posts,
-            'favorites' => $posts //お気に入り判定用
+            'favorites' => $favorites
         ];
         $data += $this->userCounts($user);
         return view('users.show',$data);

--- a/app/Post.php
+++ b/app/Post.php
@@ -17,4 +17,9 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+    //いいねしたユーザー
+    public function favoriteUsers()
+    {
+        return $this->belongsToMany(User::class, 'favorites', 'post_id', 'user_id')->withTimestamps();
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -100,4 +100,37 @@ class User extends Authenticatable
         });
     }
 
+    // いいね機能(favorites/favorite/unfavorite/isFavorite)
+    public function favorites()
+    {
+        return $this->belongsToMany(Post::class, 'favorites', 'user_id', 'post_id')->withTimestamps();
+    }
+
+    public function favorite($postId)
+    {
+        $exist = $this->isFavorite($postId);
+        if ($exist) {
+            return false;
+        } else {
+            $this->favorites()->attach($postId);
+            return true;
+        }
+    }
+
+    public function unfavorite($postId)
+    {
+        $exist = $this->isFavorite($postId);
+        if ($exist) {
+            $this->favorites()->detach($postId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function isFavorite($postId)
+    {
+        return $this->favorites()->where('post_id', $postId)->exists();
+    }
+
 }

--- a/database/migrations/2024_01_14_001624_create_favorites_table.php
+++ b/database/migrations/2024_01_14_001624_create_favorites_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFavoritesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('favorites', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->timestamps();
+            //外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->unique(['user_id','post_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('favorites');
+    }
+}

--- a/resources/views/favorite/favorite_button.blade.php
+++ b/resources/views/favorite/favorite_button.blade.php
@@ -31,3 +31,19 @@
         </div>
     </div>
 </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        // いいねボタンがクリックされた時の処理
+        document.querySelectorAll('.favorite-form').forEach(function(form) {
+            form.addEventListener('submit', function (event) {
+                event.preventDefault(); // デフォルトの挙動を防ぐ
+
+                // ここにいいねボタンが押された時の処理を追加
+
+                // 例えば、Ajaxリクエストを使っていいねの状態を更新する
+                // ここに適切なAjaxのコードを追加
+            });
+        });
+    });
+</script>

--- a/resources/views/favorite/favorite_button.blade.php
+++ b/resources/views/favorite/favorite_button.blade.php
@@ -31,19 +31,3 @@
         </div>
     </div>
 </div>
-
-<script>
-    document.addEventListener('DOMContentLoaded', function () {
-        // いいねボタンがクリックされた時の処理
-        document.querySelectorAll('.favorite-form').forEach(function(form) {
-            form.addEventListener('submit', function (event) {
-                event.preventDefault(); // デフォルトの挙動を防ぐ
-
-                // ここにいいねボタンが押された時の処理を追加
-
-                // 例えば、Ajaxリクエストを使っていいねの状態を更新する
-                // ここに適切なAjaxのコードを追加
-            });
-        });
-    });
-</script>

--- a/resources/views/favorite/favorite_button.blade.php
+++ b/resources/views/favorite/favorite_button.blade.php
@@ -1,0 +1,33 @@
+<!-- Font Awesome -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+
+<style>
+    .icon-invert {
+        color: rgb(85, 172, 47);
+    }
+</style>
+
+<div class="container">
+    <div class="row">
+        <div class="col-1">
+            @if (Auth::check() && Auth::id() !== $post->user_id)
+                @if (Auth::user()->isFavorite($post->id))
+                    <form method="POST" action="{{ route('unfavorite', $post->id) }}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-icon" style="text-align: right">
+                            <i class="fas fa-heart icon-invert"></i>
+                        </button>
+                    </form>
+                @else
+                    <form method="POST" action="{{ route('favorite', $post->id) }}">
+                        @csrf
+                        <button type="submit" class="btn btn-icon" style="text-align: right;">
+                            <i class="far fa-heart icon-invert"></i>
+                        </button>
+                    </form>
+                @endif
+            @endif
+        </div>
+    </div>
+</div>

--- a/resources/views/favorite/favorites.blade.php
+++ b/resources/views/favorite/favorites.blade.php
@@ -1,0 +1,37 @@
+<ul class="list-unstyled">
+    @foreach ($posts as $post)
+        <li class="mb-3 text-center pr-5 pl-5">
+        <div class="row text-center">
+            <div class="col-6 text-left d-inline-block mb-2">
+                <p class="mt-3 mb-0 d-inline-block">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                    <a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a>
+                </p>
+            </div>
+            @php
+                $countFavoriteUsers = $post->favoriteUsers()->count();
+            @endphp
+            <div class="col-6 text-right mt-4">いいね！
+                <span class="badge badge-pill badge-success">{{ $countFavoriteUsers }}</span>
+                <div class="d-inline-block">
+                    @include('favorite.favorite_button',['post'=>$post])
+                </div>
+            </div>
+        </div>
+            <div class="">
+                <div class="text-left d-inline-block w-75">
+                    <p class="mb-2">{{$post->content}}</p>
+                        <div class="text-left mb-3">
+                            @if(isset($post->img_path))
+                            <img src="{{ Storage::url($post->img_path) }}" width="25%">
+                            @endif
+                        </div>
+                    <p class="text-muted">{{$post->created_at}}</p>
+                </div>
+            </div>
+        </li>
+    @endforeach
+</ul>
+<div class="m-auto" style="width: fit-content">
+    {{ $posts->appends(request()->query())->links('pagination::bootstrap-4') }}
+</div>

--- a/resources/views/favorite/favorites.blade.php
+++ b/resources/views/favorite/favorites.blade.php
@@ -1,5 +1,5 @@
 <ul class="list-unstyled">
-    @foreach ($posts as $post)
+    @foreach ($favorites as $post)
         <li class="mb-3 text-center pr-5 pl-5">
         <div class="row text-center">
             <div class="col-6 text-left d-inline-block mb-2">
@@ -18,20 +18,18 @@
                 </div>
             </div>
         </div>
-            <div class="">
-                <div class="text-left d-inline-block w-75">
-                    <p class="mb-2">{{$post->content}}</p>
-                        <div class="text-left mb-3">
-                            @if(isset($post->img_path))
-                            <img src="{{ Storage::url($post->img_path) }}" width="25%">
-                            @endif
-                        </div>
-                    <p class="text-muted">{{$post->created_at}}</p>
-                </div>
+            <div class="text-left d-inline-block w-75">
+                <p class="mb-2">{{$post->content}}</p>
+                    <div class="text-left mb-3">
+                        @if(isset($post->img_path))
+                        <img src="{{ Storage::url($post->img_path) }}" width="25%">
+                        @endif
+                    </div>
+                <p class="text-muted">{{$post->created_at}}</p>
             </div>
         </li>
     @endforeach
 </ul>
 <div class="m-auto" style="width: fit-content">
-    {{ $posts->appends(request()->query())->links('pagination::bootstrap-4') }}
+    {{ $favorites->appends(request()->query())->links('pagination::bootstrap-4') }}
 </div>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -5,8 +5,19 @@
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
                 <p class="mt-3 mb-0 d-inline-block">
                     <a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a>
+                    @php
+                        $countFavoriteUsers = $post->favoriteUsers()->count();
+                    @endphp
+                    <div class="text-right">いいね！
+                        <span class="badge badge-pill badge-success">{{ $countFavoriteUsers }}</span>
+                    </div>
                 </p>
             </div>
+
+            <div class="d-inline-block">
+                @include('favorite.favorite_button',['post'=>$post])
+            </div>
+
             <div class="">
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{$post->content}}</p>
@@ -32,5 +43,5 @@
     @endforeach
 </ul>
 <div class="m-auto" style="width: fit-content">
-    {{ $posts->appends(request()->query())->links('pagination::bootstrap-4') }}
+{{ $posts->appends(request()->query())->links('pagination::bootstrap-4') }}
 </div>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -1,22 +1,24 @@
 <ul class="list-unstyled">
     @foreach ($posts as $post)
-        <li class="mb-3 text-center">
-            <div class="text-left d-inline-block w-75 mb-2">
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+        <li class="mb-3 text-center pr-5 pl-5">
+        <div class="row text-center">
+            <div class="col-6 text-left d-inline-block mb-2">
                 <p class="mt-3 mb-0 d-inline-block">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
                     <a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a>
-                    @php
-                        $countFavoriteUsers = $post->favoriteUsers()->count();
-                    @endphp
-                    <div class="text-right">いいね！
-                        <span class="badge badge-pill badge-success">{{ $countFavoriteUsers }}</span>
-                    </div>
                 </p>
             </div>
-
-            <div class="d-inline-block">
-                @include('favorite.favorite_button',['post'=>$post])
+            @php
+                $countFavoriteUsers = $post->favoriteUsers()->count();
+            @endphp
+            <div class="col-6 text-right mt-4">いいね！
+                <span class="badge badge-pill badge-success">{{ $countFavoriteUsers }}</span>
+                <div class="d-inline-block">
+                    @include('favorite.favorite_button',['post'=>$post])
+                </div>
             </div>
+        </div>
+
 
             <div class="">
                 <div class="text-left d-inline-block w-75">

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -43,5 +43,5 @@
     @endforeach
 </ul>
 <div class="m-auto" style="width: fit-content">
-{{ $posts->appends(request()->query())->links('pagination::bootstrap-4') }}
+    {{ $posts->appends(request()->query())->links('pagination::bootstrap-4') }}
 </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -18,19 +18,46 @@
                     @endif
                     <div class="text-center mt-3">@include('follow.follow_button')</div>
                 </div>
+                <div class="text-right">
+                    <span class="badge badge-pill badge-success">獲得いいね！：{{ $totalFavorites }}</span>
+                </div>
             </div>
+
 
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
-                <li class="nav-item"><a href="{{route('user.show',$user->id)}}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">タイムライン</a></li>
-                <li class="nav-item"><a href="{{route('user.followings',$user->id)}}" class="nav-link {{ Request::routeIs('user.followings') ? 'active' : '' }}">フォロー中</a></li>
-                <li class="nav-item"><a href="{{route('user.followers',$user->id)}}" class="nav-link {{ Request::routeIs('user.followers') ? 'active' : '' }}">フォロワー</a></li>
+                <li class="nav-item">
+                    <a href="{{route('user.show',$user->id)}}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">
+                        タイムライン <div class="badge badge-secondary">{{ $countPosts }}</div>
+                    </a>
+                </li>
+
+                <li class="nav-item">
+                    <a href="{{route('user.favorites',$user->id)}}" class="nav-link {{ Request::routeIs('user.favorites') ? 'active' : '' }}">
+                        お気に入り <div class="badge badge-secondary">{{ $countFavorites }}</div>
+                    </a>
+                </li>
+
+                <li class="nav-item">
+                    <a href="{{route('user.followings',$user->id)}}" class="nav-link {{ Request::routeIs('user.followings') ? 'active' : '' }}">
+                        フォロー中
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="{{route('user.followers',$user->id)}}" class="nav-link {{ Request::routeIs('user.followers') ? 'active' : '' }}">
+                        フォロワー
+                    </a>
+                </li>
             </ul>
+
+            {{-- なぜ必要？ --}}
             @if(isset($followers))
                 @include('follow.followers' , [ 'followers' => $followers])
             @elseif(isset($followings))
                 @include('follow.followings' , ['followings' => $followings])
+            {{-- @elseif(isset($favorites))
+                @include('users.favorites' , ['favorites' => $favorites]) --}}
             @else
                 @include('posts.index' , ['user' => $user, 'posts' => $posts])
             @endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,8 +19,7 @@
                     <div class="text-center mt-3">@include('follow.follow_button')</div>
                 </div>
                 <div class="text-right">
-                    {{-- @php dd($totalFavorites); @endphp --}}
-                    <span class="badge badge-pill badge-success">獲得いいね！：{{ 'totalFavorites' }}</span>
+                    <span class="badge badge-pill badge-success">獲得いいね！：{{ $totalFavorites }}</span>
                 </div>
             </div>
 
@@ -29,28 +28,23 @@
             <ul class="nav nav-tabs nav-justified mb-3">
                 <li class="nav-item">
                     <a href="{{route('user.show',$user->id)}}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">
-                        {{-- タイムライン <div class="badge badge-secondary">{{ $countPosts }}</div> --}}
-
                         タイムライン( {{ $countPosts }} )
                     </a>
                 </li>
 
                 <li class="nav-item">
                     <a href="{{route('user.favorites',$user->id)}}" class="nav-link {{ Request::routeIs('user.favorites') ? 'active' : '' }}">
-                        {{-- お気に入り <div class="badge badge-secondary">{{ $countFavorites }}</div> --}}
                         お気に入り({{ $countFavorites }})
                     </a>
                 </li>
 
                 <li class="nav-item">
                     <a href="{{route('user.followings',$user->id)}}" class="nav-link {{ Request::routeIs('user.followings') ? 'active' : '' }}">
-                        {{-- @php dd($countFollowings); @endphp --}}
                         フォロー中({{ $countFollowings }})
                     </a>
                 </li>
                 <li class="nav-item">
                     <a href="{{route('user.followers',$user->id)}}" class="nav-link {{ Request::routeIs('user.followers') ? 'active' : '' }}">
-                        {{-- @php dd($countFollowers); @endphp --}}
                         フォロワー({{ $countFollowers }})
                     </a>
                 </li>
@@ -60,8 +54,10 @@
                 @include('follow.followers' , [ 'followers' => $followers])
             @elseif(isset($followings))
                 @include('follow.followings' , ['followings' => $followings])
+            @elseif(isset($favorites))
+                @include('favorite.favorites' , ['posts' => $posts])
             @else
-                @include('posts.index' , ['user' => $user, 'posts' => $posts])
+                @include('posts.index' , ['posts' => $posts])
             @endif
         </div>
     </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -55,7 +55,7 @@
             @elseif(isset($followings))
                 @include('follow.followings' , ['followings' => $followings])
             @elseif(isset($favorites))
-                @include('favorite.favorites' , ['posts' => $posts])
+                @include('favorite.favorites' , ['favorites' => $favorites])
             @else
                 @include('posts.index' , ['posts' => $posts])
             @endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,45 +19,47 @@
                     <div class="text-center mt-3">@include('follow.follow_button')</div>
                 </div>
                 <div class="text-right">
-                    <span class="badge badge-pill badge-success">獲得いいね！：{{ $totalFavorites }}</span>
+                    {{-- @php dd($totalFavorites); @endphp --}}
+                    <span class="badge badge-pill badge-success">獲得いいね！：{{ 'totalFavorites' }}</span>
                 </div>
             </div>
-
 
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
                 <li class="nav-item">
                     <a href="{{route('user.show',$user->id)}}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">
-                        タイムライン <div class="badge badge-secondary">{{ $countPosts }}</div>
+                        {{-- タイムライン <div class="badge badge-secondary">{{ $countPosts }}</div> --}}
+
+                        タイムライン( {{ $countPosts }} )
                     </a>
                 </li>
 
                 <li class="nav-item">
                     <a href="{{route('user.favorites',$user->id)}}" class="nav-link {{ Request::routeIs('user.favorites') ? 'active' : '' }}">
-                        お気に入り <div class="badge badge-secondary">{{ $countFavorites }}</div>
+                        {{-- お気に入り <div class="badge badge-secondary">{{ $countFavorites }}</div> --}}
+                        お気に入り({{ $countFavorites }})
                     </a>
                 </li>
 
                 <li class="nav-item">
                     <a href="{{route('user.followings',$user->id)}}" class="nav-link {{ Request::routeIs('user.followings') ? 'active' : '' }}">
-                        フォロー中
+                        {{-- @php dd($countFollowings); @endphp --}}
+                        フォロー中({{ $countFollowings }})
                     </a>
                 </li>
                 <li class="nav-item">
                     <a href="{{route('user.followers',$user->id)}}" class="nav-link {{ Request::routeIs('user.followers') ? 'active' : '' }}">
-                        フォロワー
+                        {{-- @php dd($countFollowers); @endphp --}}
+                        フォロワー({{ $countFollowers }})
                     </a>
                 </li>
             </ul>
 
-            {{-- なぜ必要？ --}}
             @if(isset($followers))
                 @include('follow.followers' , [ 'followers' => $followers])
             @elseif(isset($followings))
                 @include('follow.followings' , ['followings' => $followings])
-            {{-- @elseif(isset($favorites))
-                @include('users.favorites' , ['favorites' => $favorites]) --}}
             @else
                 @include('posts.index' , ['user' => $user, 'posts' => $posts])
             @endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,6 +12,7 @@
 
     @if(Auth::check())
     {{-- 投稿する --}}
+    <div class="container text-left">
         <div class="text-center mb-3">
             <form method="POST" action="{{ route('createPost') }}" class="d-inline-block w-75" enctype="multipart/form-data">
                 @csrf {{-- CSRFトークンを追加 --}}
@@ -19,6 +20,7 @@
                 @include('commons.flash_message')
                 <div class="form-group">
                     @include('commons.error_messages')
+
                     <textarea class="form-control" name="content" rows="2">{{ old('content') }}</textarea>
                     <div class ="text-center mt-3">
                         <input type="file" name="img_path" accept=".jpg, .png">
@@ -26,16 +28,17 @@
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-primary">投稿する</button>
                     </div>
-                </?div>
+                </div>
             </form>
         </div>
+    </div>
     @endif
     {{-- 投稿一覧 --}}
-    @if($posts->isEmpty())
+        @if($posts->isEmpty())
         <p class="text-danger">検索結果：0件</p>
-    @else
+        @else
         @include('posts.index', ['posts' => $posts])
-    @endif
+        @endif
 @endsection
 
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -34,11 +34,11 @@
     </div>
     @endif
     {{-- 投稿一覧 --}}
-        @if($posts->isEmpty())
+    @if($posts->isEmpty())
         <p class="text-danger">検索結果：0件</p>
-        @else
+    @else
         @include('posts.index', ['posts' => $posts])
-        @endif
+    @endif
 @endsection
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,8 @@ Route::group(['prefix' => 'users/{id}'],function(){
     Route::get('', 'UsersController@show')->name('user.show');
     Route::get('followings','UsersController@followings')->name('user.followings');
     Route::get('followers','UsersController@followers')->name('user.followers');
+    Route::get('favorites','UsersController@favorites')->name('user.favorites');
+
 });
 
 // ログイン後
@@ -50,9 +52,14 @@ Route::group(['middleware' => 'auth'], function(){
         //新規投稿作成
         Route::post('/', 'PostsController@store')->name('createPost');
     });
-});
     //フォロー機能
     Route::group(['prefix' => 'users/{id}'],function(){
         Route::post('follow','FollowController@store')->name('follow');
         Route::delete('unfollow','FollowController@destroy')->name('unfollow');
     });
+    // いいね
+    Route::group(['prefix'=> 'posts/{id}'],function(){
+        Route::post('favorite','FavoriteController@store')->name('favorite');
+        Route::delete('unfavorite','FavoriteController@destroy')->name('unfavorite');
+    });
+});


### PR DESCRIPTION
## issue
- Closes #860
## 概要
- いいね機能

## 動作確認手順

- favoritesテーブルを新規作成したため、マイグレーションをfresh してください

- トップページの投稿一覧：各投稿に「いいね！」された件数と、「いいね！」する/解除ボタン（ハートアイコン）が表示される
但しログイン後は自分の投稿には、「いいね！」する/解除ボタン（ハートアイコン）は表示されない
- ユーザー詳細画面：「タイムライン」、「お気に入り」タブに件数が表示される
- 「タイムライン」：（トップページと同様）各投稿に「いいね！」数が表示される
- 「お気に入り」：ユーザーが「いいね！」した投稿が表示され、「いいね！」数と、「いいね！」する/解除ボタン（ハートアイコン）が表示される
- 詳細画面のユーザーアイコン下部に、ユーザーが獲得した合計「いいね！」数が表示される

## 考慮して欲しいこと
- トップページの各投稿のユーザーアイコンの表示を揃えたいのですが、うまくいきません。
- 「いいね！」関連のボタンをユーザーアイコンと同列で、右寄表示させたいのですが、こちらもうまくいきませんでした。どのようにスタイルの設定を記載すればよいでしょうか。

- 詳細画面の「お気に入り」タブの投稿表示について、show.blade.php の下部で@if文で条件分岐している箇所の@include('users.favorites' , ['favorites' => $favorites]) --}}について、一旦コメントアウトしています。
なぜこれで問題なく表示できているのかが分かりません。
また、タブの切り替え部分でルーティングを記載しているのに、ここではなんのために条件分岐を記載しているのでしょうか。

- favorites()メソッドは、UsersControllerとUser.phpモデルの両方に favorites() として、同名で定義しています。
モデルの方はリレーション設定ですが、同名でも問題はないでしょうか。