### PR TITLE
#903 投稿編集画面・更新(近藤佑哉)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -31,6 +31,6 @@ class PostsController extends Controller
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
         $post->save();
-        return redirect('/');
+        return redirect('/')->with('success', '投稿を更新しました！');
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -15,4 +15,22 @@ class PostsController extends Controller
         $posts->save();
         return back();
     }
+
+    public function edit($id) {
+        $user = \Auth::user();
+        $post = Post::findOrFail($id);
+    
+        if (\Auth::check() && \Auth::id() == $post->user_id) {
+            return view('posts.edit', ['post' => $post]);
+        }
+        abort(404);
+    }
+
+    public function update(PostRequest $request, $id) {
+        $post = Post::findOrFail($id);
+        $post->content = $request->content;
+        $post->user_id = $request->user()->id;
+        $post->save();
+        return redirect()->route('post.edit', ['id' => $post->id])->with('success', '投稿を更新しました！');
+    }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -31,6 +31,6 @@ class PostsController extends Controller
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
         $post->save();
-        return redirect()->route('post.edit', ['id' => $post->id])->with('success', '投稿を更新しました！');
+        return redirect('/');
     }
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.app')
+@section('content')
+    <h2 class="mt-5">投稿を編集する</h2>
+    <form method="POST" action="{{ route('post.update', ['id' => $post->id]) }}">
+        @csrf
+        @method('PUT')
+        @include('commons.error_messages')
+        @if(session('success'))
+            <div class="alert alert-success">
+                {{ session('success') }}
+            </div>
+        @endif
+        <div class="form-group">
+            <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </form>
+@endsection 

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -5,11 +5,6 @@
         @csrf
         @method('PUT')
         @include('commons.error_messages')
-        @if(session('success'))
-            <div class="alert alert-success">
-                {{ session('success') }}
-            </div>
-        @endif
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
         </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,6 +9,11 @@
 @if(Auth::check())
     <div class="w-75 m-auto">@include('commons.error_messages')</div>
     <div class="text-center mb-3">
+        @if(session('success'))
+            <div class="alert alert-success">
+                {{ session('success') }}
+            </div>
+        @endif
         <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
             @csrf
             <div class="form-group">

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,8 @@ Route::group(['middleware' => 'auth'], function () {
     // 投稿
     Route::prefix('posts')->group(function () {
         Route::post('/', 'PostsController@store')->name('post.store');
+        Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
+        Route::put('{id}', 'PostsController@update')->name('post.update');
     });
     // ユーザ編集・更新
     Route::group(['prefix' => 'users'],function(){


### PR DESCRIPTION
## issue
 - Closes #903 
## 概要
 - 投稿編集画面・更新
## 動作確認手順
 - ログインユーザの投稿のidをurlに入れる
(例→localhost:8080/posts/{$id}/edit)
- 投稿していた文章を書き換えて更新するボタンをクリックするとフラッシュメッセージで「投稿を更新しました！」と表示
- Adminerで選択された投稿内容が更新されているか確認
- ログインユーザではない投稿のurlにアクセスすると404エラー画面に遷移
## 考慮してほしいこと
 - ユーザ詳細ページがマージされていないため、更新するボタンをクリックして更新成功するとフラッシュメッセージで「投稿を更新しました！」と表示させています。
## 確認してほしいこと
 - 更新内容がAminerにて更新されているか確認お願い致します。