### PR TITLE
投稿削除機能(チームＤ井手)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -41,4 +41,12 @@ class PostsController extends Controller
         $post->save();
         return redirect('/')->with('success', '投稿を更新しました！');
     }
+
+    public function destroy($id) {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
+            $post->delete();
+        }
+        return back();
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -39,14 +39,4 @@ class UsersController extends Controller
         $user->save();
         return redirect()->route('users.edit', ['id' => $user->id]);
     }
-
-    public function destroy($id)
-    {
-        if ($id === Auth::id()) {
-            $user = User::findOrFail($id);
-            $user->delete();
-            return redirect('/');
-        }
-        abort(404);
-    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -39,4 +39,14 @@ class UsersController extends Controller
         $user->save();
         return redirect()->route('users.edit', ['id' => $user->id]);
     }
+
+    public function destroy($id)
+    {
+        if ($id === Auth::id()) {
+            $user = User::findOrFail($id);
+            $user->delete();
+            return redirect('/');
+        }
+        abort(404);
+    }
 }

--- a/resources/views/posts.blade.php
+++ b/resources/views/posts.blade.php
@@ -13,8 +13,8 @@
             </div>
             <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                 <!-- 本人の場合、削除と編集するボタンを表示 -->
-                @if(Auth::check() && Auth::user()->id == $post->user->id)
-                    <form method="POST" action="{{ route('users.update', ['id' => Auth::id()]) }}">
+                @if(Auth::id() === $post->user_id)
+                    <form method="POST" action="{{ route('post.delete', $post->id) }}">
                         @csrf
                         @method('DELETE')
                         <button type="submit" class="btn btn-danger">削除</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('/', 'PostsController@store')->name('post.store');
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
+        Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
     // ユーザ編集・更新・フォロー
     Route::group(['prefix' => 'users'],function(){


### PR DESCRIPTION
## issue
 - Closes #904
## 概要
 - 投稿を削除できるようになる
## 動作確認手順
 - ログインをしてから、任意の投稿を「削除」ボタンを押して表示しないようにする。
## 考慮してほしいこと
 - 今回は特にありません。
## 確認してほしいこと
 - 投稿の削除は論理削除で処理されているはずです。