### PR TITLE
ユーザー退会機能（えんどう）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -45,10 +45,6 @@ class UsersController extends Controller
     {
         $user = User::findOrFail($id);
         if (\Auth::user()->id === $user->id) {
-            \Auth::logout();
-            $user->posts->each(function ($post) {
-                $post->update(['deleted_at' => now()]);
-            });
             $user->delete();
         }
         return redirect('/');

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -14,7 +14,7 @@ class UsersController extends Controller
     public function show($id)
     {
         $user = User::findOrFail($id);
-        $posts = $user->posts();
+        $posts = $user->posts()->orderBy('id', 'desc')->paginate(10);
         $data = [
             'user'=> $user,
             'posts'=>$posts
@@ -39,5 +39,18 @@ class UsersController extends Controller
         $user->password = Hash::make($request->password); 
         $user->save();
         return redirect()->route('user.show',['id'=> $user->id]);
+    }
+
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::user()->id === $user->id) {
+            \Auth::logout();
+            $user->posts->each(function ($post) {
+                $post->update(['deleted_at' => now()]);
+            });
+            $user->delete();
+        }
+        return redirect('/');
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -9,6 +9,10 @@ class Post extends Model
 {
     use SoftDeletes;
 
+    protected $fillable = [
+        'user_id', 'content', 'deleted_at',
+    ];
+
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/User.php
+++ b/app/User.php
@@ -44,4 +44,12 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public static function boot()
+    {
+        parent::boot();
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -42,8 +42,6 @@ class User extends Authenticatable
 
     public function posts()
     {
-        return $this->hasMany(Post::class)
-            ->orderBy('id', 'desc')
-            ->paginate(10);
+        return $this->hasMany(Post::class);
     }
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -41,9 +41,13 @@
                     <label>本当に退会しますか？</label>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
-                    <form action="" method="POST">
-                        <button type="submit" class="btn btn-danger">退会する</button>
-                    </form>
+                    @if (Auth::check() && Auth::id() === $user->id)
+                        <form action="{{ route('user.delete', $user->id) }}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">退会する</button>
+                        </form>
+                    @endif
                     <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('{id}', 'UsersController@show')->name('user.show');
         Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
         Route::put('{id}', 'UsersController@update')->name('user.update');
+        Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
     });
     // 投稿・削除
     Route::prefix('post')->group(function () {


### PR DESCRIPTION
# issue
- #902 

# 概要
- ユーザー退会機能

# 動作確認手順
- モーダルの削除ボタン押下後、ユーザー削除とユーザーに紐付く全ての投稿削除が実行されることを確認
- ユーザー、紐付く投稿削除後、トップページに遷移する事を確認
- トップページに遷移後、ログアウトした状態になっていることを確認
- 今回の実装はソフトデリート仕様なので、Adminerで削除を実行したユーザーと
紐付く投稿のdeleted_atカラムにそれぞれ時間が登録され、その後画面に表示されていない事を確認
- 同じメールアドレスにてログインと新規登録が出来ない事を確認
- コード修正後も同じ挙動であることを確認

# その他伝達事項
**- 助言通りにコード修正致しました。　大変勉強になりました！**