### PR TITLE
ユーザ退会（たわらつみだ　まなぶ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -70,17 +70,19 @@ class UsersController extends Controller
     }
 
        //ユーザ削除
-       protected function destroy($id)
+       protected function destroy(UserRequest $request, $id)
        {
-       // 指定されたIDのユーザーを取得
-       $user = User::findOrFail($id);
+           // 指定されたユーザIDを取得
+           $user = User::findOrFail($id);
        
-       // 指定されたユーザかどうかを確認
-       if (\Auth::check() && \Auth::id() == $id) {
-       return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
+           // ログインユーザのIDと指定されたIDが一致する場合のみユーザを削除
+           if (\Auth::check() && \Auth::id() == $id) {
+               $user->delete(); // ユーザを削除
+               return redirect()->route('top'); // 一覧画面へリダイレクト
+           } else {
+               // ユーザ削除の条件を満たしていない場合はエラーメッセージを表示
+               return back()->with('error', 'ユーザ削除は許可されていません。');
+           }
        }
-       $user->delete();// ユーザーを削除
-       return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
-
-    }
 }
+

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -70,19 +70,19 @@ class UsersController extends Controller
     }
 
        //ユーザ削除
-       protected function destroy(UserRequest $request, $id)
+       protected function destroy($id)
        {
            // 指定されたユーザIDを取得
            $user = User::findOrFail($id);
        
            // ログインユーザのIDと指定されたIDが一致する場合のみユーザを削除
-           if (\Auth::check() && \Auth::id() == $id) {
+           if (\Auth::id() === $user->id) {
                $user->delete(); // ユーザを削除
                return redirect()->route('top'); // 一覧画面へリダイレクト
            } else {
                // ユーザ削除の条件を満たしていない場合はエラーメッセージを表示
                return back()->with('error', 'ユーザ削除は許可されていません。');
            }
-       }
+       }       
 }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -44,8 +44,13 @@ class UsersController extends Controller
        {
        // 指定されたIDのユーザーを取得
        $user = User::findOrFail($id);
-
-       $user->delete();// ユーザーを削除
+       
+       // 指定されたユーザかどうかを確認
+       if (\Auth::check() && \Auth::id() == $id) {
        return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
        }
+       $user->delete();// ユーザーを削除
+       return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
+
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -69,7 +69,7 @@ class UsersController extends Controller
         return redirect()->route('users.show', ['id' => $user->id]);
     }
 
-       //ユーザ削除
+       //ユーザ削除　UsersControllerのclassメソッド
        protected function destroy($id)
        {
            // 指定されたユーザIDを取得
@@ -79,7 +79,8 @@ class UsersController extends Controller
            if (\Auth::id() === $user->id) {
                $user->delete(); // ユーザを削除
                return redirect()->route('top'); // 一覧画面へリダイレクト
-           } else {
+           }//ログインユーザのIDと指定されたIDが一致する場合のみユーザを削除 する範囲         
+           else {//そうでなけらばの条件分岐
                // ユーザ削除の条件を満たしていない場合はエラーメッセージを表示
                return back()->with('error', 'ユーザ削除は許可されていません。');
            }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -38,4 +38,14 @@ class UsersController extends Controller
 
         return redirect()->route('users.show', ['id' => $user->id]);
     }
+
+       //ユーザ削除
+       protected function destroy($id)
+       {
+       // 指定されたIDのユーザーを取得
+       $user = User::findOrFail($id);
+
+       $user->delete();// ユーザーを削除
+       return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
+       }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -94,4 +94,15 @@ class User extends Authenticatable
     {
         return $this->following()->where('followed_id', $user->id)->exists();
     }
+
+    //退会ユーザ所有の投稿削除 
+    //ユーザデータ削除後に投稿データを削除    
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleted(function ($user) {
+            $user->post()->delete();
+        });
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -102,7 +102,7 @@ class User extends Authenticatable
         parent::boot();
 
         static::deleted(function ($user) {
-            $user->post()->delete();
+            $user->posts()->delete();
         });
     }
 }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -25,7 +25,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">ログイン</button>
             </form>
-            <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
+            <div class="mt-2"><a href="{{ route('signup') }}">新規ユーザ登録する？</a></div><!-- 新規ユーザ登録画面への遷移ルーティング追記 -->
         </div>
     </div>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Posts></h1>
+        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Posts</h1>
     </div>
     <div class="text-center mt-3">
         <p class="d-inlin-black">新規ユーザ登録すると、<br>あなたのチャンネル作成／動画登録等ができるようになります。</p>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -30,27 +30,25 @@
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>
-
-    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4>確認</h4>
-                </div>
-                <div class="modal-body">
+        @if (Auth::id() === $user->id) <!-- ログインユーザと退会ユーザが一致した場合に退会ボタンを -->
+            <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h4>確認</h4>
+                        </div>
+                     <div class="modal-body">
                     <label>本当に退会しますか？</label>
                 </div>
-                @if (Auth::id() === $user->id) ユーザ名とメールアドレスがログインユーザ名と一致しないため退会できません。
                 <div class="modal-footer d-flex justify-content-between">
                     <form action="{{ route('users.delete', $user->id) }}" method="POST">
                         @csrf<!-- ハッキングの手口から守る（POST実行時は必ず記載） -->
                         @method('DELETE')<!-- HTTPメソッドをDELETEに指定 -->
                         <button type="submit" class="btn btn-danger">退会する</button>
                     </form>
-                @endif
+        @endif
                     <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
                 </div>
             </div>
         </div>
     </div>
-@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -40,12 +40,14 @@
                 <div class="modal-body">
                     <label>本当に退会しますか？</label>
                 </div>
+                @if (Auth::id() === $user->id) ユーザ名とメールアドレスがログインユーザ名と一致しないため退会できません。
                 <div class="modal-footer d-flex justify-content-between">
                     <form action="{{ route('users.delete', $user->id) }}" method="POST">
                         @csrf<!-- ハッキングの手口から守る（POST実行時は必ず記載） -->
                         @method('DELETE')<!-- HTTPメソッドをDELETEに指定 -->
                         <button type="submit" class="btn btn-danger">退会する</button>
                     </form>
+                @endif
                     <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
                 </div>
             </div>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -41,7 +41,9 @@
                     <label>本当に退会しますか？</label>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
-                    <form action="" method="POST">
+                    <form action="{{ route('users.delete', $user->id) }}" method="POST">
+                        @csrf<!-- ハッキングの手口から守る（POST実行時は必ず記載） -->
+                        @method('DELETE')<!-- HTTPメソッドをDELETEに指定 -->
                         <button type="submit" class="btn btn-danger">退会する</button>
                     </form>
                     <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -50,3 +50,4 @@
             </div>
         </div>
     </div>
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -30,7 +30,6 @@
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>
-        @if (Auth::id() === $user->id) <!-- ログインユーザと退会ユーザが一致した場合に退会ボタンを -->
             <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
                 <div class="modal-dialog">
                     <div class="modal-content">
@@ -46,7 +45,6 @@
                         @method('DELETE')<!-- HTTPメソッドをDELETEに指定 -->
                         <button type="submit" class="btn btn-danger">退会する</button>
                     </form>
-        @endif
                     <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,5 +42,7 @@ Route::group(['middleware' => 'auth'], function(){
     Route::prefix('users')->group(function() {
       Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
       Route::put('{id}', 'UsersController@update')->name('users.update');
+        //ユーザ退会
+        Route::delete('{id}', 'UsersController@destroy')->name('users.delete'); 
     });
   });


### PR DESCRIPTION
## issue
- ユーザ退会 #902 ユーザ退会処理

## 概要
- ユーザ退会処理（論理削除）の実装
- 同時に退会ユーザの投稿内容削除の実装
-  **追記**　ログインユーザと退会するユーザ等が一致した場合のみ処理を実行する内容に修正

## 動作確認
- localhost:8080
- 新規ユーザ登録の必要有若しくは既存ユーザを使用し削除
- **追記**　ログインユーザと異なるユーザ名ユーザe-mail入力後に退会実行
-  localhost:8088（退会ユーザ情報の確認）

## 確認したいところ（あまり意味がわかってないところ）
UsersController
`//ユーザ削除
       protected function destroy($id)
       {
       // 指定されたIDのユーザーを取得
       $user = User::findOrFail($id);
       
       // 指定されたユーザかどうかを確認
       if (\Auth::check() && \Auth::id() == $id) {
       return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト
       }
       $user->delete();// ユーザーを削除
       return redirect()->route('top'); // 一覧画面へのルート名を適宜変更 // 削除したらリダイレクト`
があります。
usersディレクトリ内のedit.blade
`  
@if (Auth::id() === $user->id) ユーザ名とメールアドレスがログインユーザ名と一致しないため退会できません。
    <div class="modal-footer d-flex justify-content-between">
    <form action="{{ route('users.delete', $user->id) }}" method="POST">
   @csrf<!-- ハッキングの手口から守る（POST実行時は必ず記載） -->
   @method('DELETE')<!-- HTTPメソッドをDELETEに指定 -->
    <button type="submit" class="btn btn-danger">退会する</button>
    </form>
    @endif
`
`(Auth::id() === $user->id) `は
//中略
コントローラーとエディットにそれぞれ記載してうまく動作しました。
 ** 質疑
両方に記載する必要があったのでしょうか。動作がよくわかりません。
行ってないことは
片方を削除した場合の動作確認は行っておりません**。

## アドバイスいただきたいところ
- ユーザ名とe-mailアドレスが異なった場合にエラーを出したい


- ユーザ名とメールアドレスがログインユーザ名と一致しないため退会できませんと出た場合に退会ボタンが押せないようにしたい

- 条件で一致しな場合はいきなり
[ユーザ名とメールアドレスがログインユーザ名と一致しないため退会できません]
[もう一度入力を見直してください] [戻る]
-と表示させたい

- ユーザ詳細画面においてパスワードを入力した場合に退会画面が出ないようにしたい
（今回担当タスク外）