### PR TITLE
url自動認識（西田修）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -57,8 +57,4 @@ class PostsController extends Controller
         return back();
     }
 
-    public function getBodyWithLinkAttribute()
-    {
-        
-    }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -56,4 +56,9 @@ class PostsController extends Controller
         }
         return back();
     }
+
+    public function getBodyWithLinkAttribute()
+    {
+        
+    }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -11,4 +11,11 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function getContentWithLinkAttribute(): string
+    {
+        $pattern = '/((?:https?|ftp):\/\/[-_.!~*\'()a-zA-Z0-9;\/?:@&=+$,%#]+)/';
+        $replace = '<a href="$1">$1</a>';
+        return preg_replace($pattern, $replace, $this->content);
+    }
 }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -7,7 +7,7 @@
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">
-                    <p class="mb-2">{{$post->content}}</p>
+                    <div>{!! nl2br($post->content_with_link) !!}</div>
                     <p class="text-muted">{{$post->created_at}}</p>
                 </div>
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">


### PR DESCRIPTION
## 概要
投稿にurlが含まれていた場合、自動認識して、ハイパーリンクにする機能

## 動作確認手順
- トップページにアクセスして、ログインする。
- 任意のurlを含んだ記事を投稿する。
- urlの文字列がハイパーリンクになり、そのリンクをクリックすると、リンクのページにページ遷移することを確認