### PR TITLE
#903 posts edit display update add (Tokeshi)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -21,7 +21,7 @@ class PostsController extends Controller
     {
         $post = Post::findOrFail($id);
         if(\Auth::id() == $post->id) {
-            return view('posts.edit', ['post' => $post,]);
+            return view('posts.edit', ['post' => $post]);
         } else{
             abort(404);
         }
@@ -33,6 +33,6 @@ class PostsController extends Controller
         $post->content = $request->content;
         $post->save();
         
-        return redirect()->route('posts.index'); //toppageへリダイレクト
+        return redirect()->route('posts.index'); 
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\PostRequest;
 use Illuminate\Http\Request;
 use App\Post;
 
@@ -14,5 +15,24 @@ class PostsController extends Controller
         return view('welcome', [
             'posts' => $posts,
         ]);
+    }
+
+    public function edit($id) 
+    {
+        $post = Post::findOrFail($id);
+        if(\Auth::id() == $post->id) {
+            return view('posts.edit', ['post' => $post,]);
+        } else{
+            abort(404);
+        }
+    }
+
+    public function update(PostRequest $request, $id) 
+    {
+        $post = Post::findOrFail($id);
+        $post->content = $request->content;
+        $post->save();
+        
+        return redirect()->route('posts.index'); //toppageへリダイレクト
     }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+class PostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content'=> 'required|max:140',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'content' => '投稿'
+        ];
+    }
+}

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5">投稿を編集する</h2>
+@include('commons.error_messages')
+    <form method="POST" action="{{ route('post.update', $post->id) }}">
+        @csrf
+        @method('PUT')
+        <div class="form-group">
+            <textarea id="content" class="form-control" name="content" rows="5"></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </form>
+@endsection

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -6,7 +6,7 @@
         @csrf
         @method('PUT')
         <div class="form-group">
-            <textarea id="content" class="form-control" name="content" rows="5"></textarea>
+            <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
         </div>
         <button type="submit" class="btn btn-primary">更新する</button>
     </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,4 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
     });
-
 });
-
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,13 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('users')->group(function () {
         Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
         Route::put('{id}', 'UsersController@update')->name('user.update');
+    });
+    // 投稿関連
+    Route::prefix('posts')->group(function () {
+        Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
+        Route::put('{id}', 'PostsController@update')->name('post.update');
+    });
+
 });
-});
+
 


### PR DESCRIPTION
## issue
- Closes #903 

## 概要
- 投稿編集、更新を実装完了
- Route 設定　投稿編集関連　edit,updateを実装
- Controller 設定　PostsControllerにedit,update関数メソッドを実装
- Requests 設定　RequestsフォルダにPostRequest.phpファイルを作成しバリデーションを実装

## 動作確認手順
- Dockerコンテナを起動した状態でhttp://localhost:8080/にてtestアカウントでログインする
- http://localhost:8080/users/1/edit のURLを直接入力して投稿編集画面へ遷移する
- ログインしていないユーザーはloginへ遷移することを確認
- 投稿内容を140以内であれば、更新成功
- 140以上であればバリデーションエラーが表示
- 成功すると、リダイレクトによりtoppageへ遷移する

## 考慮して欲しいこと
- ユーザー詳細がまだ未実装のため、/users/1/edit直URL打ちで確認してます

## 確認して欲しい事
- 投稿更新後にtoppageに遷移する際のメソッドはredirectでよかったのかどうか悩みました。
下記のコードでもいいかと思いましたが、シンプルの方がいいと思いredirectにしました。
考え方は間違ってないでしょうか。

```
public function update(PostRequest $request, $id) 
{
    $post = Post::findOrFail($id);
    $post->content = $request->content;
    $post->save();

    // ポストを更新した後、全てのポストを取得
    $posts = Post::orderBy('id', 'desc')->paginate(10);  // ページネーションも考慮

    return view('welcome', ['posts' => $posts]);
}
```


