### PR TITLE
投稿削除時のフラッシュメッセージ(川原)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -54,7 +54,7 @@ class PostsController extends Controller
         if (\Auth::id() == $post->user_id) {
             $post->delete();
         }
-        return back();
+        return back()->with('deleteMessage', '投稿を削除しました');
     }
 
 }


### PR DESCRIPTION
## issue
- Closes #899

## 概要
- 投稿削除時のフラッシュメッセージ

## 動作確認手順
- http://localhost:8080/ へアクセスし、ログイン後の投稿を作成し、その後投稿削除時に「投稿を削除しました」が画面上に表示されるか確認する。

## 考慮して欲しいこと
- 今回は特にありません。

## 確認してほしいこと
- 今回は特にありません。