### PR TITLE
#906 ユーザ編集画面・更新(近藤佑哉)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Models\User;
+use App\Http\Requests\UserRequest;
 
 class UsersController extends Controller
 {
@@ -12,28 +12,16 @@ class UsersController extends Controller
         return view('welcome');
     }
 
-    // public function show() {
-    //     $user = User::findOrFail($id);
-    //     return view('users.show', compact('user'));
-    // }
-
-    public function edit() {
+    public function edit($id) {
         $user = \Auth::user();
-        return view('users.edit', ['user' => $user]);
+
+        if (\Auth::check() && \Auth::id() == $id) {
+            return view('users.edit', ['user' => $user]);
+        }
+        abort(404);
     }
 
-    public function update(Request $request) {
-        // バリデーションルールを定義
-        $rules = [
-            'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:users,email,'.\Auth::id(),
-            'password' => 'nullable|string|min:8|confirmed',
-        ];
-    
-        // バリデーションを実行
-        $validatedData = $request->validate($rules);
-    
-        // ユーザー情報を更新
+    public function update(UserRequest $request, $id) {   
         $user = \Auth::user();
         $user->name = $request->input('name');
         $user->email = $request->input('email');
@@ -41,19 +29,6 @@ class UsersController extends Controller
             $user->password = bcrypt($request->input('password'));
         }
         $user->save();
-    
-        return view('users.detail');
+        return redirect()->route('users.edit', ['id' => $user->id]);
     }
-    
-    public function delete(Request $request) {
-        if (\Auth::check()) {
-            $user = \Auth::user();
-            $user->delete();
-    
-            \Auth::logout();
-        }
-    
-        return redirect('/');
-    }
-    
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\User;
 use App\Http\Requests\UserRequest;
 
 class UsersController extends Controller
@@ -22,7 +23,7 @@ class UsersController extends Controller
     }
 
     public function update(UserRequest $request, $id) {   
-        $user = \Auth::user();
+        $user = User::find($id);
         $user->name = $request->input('name');
         $user->email = $request->input('email');
         if ($request->filled('password')) {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\User;
 
 class UsersController extends Controller
 {
@@ -10,4 +11,49 @@ class UsersController extends Controller
     {
         return view('welcome');
     }
+
+    // public function show() {
+    //     $user = User::findOrFail($id);
+    //     return view('users.show', compact('user'));
+    // }
+
+    public function edit() {
+        $user = \Auth::user();
+        return view('users.edit', ['user' => $user]);
+    }
+
+    public function update(Request $request) {
+        // バリデーションルールを定義
+        $rules = [
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users,email,'.\Auth::id(),
+            'password' => 'nullable|string|min:8|confirmed',
+        ];
+    
+        // バリデーションを実行
+        $validatedData = $request->validate($rules);
+    
+        // ユーザー情報を更新
+        $user = \Auth::user();
+        $user->name = $request->input('name');
+        $user->email = $request->input('email');
+        if ($request->filled('password')) {
+            $user->password = bcrypt($request->input('password'));
+        }
+        $user->save();
+    
+        return view('users.detail');
+    }
+    
+    public function delete(Request $request) {
+        if (\Auth::check()) {
+            $user = \Auth::user();
+            $user->delete();
+    
+            \Auth::logout();
+        }
+    
+        return redirect('/');
+    }
+    
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|',
+            'password' => 'required|string|min:8|confirmed',
+        ];
+    }
+}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,56 @@
+@extends('layouts.app')
+@section('content')
+    <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+    @if(Auth::check())
+        <form method="POST" action="{{ route('users.update', ['id' => Auth::id()]) }}">
+            @csrf
+            @method('PUT')
+            <input type="hidden" name="id" value="{{ Auth::id() }}" />
+            @include('commons.error_messages')
+            <div class="form-group">
+                <label for="name">ユーザ名</label>
+                <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
+            </div>
+            <div class="form-group">
+                <label for="email">メールアドレス</label>
+                <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
+            </div>
+            <div class="form-group">
+                <label for="password">パスワード</label>
+                <input class="form-control" type="password" name="password" />
+            </div>
+            <div class="form-group">
+                <label for="password_confirmation">パスワードの確認</label>
+                <input class="form-control" type="password" name="password_confirmation" />
+            </div>
+
+            <div class="d-flex justify-content-between">
+                <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+                <button type="submit" class="btn btn-primary">更新する</button>
+            </div>
+        </form>
+    @endif
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    @if(Auth::check())
+                        <form method="POST" action="{{ route('users.delete', ['id' => Auth::id()]) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">退会する</button>
+                        </form>
+                        <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,56 +1,30 @@
 @extends('layouts.app')
 @section('content')
     <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
-    @if(Auth::check())
-        <form method="POST" action="{{ route('users.update', ['id' => Auth::id()]) }}">
-            @csrf
-            @method('PUT')
-            <input type="hidden" name="id" value="{{ Auth::id() }}" />
-            @include('commons.error_messages')
-            <div class="form-group">
-                <label for="name">ユーザ名</label>
-                <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
-            </div>
-            <div class="form-group">
-                <label for="email">メールアドレス</label>
-                <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
-            </div>
-            <div class="form-group">
-                <label for="password">パスワード</label>
-                <input class="form-control" type="password" name="password" />
-            </div>
-            <div class="form-group">
-                <label for="password_confirmation">パスワードの確認</label>
-                <input class="form-control" type="password" name="password_confirmation" />
-            </div>
-
-            <div class="d-flex justify-content-between">
-                <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-                <button type="submit" class="btn btn-primary">更新する</button>
-            </div>
-        </form>
-    @endif
-
-    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4>確認</h4>
-                </div>
-                <div class="modal-body">
-                    <label>本当に退会しますか？</label>
-                </div>
-                <div class="modal-footer d-flex justify-content-between">
-                    @if(Auth::check())
-                        <form method="POST" action="{{ route('users.delete', ['id' => Auth::id()]) }}">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-danger">退会する</button>
-                        </form>
-                        <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-                    @endif
-                </div>
-            </div>
+    <form method="POST" action="{{ route('users.update', ['id' => Auth::id()]) }}">
+        @csrf
+        @method('PUT')
+        @include('commons.error_messages')
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
         </div>
-    </div>
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
+        </div>
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password_confirmation" />
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+    </form>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,3 +16,11 @@ Route::get('/', 'UsersController@index');
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
+
+// ユーザ編集・更新
+Route::group(['prefix' => 'users'],function(){
+    // Route::get('', 'UsersController@show')->name('user.show');
+    Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
+    Route::put('{id}', 'UsersController@update')->name('users.update');
+    Route::delete('{id}', 'UsersController@delete')->name('users.delete');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,6 @@ Route::group(['prefix' => 'users'],function(){
     // Route::get('', 'UsersController@show')->name('user.show');
     Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
     Route::put('{id}', 'UsersController@update')->name('users.update');
-    Route::delete('{id}', 'UsersController@delete')->name('users.delete');
 });
 // ログイン
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');


### PR DESCRIPTION
## issue
 - Close #906
 
## 概要
 - ユーザ編集画面・更新
 
## 動作確認手順
 - ユーザ情報更新
① localhost:8080/users/{{ id }}/editでユーザ情報を編集するhtmlを出力
② 更新するボタンを押してユーザ情報が変わっていることを確認
③ ユーザ情報、メールアドレス、パスワードのいずれかが空白、パスワードが一致しない事でバリデーションエラーが出力されることを確認

 - ユーザ情報削除
退会するボタンからモーダルの退会するボタンをクリックしてwelcome.blade.phpへ遷移することを確認

## 考慮してほしいこと
 - 本来は更新するボタンをクリックした際にユーザ詳細画面へ遷移するかと思うのですが、設定していないためエラーが起こると考えられます。今回はあらかじめ設定しておきました。
 UserController.php 45行目 ```return view('users.detail');```

 - テストとしてwelcome.blade.phpに設定してユーザ名、メールアドレス、パスワードが変更していることを確認できました。
 
## 確認してほしいこと
- 考慮して欲しいことに記載した部分の動作確認をお願い致します。
```return view('users.detail');```
↓
```return view('welcome');```