### PR TITLE
ユーザ退会処理（たわらつみだ　まなぶ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -7,11 +7,45 @@ use App\User;
 
 class UsersController extends Controller
 {
-    // ユーザ詳細
+    //ユーザ削除
+    public function destroy($id)
+    {
+    // 指定されたIDのユーザーを取得
+    $user = User::findOrFail($id);
+
+    if (!$user) {
+        // ユーザーが存在しない場合の処理（エラーハンドリングなど）アレンジ用
+        // 例えば、リダイレクトしてエラーメッセージを表示するなど　アレンジ用
+    }
+    $user->delete();// ユーザーを削除
+    return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
+    }
+
+
+    
+    // ユーザ詳細（担当タスク外）
     public function show($id)
     {
         $user = User::findOrFail($id);
 
         return view('users.show', compact('user', $user));
     }
-}
+    //ユーザ情報更新（担当タスク外）
+    public function update(Request $request, $id)
+    {
+        $user = User::findOrFail($id);
+        $user->name = $request->input('name');
+        $user->email = $request->input('email');
+        $user->save();
+
+        return redirect()->route('users.show', ['user' => $user,]);
+    }
+    //ユーザ情報編集（担当タスク外）
+    public function edit($id)
+    {
+        $user = User::findOrFail($id);
+
+        return view('users.edit', ['user' => $user,]);
+    }
+ }
+       

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -20,32 +20,5 @@ class UsersController extends Controller
     $user->delete();// ユーザーを削除
     return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
     }
-
-
-    
-    // ユーザ詳細（担当タスク外）
-    public function show($id)
-    {
-        $user = User::findOrFail($id);
-
-        return view('users.show', compact('user', $user));
-    }
-    //ユーザ情報更新（担当タスク外）
-    public function update(Request $request, $id)
-    {
-        $user = User::findOrFail($id);
-        $user->name = $request->input('name');
-        $user->email = $request->input('email');
-        $user->save();
-
-        return redirect()->route('users.show', ['user' => $user,]);
-    }
-    //ユーザ情報編集（担当タスク外）
-    public function edit($id)
-    {
-        $user = User::findOrFail($id);
-
-        return view('users.edit', ['user' => $user,]);
-    }
  }
        

--- a/composer.lock
+++ b/composer.lock
@@ -1895,16 +1895,16 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.4.35",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "9e615d367e2bed41f633abb383948c96a2dbbfae"
+                "reference": "0934c9f1d433776f25c629bdc93f3e157d139e08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/9e615d367e2bed41f633abb383948c96a2dbbfae",
-                "reference": "9e615d367e2bed41f633abb383948c96a2dbbfae",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/0934c9f1d433776f25c629bdc93f3e157d139e08",
+                "reference": "0934c9f1d433776f25c629bdc93f3e157d139e08",
                 "shasum": ""
             },
             "require": {
@@ -1941,7 +1941,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.4.35"
+                "source": "https://github.com/symfony/css-selector/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -1957,7 +1957,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/debug",
@@ -2640,16 +2640,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v5.4.38",
+            "version": "v5.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "82fa6be8a0295a3932df871e88fc8c8d77aa71d4"
+                "reference": "a5364f016fd9e090f7b4f250a97ea6925a5ca985"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/82fa6be8a0295a3932df871e88fc8c8d77aa71d4",
-                "reference": "82fa6be8a0295a3932df871e88fc8c8d77aa71d4",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a5364f016fd9e090f7b4f250a97ea6925a5ca985",
+                "reference": "a5364f016fd9e090f7b4f250a97ea6925a5ca985",
                 "shasum": ""
             },
             "require": {
@@ -2705,7 +2705,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.4.38"
+                "source": "https://github.com/symfony/mime/tree/v5.4.39"
             },
             "funding": [
                 {
@@ -2721,7 +2721,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-21T07:25:32+00:00"
+            "time": "2024-04-18T08:26:06+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -25,7 +25,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">ログイン</button>
             </form>
-            <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
+            <div class="mt-2"><a href="{{ route('signup') }}">新規ユーザ登録する？</a></div><!-- 新規ユーザ登録画面への遷移ルーティング追記 -->
         </div>
     </div>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Posts></h1>
+        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Posts</h1>
     </div>
     <div class="text-center mt-3">
         <p class="d-inlin-black">新規ユーザ登録すると、<br>あなたのチャンネル作成／動画登録等ができるようになります。</p>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,55 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+        @include('commons.error_messages')
+    <form method="POST" action="{{ route('users.update', $user->id) }}">
+        @csrf
+        @method('PUT')
+        <input type="hidden" name="id" value="" />
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name') }}" name="name" >
+        </div>
+
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{ old('email') }}" name="email" >
+        </div>
+
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" >
+        </div>
+
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password_confirmation" >
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+    </form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="{{ route('users.delete', $user->id) }}" method="POST"><!-- 削除ルーティング名　-->
+                        @csrf<!-- ハッキングの手口から守る（POST実行時は必ず記載） -->
+                        @method('DELETE')<!-- HTTPメソッドをDELETEに指定 -->
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,55 +1,6 @@
 @extends('layouts.app')
 @section('content')
-<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
-        @include('commons.error_messages')
-    <form method="POST" action="{{ route('users.update', $user->id) }}">
-        @csrf
-        @method('PUT')
-        <input type="hidden" name="id" value="" />
-        <div class="form-group">
-            <label for="name">ユーザ名</label>
-            <input class="form-control" value="{{ old('name') }}" name="name" >
-        </div>
-
-        <div class="form-group">
-            <label for="email">メールアドレス</label>
-            <input class="form-control" value="{{ old('email') }}" name="email" >
-        </div>
-
-        <div class="form-group">
-            <label for="password">パスワード</label>
-            <input class="form-control" type="password" name="password" >
-        </div>
-
-        <div class="form-group">
-            <label for="password_confirmation">パスワードの確認</label>
-            <input class="form-control" type="password" name="password_confirmation" >
-        </div>
-
-        <div class="d-flex justify-content-between">
-            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-            <button type="submit" class="btn btn-primary">更新する</button>
-        </div>
-    </form>
-
-    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4>確認</h4>
-                </div>
-                <div class="modal-body">
-                    <label>本当に退会しますか？</label>
-                </div>
-                <div class="modal-footer d-flex justify-content-between">
                     <form action="{{ route('users.delete', $user->id) }}" method="POST"><!-- 削除ルーティング名　-->
                         @csrf<!-- ハッキングの手口から守る（POST実行時は必ず記載） -->
                         @method('DELETE')<!-- HTTPメソッドをDELETEに指定 -->
-                        <button type="submit" class="btn btn-danger">退会する</button>
-                    </form>
-                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-                </div>
-            </div>
-        </div>
-    </div>
 @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -9,7 +9,7 @@
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 308) }}" alt="ユーザのアバター画像">
                     <div class="mt-3">
-                        <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a> <!-- 退会処理画面への遷移　ユーザ退会用で作成-->
+                        <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                     </div>
                 </div>
             </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -9,7 +9,7 @@
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 308) }}" alt="ユーザのアバター画像">
                     <div class="mt-3">
-                        <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                        <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a> <!-- 退会処理画面への遷移　ユーザ退会用で作成-->
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -13,8 +14,10 @@
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
+
 // トップページの投稿表示
 Route::get('/', 'PostsController@index')->name('top');
+
 // ユーザー　ログイン・ログアウト
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
@@ -29,7 +32,8 @@ Route::group(['prefix' => 'posts', 'middleware' => 'auth'], function () {
     Route::post('/follow/{id}', 'FollowController@store')->name('follow.store');
     Route::delete('/unfollow/{id}', 'FollowController@destroy')->name('follow.destroy');
 });
- //　ログイン後
+    
+    //　ログイン後
 Route::group(['middleware' => 'auth'], function () {
     //　ユーザ退会・更新
      Route::prefix('users')->group(function () {
@@ -38,5 +42,7 @@ Route::group(['middleware' => 'auth'], function () {
      Route::put('{id}', 'UsersController@update')->name('users.update'); //ユーザ退会用で作成
     });
 });
+
+
 // ユーザ詳細
 Route::get('/users/{id}', 'UsersController@show')->name('users.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,9 +37,7 @@ Route::group(['prefix' => 'posts', 'middleware' => 'auth'], function () {
 Route::group(['middleware' => 'auth'], function () {
     //　ユーザ退会・更新
      Route::prefix('users')->group(function () {
-     Route::delete('/users{id}', 'UsersController@destroy')->name('users.delete'); //ユーザ削除
-     Route::get('/users/{id}', 'UsersController@edit')->name('users.edit'); //ユーザ退会用で作成
-     Route::put('{id}', 'UsersController@update')->name('users.update'); //ユーザ退会用で作成
+     Route::delete('{id}/edit', 'UsersController@destroy')->name('users.delete'); //ユーザ削除
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -14,10 +13,8 @@
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
-
 // トップページの投稿表示
 Route::get('/', 'PostsController@index')->name('top');
-
 // ユーザー　ログイン・ログアウト
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,9 +26,20 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 // 投稿新規作成
 Route::group(['prefix' => 'posts', 'middleware' => 'auth'], function () {
     Route::post('/', 'PostsController@store')->name('posts.store');
-    Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit');
-    Route::patch('{id}/update', 'PostsController@update')->name('posts.update');
+    // Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit');// ユーザ情報のため別記述を作成　別途メンバーを打ち合わせ
+    // Route::patch('{id}/update', 'PostsController@update')->name('posts.update');//　ユーザ情報のため別記述を作成　別途メンバーと打ち合わせ
 });
+    
+    //　ログイン後
+Route::group(['middleware' => 'auth'], function () {
+    //　ユーザ退会・更新
+     Route::prefix('users')->group(function () {
+     Route::delete('/users{id}', 'UsersController@destroy')->name('users.delete'); //ユーザ削除
+     Route::get('/users/{id}', 'UsersController@edit')->name('users.edit'); //ユーザ退会用で作成
+     Route::put('{id}', 'UsersController@update')->name('users.update'); //ユーザ退会用で作成
+    });
+});
+
 
 // ユーザ詳細
 Route::get('/users/{id}', 'UsersController@show')->name('users.show');


### PR DESCRIPTION
## issue
- #902  ユーザ退会処理

## 概要
- ユーザ退会処理（論理削除）の実装

## 動作確認
- localhost:8080
- 新規ユーザ登録の必要有若しくは既存ユーザを使用し削除
- localhost:8088（ユーザ削除情報の確認）

## 考慮して欲しいこと
- UserControllerのユーザ削除
　 public function destroy($id)
    {
    $user = User::findOrFail($id);

    _if (!$user) **{**
    **}**_
    $user->delete();
    return redirect()->route('top'); 
    }

### 以下質疑
   _if (!$user) **{**
    **}**_の{}を外したら動作しませんでした。
ここについて理解できておりません。

## 今後チャレンジしてみたいこと
- 現在、ユーザ退会においてエラーを作成しておりません。
　ユーザ名が違うとかそのユーザは存在しないとかのエラーがあると
実際に操作する人に親切ではなかと思う。

## アドバイスしていただきたいこと
- 今回、実際のローカルweb画面で動作を確認したいため、他の方が作成するタスクを
仮に作成し、動作環境を構築しました。ユーザ退会処理のみ作成する場合は、どのように
作成したらよろしいでしょうか。