### PR TITLE
#902ユーザ退会(西田）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -27,4 +27,13 @@ class UsersController extends Controller
         $user->save();
         return back();
     }
+
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() == $user->id) {
+            $user->delete();
+        }
+        return back();
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,12 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public static function boot()
+    {
+        parent::boot();
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -44,7 +44,9 @@
                 <label>本当に退会しますか？</label>
               </div>
               <div class="modal-footer d-flex justify-content-between">
-                  <form action="" method="POST">
+                  <form action="{{ route('user.delete', $user->id) }}" method="POST">
+                    @csrf
+                    @method('DELETE')
                       <button type="submit" class="btn btn-danger">退会する</button>
                   </form>
                   <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('users')->group(function () {
         Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
         Route::put('{id}', 'UsersController@update')->name('user.update');
+        Route::delete('{id}','UsersController@destroy')->name('user.delete');
     });
 });
 


### PR DESCRIPTION
## 概要
- #902ユーザ退会

## 動作確認手順
- 下記urlにアクセスし、ユーザ編集画面表示する。
http://localhost:8080/users/（ユーザid）/edit
- ”退会する”ボタンをクリック、次画面で表示される”退会するボタン”をクリック
- データベースAdminer のusersテーブル及びpostsテーブルの”deleted_at”カラムに、論理削除日時が反映されているかを確認

## 考慮してほしいこと
特にありません。

## 確認してほしいこと
ユーザ退会に連動して投稿を論理削除の場合には、ネットで調べたところ、userモデルに下記のメソッドを入れる必要があるようでした。

```
public static function boot()
    {
        parent::boot();
        static::deleted(function ($user) {
            $user->posts()->delete();
        });
    }
```

物理削除の場合には、マイグレーションファイルで外部キー制約をかければ、モデルファイルには特に上記コードのような記述は必要ないようでした。