### PR TITLE
#1021 画像付き投稿機能(近藤佑哉)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Http\Requests\PostRequest;
+use Illuminate\Support\Str;
 use App\Post;
 
 class PostsController extends Controller
@@ -17,13 +18,27 @@ class PostsController extends Controller
     }
 
     public function store(PostRequest $request) {
+        $fileName = 'images';
+        $image = $request->file('image'); // リクエストから画像ファイルを取得します
+        if(isset($image)) {
+            // 拡張子を取得します
+            $ext = $image->guessExtension();
+            // アップロードファイル名は [ランダム文字列20文字].[拡張子] になります
+            $filename = Str::random(20) . ".{$ext}";
+            // publicディスク(storage/app/public/)のimagesディレクトリに画像を保存します
+            $path = $image->storeAs('images', $filename, 'public');
+        }
+    
         $posts = new Post;
-        $posts->content = $request->content;
+        $posts->content = $request->content ?? null;
+        // 保存した画像のパスを使用します
+        $posts->image = $path ?? null; // 画像がアップロードされなかった場合に備えて null を設定します
         $posts->user_id = $request->user()->id;
+    
         $posts->save();
         return back();
     }
-
+    
     public function edit($id) {
         $user = \Auth::user();
         $post = Post::findOrFail($id);

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -51,8 +51,21 @@ class PostsController extends Controller
     }
     //投稿内容の変更
     public function update(PostRequest $request, $id) {
+        $fileName = 'images';
+        $image = $request->file('image'); // リクエストから画像ファイルを取得します
+        if(isset($image)) {
+            // 拡張子を取得します
+            $ext = $image->guessExtension();
+            // アップロードファイル名は [ランダム文字列20文字].[拡張子] になります
+            $filename = Str::random(20) . ".{$ext}";
+            // publicディスク(storage/app/public/)のimagesディレクトリに画像を保存します
+            $path = $image->storeAs('images', $filename, 'public');
+        }
+
+
         $post = Post::findOrFail($id);
         $post->content = $request->content;
+        $post->image = $path ?? null;
         $post->user_id = $request->user()->id;
         $post->save();
         return redirect('/')->with('updateSuccessMessage', '投稿を更新しました');

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,9 +24,8 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
-            'content' => 'sometimes|nullable|max:140',
-            'image' => 'sometimes|nullable|image|mimes:jpeg,png,jpg,gif|required_without:content',
+            'content' => 'sometimes|nullable|max:140|required_without_all:image',
+            'image' => 'sometimes|nullable|image|mimes:jpeg,png,jpg,gif|required_without_all:content',
         ];
     }
-    
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,7 +24,9 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
-            'content' => 'required|max:140',
+            'content' => 'sometimes|nullable|max:140',
+            'image' => 'sometimes|nullable|image|mimes:jpeg,png,jpg,gif|required_without:content',
         ];
     }
+    
 }

--- a/database/migrations/2024_02_04_012130_create_posts_table.php
+++ b/database/migrations/2024_02_04_012130_create_posts_table.php
@@ -15,7 +15,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->text('content');
+            $table->text('content')->nullable();
             $table->bigInteger('user_id')->unsigned()->index();
             $table->timestamps();
             // 新しい外部キー制約を追加

--- a/database/migrations/2024_03_14_000620_add_post_with_image_to_create_posts_table.php
+++ b/database/migrations/2024_03_14_000620_add_post_with_image_to_create_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPostWithImageToCreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('image')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('image');  //カラムの削除
+        });
+    }
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -102,7 +102,7 @@ return [
     'required_with' => ':valuesが指定されている場合、:attributeも指定してください。',
     'required_with_all' => ':valuesが全て指定されている場合、:attributeも指定してください。',
     'required_without' => ':valuesが指定されていない場合、:attributeを指定してください。',
-    'required_without_all' => ':valuesが全て指定されていない場合、:attributeを指定してください。',
+    'required_without_all' => ':values、:attributeどちらかは必ず指定してください。',
     'same' => ':attributeと:otherが一致しません。',
     'size' => [
         'numeric' => ':attributeには、:sizeを指定してください。',

--- a/resources/views/posts.blade.php
+++ b/resources/views/posts.blade.php
@@ -3,12 +3,23 @@
     <li class="mb-3 text-center">
         <div class="text-left d-inline-block w-75 mb-2">
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-            <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $post->user->name }}</a></p>
+            <p class="mt-3 mb-0 d-inline-block">
+                @if(Auth::check() && Auth::id() == $post->user->id)
+                    <a href="{{ route('user.show', Auth::id()) }}">{{ $post->user->name }}</a>
+                @else
+                    <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>
+                @endif
+            </p>
         </div>
         <div class="">
             <div class="text-left d-inline-block w-75">
                 <!-- $post が使われている部分 -->
                 <p class="mb-2">{{ $post->content }}</p>
+            @if($post->image)
+                <div class="">
+                    <img src="{{ Storage::url($post->image) }}" alt="投稿画像" class="img-fluid">
+                </div>
+            @endif
                 <p class="text-muted">{{ $post->created_at }}</p>
             </div>
             <div class="d-flex justify-content-between w-75 pb-3 m-auto">

--- a/resources/views/posts.blade.php
+++ b/resources/views/posts.blade.php
@@ -4,11 +4,7 @@
         <div class="text-left d-inline-block w-75 mb-2">
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
             <p class="mt-3 mb-0 d-inline-block">
-                @if(Auth::check() && Auth::id() == $post->user->id)
-                    <a href="{{ route('user.show', Auth::id()) }}">{{ $post->user->name }}</a>
-                @else
-                    <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>
-                @endif
+                <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>
             </p>
         </div>
         <div class="">

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,12 +1,20 @@
 @extends('layouts.app')
 @section('content')
     <h2 class="mt-5">投稿を編集する</h2>
-    <form method="POST" action="{{ route('post.update', ['id' => $post->id]) }}">
+    <form method="POST" action="{{ route('post.update', ['id' => $post->id]) }}" enctype="multipart/form-data">
         @csrf
         @method('PUT')
         @include('commons.error_messages')
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
+        @if($post->image)
+            <div class="mt-5">
+                <img src="{{ Storage::url($post->image) }}" alt="投稿画像" class="img-fluid">
+            </div>
+        @endif
+            <div class="pt-3">
+                <input type="file" name="image">
+            </div>
         </div>
         <button type="submit" class="btn btn-primary">更新する</button>
     </form>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -7,11 +7,11 @@
         @include('commons.error_messages')
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
-        @if($post->image)
-            <div class="mt-5">
-                <img src="{{ Storage::url($post->image) }}" alt="投稿画像" class="img-fluid">
-            </div>
-        @endif
+            @if($post->image)
+                <div class="mt-5">
+                    <img src="{{ Storage::url($post->image) }}" alt="投稿画像" class="img-fluid">
+                </div>
+            @endif
             <div class="pt-3">
                 <input type="file" name="image">
             </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -9,9 +9,11 @@
                 </div>
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src( $user->email , 400 ) }}" alt="ユーザのアバター画像">
+                @if(Auth::check() && Auth::id() == $user->id)
                     <div class="mt-3">
-                        <a href="{{ route('users.edit' , $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                        <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                     </div>
+                @endif
                 </div>
             </div>
         </aside>
@@ -41,7 +43,9 @@
                     <div class="text-left d-inline-flex w-75 mb-2 align-items-center justify-content-between">
                         <div>
                             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像">
-                            <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $user->name }}</a></p>
+                            <p class="mt-3 mb-0 d-inline-block">
+                                <a href="{{ route('user.show', $user->id) }}">{{ $user->name }}</a>
+                            </p>
                         </div>
                         <!-- フォローボタン -->
                         <div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -14,10 +14,13 @@
                 {{ session('success') }}
             </div>
         @endif
-        <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+        <form method="POST" action="{{ route('post.store') }}" enctype="multipart/form-data" class="d-inline-block w-75">
             @csrf
             <div class="form-group">
                 <textarea class="form-control" name="content" rows="4"></textarea>
+                <div class="pt-3">
+                    <input type="file" name="image">
+                </div>
                 <div class="text-left mt-3">
                     <button type="submit" class="btn btn-primary">投稿する</button>
                 </div>


### PR DESCRIPTION
## issue
 - Closes #1021 
## 概要
 - 画像付き投稿機能
## 動作確認手順

1.  トップページで画像を選択
2. 投稿するボタンをクリックして投稿一覧に表示されていることを確認
3. 文字か写真どちらかを必須を入力しないとバリデーションエラーが出ることを確認
4. ユーザー詳細画面でも画像付きの投稿があることを確認
5. 投稿の編集画面で画像が表示されており、画像を再選択して更新すると反映されていることを確認

## 考慮してほしいこと
 - 文字か写真どちらかを必須にしました。
## 確認してほしいこと
 - 上記の1~5の動作確認をお願い致します。
 - 全体の修正ポイントとして、他ユーザーの詳細画面へ遷移する動きも追加しました。