### PR TITLE
画像投稿機能の実装（あべ）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -6,8 +6,11 @@ use Illuminate\Http\Request;
 use App\Post;
 use App\User;
 use App\Http\Requests\PostRequest;
-
+use App\PostImage;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+use function PHPUnit\Framework\isNull;
 
 class PostsController extends Controller
 {
@@ -49,13 +52,33 @@ class PostsController extends Controller
         $post->content = $request->content;
         $post->save();
 
+        if (request()->file()) {
+            $this->savePostImages($post->id);
+        }
+
         return back();
+    }
+
+    public function savePostImages($postId)
+    {
+        foreach (request()->file('postImgs') as $postFile) {
+            $fileName = $postFile->store('public/images/postImgs');
+            $fileName = str_replace('public/images/postImgs/', '', $fileName);
+            $postImage = new PostImage;
+            $postImage->post_id = $postId;
+            $postImage->image_name = $fileName;
+            $postImage->save();
+        }
     }
 
     public function destroy($id)
     {
         $post = Post::findOrFail($id);
         if (\Auth::id() === $post->user_id) {
+            foreach ($post->postImages as $postImage) {
+                Storage::disk('public')->delete('images/postImgs/' . $postImage->image_name);
+                $postImage->delete();
+            }
             $post->delete();
         }
         return back();

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -25,6 +25,7 @@ class PostRequest extends FormRequest
     {
         return [
             'content'  => 'required | string | max:140',
+            'postImg.*' => 'image |mimes:png,jpg,jpeg|max:1024'
         ];
     }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -25,7 +25,7 @@ class PostRequest extends FormRequest
     {
         return [
             'content'  => 'required | string | max:140',
-            'postImg.*' => 'image |mimes:png,jpg,jpeg|max:1024'
+            'postImgs.*' => 'image |mimes:png,jpg,jpeg|max:5242880'
         ];
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -12,4 +12,9 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function postImages()
+    {
+        return $this->hasMany(PostImage::class);
+    }
 }

--- a/app/PostImage.php
+++ b/app/PostImage.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PostImage extends Model
+{
+    protected $fillable = ['post_id', 'image_name'];
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/database/migrations/2024_03_20_104635_create_post_images_table.php
+++ b/database/migrations/2024_03_20_104635_create_post_images_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostImagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post_images', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->string('image_name');
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post_images');
+    }
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -146,7 +146,8 @@ return [
         'name' => '名前',
         'email' => 'メールアドレス',
         'password' => 'パスワード',
-        'content' => '投稿文'
+        'content' => '投稿文',
+        'postImgs.*' => '画像'
     ],
 
 ];

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -19,7 +19,16 @@
                 </div>
                 <div>
                     <div class="text-left d-inline-block col-12 mb-2">
-                        <p class="mb-2 post_content">{!! nl2br(e($post->content)) !!}</p>
+                        <p class="pb-3 post_content">{!! nl2br(e($post->content)) !!}</p>
+                        @if ($post->postImages->count() >= 1)
+                            <div class="d-flex flex-wrap pb-2">
+                                @foreach ($post->postImages as $postImage)
+                                    <img src="{{ asset('storage/images/postImgs/' . $postImage->image_name) }}"
+                                        alt="" class="col-6">
+                                @endforeach
+                            </div>
+                        @endif
+
                         <time class="text-muted">{{ $post->created_at }}</time>
                     </div>
                     <div class="pt-2 col-12 action_area">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -24,7 +24,7 @@
                             <div class="d-flex flex-wrap pb-2">
                                 @foreach ($post->postImages as $postImage)
                                     <img src="{{ asset('storage/images/postImgs/' . $postImage->image_name) }}"
-                                        alt="" class="col-6">
+                                        alt="" class="col-6 pb-2">
                                 @endforeach
                             </div>
                         @endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -28,10 +28,10 @@
                 <div class="form-group">
                     <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
                     <div>
-                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
-                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
-                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
-                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg">
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg">
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg">
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg">
                     </div>
                     <div class="text-right mt-3">
                         <button type="submit" class="btn btn_accent-color">投稿する</button>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -22,10 +22,17 @@
     <div class="w-75 m-auto">@include('commons.error_messages')</div>
     @if (Auth::check())
         <div class="text-center mb-3 pt-3">
-            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75"
+                enctype="multipart/form-data">
                 @csrf
                 <div class="form-group">
                     <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
+                    <div>
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
+                        <input type="file" name="postImgs[]" accept=".png, .jpg, .jpeg" id="postImg">
+                    </div>
                     <div class="text-right mt-3">
                         <button type="submit" class="btn btn_accent-color">投稿する</button>
                     </div>


### PR DESCRIPTION
## issue
- ありません

## 概要
- 画像投稿機能の実装

## 動作確認手順
```
php artisan migrate
```
を実行する
- 登録済みのユーザーでログインして、テキストボックスの下にinput fileが4つあることを確認
- 投稿文は必須なので、投稿文を記入して任意の画像を1~4枚選択してから投稿ボタンを押して、投稿一覧に投稿の内容が表示されることを確認
- 投稿を削除し、データベース上でpost_imagesから関連カラムが削除されること、public/images/postImgファイル内からファイルが削除されることを確認

## 考慮して欲しいこと
- input fileのボタンや表示、レイアウトは後で整える予定です
- プレビュー表示も後で追加する予定です

## 確認してほしいこと
- 一つのフォームで複数投稿も考えましたが、バリデーションを通らないとファイル数の制限ができないことと、一つのファイルを削除、変更したいときに全てのファイルを選択しなおす手間がかかるためux的に良くないと考え、フォームを複数置く形にしましたが、どちらが良かったのでしょうか？