### PR TITLE
#906ユーザ編集画面・更新（とさか）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\UserRequest;
 use App\User;
+use Illuminate\Support\Facades\Hash;
 
 class UsersController extends Controller
 {
@@ -13,5 +15,27 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
 
         return view('users.show', compact('user', $user));
+    }
+
+    // ユーザ編集画面・更新
+    public function edit($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::check() && \Auth::id() == $id) {
+            return view('users.edit', ['user' => $user]);
+        }
+        abort(404); // デモ画面は、ログイン画面に遷移させていたが、挙動がうまくいかなかったため、404エラーを返すように実装
+    }
+
+    public function update(UserRequest $request, $id)
+    {
+        $user = User::findOrFail($id);
+
+        $user->name = $request->name ;
+        $user->email = $request->email ;
+        $user->password = Hash::make($request->password);
+        $user->save();
+
+        return redirect()->route('users.show', ['id' => $user->id]);
     }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($this->user()->id)],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+    public function attributes()
+    {
+        return [
+            'name' => '名前',
+            'email' => 'メールアドレス',
+            'password' => 'パスワード',
+        ];
+    }
+}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+    <form method="POST" action="{{ route('users.update', $user->id) }}">
+        @csrf
+        @method('PUT')
+        @include('commons.error_messages')
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
+        </div>
+
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input id="email" class="form-control" value="{{ old('email', $user->email) }}" name="email" />
+        </div>
+
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input id="password" class="form-control" type="password" value="" name="password" />
+        </div>
+
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input id="password_confirmation" class="form-control" type="password" value="" name="password_confirmation"/>
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+    </form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="" method="POST">
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -9,7 +9,7 @@
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 308) }}" alt="ユーザのアバター画像">
                     <div class="mt-3">
-                        <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                        <a href="{{ route('users.edit', ['id' => $user->id]) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,3 +36,11 @@ Route::group(['prefix' => 'posts', 'middleware' => 'auth'], function () {
 
 // ユーザ詳細
 Route::get('/users/{id}', 'UsersController@show')->name('users.show');
+
+// ユーザ編集画面・更新(ログインユーザのみ、prefixでグループ化)
+Route::group(['middleware' => 'auth'], function(){
+    Route::prefix('users')->group(function() {
+      Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
+      Route::put('{id}', 'UsersController@update')->name('users.update');
+    });
+  });


### PR DESCRIPTION
## issue
- Closes #906

## 概要
- ユーザ編集画面・更新

## 動作確認手順
- http://localhost:8080/ へアクセス
メールアドレス：'yusuke@sample.com'
パスワード：'yusuke'
を入力し、ログインボタンを押下
`http://localhost:8080/users/5/edit`

## 考慮してほしいこと
下記タスクにてマージ対応後の修正
#906ユーザ編集画面・更新（とさか） #1088 
https://github.com/yukihiroLaravel/joint_develop/pull/1088#issue-2279713765

マージを想定していなかったので、再アップとなってます。

## 確認してほしいこと
一度登録したメールアドレスは使えない状態になってしまってましたが、メアドの変更を希望しない場合は元のものを使えるよう、ログイン者自身のメアドと同じであれば重複OKに修正済み。
