### PR TITLE
コメント機能(えんどう）

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -10,9 +10,4 @@ class Comment extends Model
     {
         return $this->belongsTo(User::class);
     }
-
-    Public function post()
-    {
-        return $this->belongsTo(Post::class);
-    }
 }

--- a/app/Comment.php
+++ b/app/Comment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    Public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    Public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -12,31 +12,32 @@ class CommentsController extends Controller
 {
     public function store(CommentRequest $request)
     {
+        $postId = $request->post_id;
+        $commentContent = $request->input('comment_' . $postId);
         $comment = new Comment;
-        $comment->comment = $request->comment;
-        $comment->post_id = $request->post_id;
+        $comment->comment = $commentContent;
+        $comment->post_id = $postId;
         $comment->user_id = \Auth::id();
         $comment->save();
         session()->flash('flash_message', 'コメント登録しました！');
-        return redirect('/');
+        return redirect()->back()->withInput([]);
     }
 
-    public function update(Request $request, $comment_id)
+    public function update(Request $request, $commentId)
     {
-        $comment = Comment::findOrFail($comment_id);
+        $comment = Comment::findOrFail($commentId);
         $comment->comment = $request->comment_content;
         $comment->save();
         return response()->json(['success' => true, 'message' => 'Comment updated']);
     }
 
-    public function destroy(Request $request, $comment_id)
+    public function destroy(Request $request, $commentId)
     {
-        $comment = Comment::find($comment_id);
+        $comment = Comment::find($commentId);
         if ($comment) {
             $comment->delete();
             return response()->json(['success' => true, 'message' => 'Comment deleted']);
-        } else {
-            return response()->json(['success' => false, 'message' => 'Comment not found'], 404);
         }
+        return response()->json(['success' => false, 'message' => 'Comment not found'], 404);
     }
 }

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -5,27 +5,13 @@ namespace App\Http\Controllers;
 use App\Comment;
 use App\User;
 use App\Post;
+use App\Http\Requests\CommentRequest;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator;
 
 class CommentsController extends Controller
 {
-    public function store(Request $request)
+    public function store(CommentRequest $request)
     {
-        // バリデーションルールの定義
-        $rules = [
-            'comment' => 'required', // コメントが必須であることを指定
-        ];
-
-        // バリデーションの実行
-        $validator = Validator::make($request->all(), $rules);
-
-        // バリデーションに失敗した場合
-        if ($validator->fails()) {
-            return redirect()->back()->withErrors($validator)->withInput();
-        }
-
-        // Commentモデル作成
         $comment = new Comment;
         $comment->comment = $request->comment;
         $comment->post_id = $request->post_id;
@@ -33,12 +19,6 @@ class CommentsController extends Controller
         $comment->save();
         session()->flash('flash_message', 'コメント登録しました！');
         return redirect('/');
-
-        // コメントの保存が成功したことを示すレスポンスを返す
-        return response()->json([
-            'success' => true,
-            'comment' => $comment,
-        ]);
     }
 
     public function update(Request $request, $comment_id)
@@ -46,7 +26,6 @@ class CommentsController extends Controller
         $comment = Comment::findOrFail($comment_id);
         $comment->comment = $request->comment_content;
         $comment->save();
-        // コメントの更新後にJSONレスポンスを返す
         return response()->json(['success' => true, 'message' => 'Comment updated']);
     }
 
@@ -55,7 +34,6 @@ class CommentsController extends Controller
         $comment = Comment::find($comment_id);
         if ($comment) {
             $comment->delete();
-            // コメントの削除後にJSONレスポンスを返す
             return response()->json(['success' => true, 'message' => 'Comment deleted']);
         } else {
             return response()->json(['success' => false, 'message' => 'Comment not found'], 404);

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Comment;
+use App\User;
+use App\Post;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class CommentsController extends Controller
+{
+    public function store(Request $request)
+    {
+        // バリデーションルールの定義
+        $rules = [
+            'comment' => 'required', // コメントが必須であることを指定
+        ];
+
+        // バリデーションの実行
+        $validator = Validator::make($request->all(), $rules);
+
+        // バリデーションに失敗した場合
+        if ($validator->fails()) {
+            return redirect()->back()->withErrors($validator)->withInput();
+        }
+
+        // Commentモデル作成
+        $comment = new Comment;
+        $comment->comment = $request->comment;
+        $comment->post_id = $request->post_id;
+        $comment->user_id = \Auth::id();
+        $comment->save();
+        session()->flash('flash_message', 'コメント登録しました！');
+        return redirect('/');
+
+        // コメントの保存が成功したことを示すレスポンスを返す
+        return response()->json([
+            'success' => true,
+            'comment' => $comment,
+        ]);
+    }
+
+    public function update(Request $request, $comment_id)
+    {
+        $comment = Comment::findOrFail($comment_id);
+        $comment->comment = $request->comment_content;
+        $comment->save();
+        // コメントの更新後にJSONレスポンスを返す
+        return response()->json(['success' => true, 'message' => 'Comment updated']);
+    }
+
+    public function destroy(Request $request, $comment_id)
+    {
+        $comment = Comment::find($comment_id);
+        if ($comment) {
+            $comment->delete();
+            // コメントの削除後にJSONレスポンスを返す
+            return response()->json(['success' => true, 'message' => 'Comment deleted']);
+        } else {
+            return response()->json(['success' => false, 'message' => 'Comment not found'], 404);
+        }
+    }
+}

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Post;
+use App\Comment;
 use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller
@@ -10,6 +11,9 @@ class PostsController extends Controller
     public function index()
     {
         $posts = Post::orderBy('id', 'desc')->paginate(10);
+        foreach ($posts as $post) {
+            $post->comments = $post->comments()->orderBy('created_at', 'desc')->get();
+        }
         return view('welcome', [
             'posts' => $posts
         ]);

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -11,16 +11,17 @@ class PostsController extends Controller
 {
     public function index()
     {
-        $posts = Post::orderBy('id', 'desc')->paginate(10);
-        foreach ($posts as $post) {
-            $post->comments = $post->comments()->orderBy('created_at', 'desc')->get();
-        }
+        $posts = Post::with(['comments' => function ($query) {
+            $query->orderBy('created_at', 'desc');
+        }])->orderBy('id', 'desc')->paginate(10);
+        
         $tags = Tag::orderBy('id')->get();
         return view('welcome', [
             'posts' => $posts,
             'tags' => $tags,
         ]);
     }
+    
     public function store(PostRequest $request)
     {
         $post = new Post;

--- a/app/Http/Requests/CommentRequest.php
+++ b/app/Http/Requests/CommentRequest.php
@@ -11,6 +11,23 @@ class CommentRequest extends FormRequest
      *
      * @return bool
      */
+    public function rules()
+    {
+        $postId = $this->route('post_id');
+        return [
+            'comment_' . $postId => 'required|max:140'
+        ];
+    }
+
+    public function attributes()
+    {
+        $postId = $this->route('post_id');
+        return [
+            'comment_' . $postId => 'コメント'
+        ];
+    }
+
+
     public function authorize()
     {
         return true;
@@ -21,17 +38,5 @@ class CommentRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
-    {
-        return [
-            'comment' => 'required|max:500'
-        ];
-    }
-
-    public function attributes()
-    {
-        return [
-            'comment' => 'コメント'
-        ];
-    }
+    
 }

--- a/app/Http/Requests/CommentRequest.php
+++ b/app/Http/Requests/CommentRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'comment' => 'required|max:500'
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'comment' => 'コメント'
+        ];
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -18,6 +18,11 @@ class Post extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
     public function favoriteUsers()
     {
         return $this->belongsToMany(User::class, 'favorites', 'post_id', 'user_id')->withTimestamps();

--- a/app/User.php
+++ b/app/User.php
@@ -77,6 +77,10 @@ class User extends Authenticatable
         return $this->favorites()->where('post_id', $postId)->exists();
     }
 
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
 
     public static function boot()
     {

--- a/config/app.php
+++ b/config/app.php
@@ -225,7 +225,6 @@ return [
         'URL' => Illuminate\Support\Facades\URL::class,
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
-
     ],
 
 ];

--- a/database/migrations/2024_05_16_020830_create_comments_table.php
+++ b/database/migrations/2024_05_16_020830_create_comments_table.php
@@ -15,7 +15,7 @@ class CreateCommentsTable extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('comment');
+            $table->text('comment');
             $table->bigInteger('user_id')->unsigned()->index();
             $table->bigInteger('post_id')->unsigned()->index();
             $table->timestamps();

--- a/database/migrations/2024_05_16_020830_create_comments_table.php
+++ b/database/migrations/2024_05_16_020830_create_comments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('comment');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->timestamps();
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/resources/views/comments/comment.blade.php
+++ b/resources/views/comments/comment.blade.php
@@ -9,7 +9,7 @@
             <form method="POST" action="{{ route('comment.store', ['post_id' => $post->id]) }}" class="w-100 d-inline-block w-75">
                 @csrf
                 <div class="form-group">
-                    <textarea class="form-control w-100" name="comment" placeholder="コメント..." rows="3"></textarea>
+                    <textarea class="form-control w-100" name="comment" placeholder="コメントを入力..." rows="10">{{ old('comment') }}</textarea>
                     {{ csrf_field() }}
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-sm btn-primary">コメント登録</button>
@@ -18,5 +18,4 @@
             </form>
         </div>
     </div>
-    <hr>
 @endif

--- a/resources/views/comments/comment.blade.php
+++ b/resources/views/comments/comment.blade.php
@@ -9,8 +9,7 @@
             <form method="POST" action="{{ route('comment.store', ['post_id' => $post->id]) }}" class="w-100 d-inline-block w-75">
                 @csrf
                 <div class="form-group">
-                    <textarea class="form-control w-100" name="comment" placeholder="コメントを入力..." rows="10">{{ old('comment') }}</textarea>
-                    {{ csrf_field() }}
+                    <textarea class="form-control w-100" name="comment_{{ $post->id }}" placeholder="コメントを入力..." rows="4">{{ old('comment_' . $post->id) }}</textarea>
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-sm btn-primary">コメント登録</button>
                     </div>
@@ -19,3 +18,5 @@
         </div>
     </div>
 @endif
+
+

--- a/resources/views/comments/comment.blade.php
+++ b/resources/views/comments/comment.blade.php
@@ -1,0 +1,22 @@
+@if(Auth::check() && Auth::id())
+    <div class="w-75 bg-light mb-2 mx-auto">
+        @include('comments.comment_list')
+    </div>
+@endif
+@if(Auth::check() && Auth::id() !== $post->user_id)
+    <div class="text-center">
+        <div class="d-flex w-75 pb-3 m-auto">
+            <form method="POST" action="{{ route('comment.store', ['post_id' => $post->id]) }}" class="w-100 d-inline-block w-75">
+                @csrf
+                <div class="form-group">
+                    <textarea class="form-control w-100" name="comment" placeholder="コメント..." rows="3"></textarea>
+                    {{ csrf_field() }}
+                    <div class="text-left mt-3">
+                        <button type="submit" class="btn btn-sm btn-primary">コメント登録</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+    <hr>
+@endif

--- a/resources/views/comments/comment_list.blade.php
+++ b/resources/views/comments/comment_list.blade.php
@@ -1,0 +1,159 @@
+@foreach ($post->comments as $comment) 
+    <div class="comment-container" data-comment-id="{{ $comment->id }}">
+        <div class="d-flex justify-content-between m-auto" style="width: 100%;">
+            <div class="w-100">
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src( $comment->user->email, 55) }}" alt="ユーザのアバター画像">
+                <a class="no-text-decoration black-color" style="font-size: 18px;" href="/users/{{ $comment->user->id }}">{{ $comment->user->name }}</a>
+                <span class="ml-4" style="font-size: 18px;">{{ $comment->created_at->diffForHumans() }}</span>
+                @if (Auth::check() && $comment->user && $comment->user->id == Auth::user()->id)
+                    <a href="#" class="ml-4 edit-comment-link" data-comment-id="{{ $comment->id }}"><i class="fas fa-edit" style="color: #1a33ea; font-size: 20px;"></i></a>
+                    <a href="#" class="ml-4 delete-comment" data-comment-id="{{ $comment->id }}"><i class="fas fa-trash-alt" style="color: #f01939; font-size: 20px;"></i></a>
+                @endif
+                <div class="w-100 text-left mb-2 mt-3 comment-content" data-comment-id="{{ $comment->id }}">
+                    {{ $comment->comment }}
+                </div>
+                <form action="{{ route('comment.update', ['comment_id' => $comment->id]) }}" method="POST" class="edit-comment-form d-none w-100" data-comment-id="{{ $comment->id }}">
+                    @csrf
+                    @method('PUT')
+                    <div class="form-group">
+                        <textarea class="form-control w-100" name="comment_content" rows="3">{{ $comment->comment }}</textarea>
+                    </div>
+                    <button type="submit" class="btn btn-sm btn-primary">更新</button>
+                    <button type="button" class="btn btn-sm btn-secondary cancel-edit">キャンセル</button>
+                </form>
+            </div>
+        </div>
+    </div>
+@endforeach
+
+<meta name="csrf-token" content="{{ csrf_token() }}">
+
+<style>
+    .comment-container {
+        width: 100% !important;
+    }
+    .edit-comment-form {
+        width: 100% !important;
+    }
+</style>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        // コメント内容を一時保存するための変数
+        const commentContents = {};
+
+        // 編集リンクがクリックされたときの処理
+        document.querySelectorAll('.edit-comment-link').forEach(link => {
+            link.addEventListener('click', (event) => {
+                event.preventDefault();
+                const commentId = link.getAttribute('data-comment-id');
+                const contentDiv = document.querySelector(`.comment-content[data-comment-id="${commentId}"]`);
+                const form = document.querySelector(`.edit-comment-form[data-comment-id="${commentId}"]`);
+                // 現在のコメント内容を保存
+                commentContents[commentId] = contentDiv.textContent.trim();
+                contentDiv.classList.add('d-none');
+                form.classList.remove('d-none');
+            });
+        });
+
+        // キャンセルボタンがクリックされたときの処理
+        document.querySelectorAll('.cancel-edit').forEach(button => {
+            button.addEventListener('click', (event) => {
+                const form = event.target.closest('.edit-comment-form');
+                const commentId = form.getAttribute('data-comment-id');
+                const contentDiv = document.querySelector(`.comment-content[data-comment-id="${commentId}"]`);
+                // 編集前のコメント内容をフォームにセット
+                form.querySelector('textarea').value = commentContents[commentId];
+                contentDiv.classList.remove('d-none');
+                form.classList.add('d-none');
+            });
+        });
+
+        // フォーム外のクリックでキャンセルする処理
+        document.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!target.closest('.edit-comment-form') && !target.closest('.edit-comment-link')) {
+                document.querySelectorAll('.edit-comment-form').forEach(form => {
+                    const commentId = form.getAttribute('data-comment-id');
+                    const contentDiv = document.querySelector(`.comment-content[data-comment-id="${commentId}"]`);
+                    if (!form.classList.contains('d-none')) {
+                        // 編集前のコメント内容をフォームにセット
+                        form.querySelector('textarea').value = commentContents[commentId];
+                        contentDiv.classList.remove('d-none');
+                        form.classList.add('d-none');
+                    }
+                });
+            }
+        });
+
+        // 編集フォームが送信されたときの処理
+        document.querySelectorAll('.edit-comment-form').forEach(form => {
+            form.addEventListener('submit', (event) => {
+                event.preventDefault();
+                const commentId = form.getAttribute('data-comment-id');
+                const content = form.querySelector('textarea').value;
+
+                // Ajaxリクエストの例 (必要な場合)
+                fetch(form.action, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': form.querySelector('input[name="_token"]').value,
+                    },
+                    body: JSON.stringify({
+                        _method: 'PUT',
+                        comment_content: content,
+                    }),
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        const contentDiv = document.querySelector(`.comment-content[data-comment-id="${commentId}"]`);
+                        contentDiv.textContent = content;
+                        contentDiv.classList.remove('d-none');
+                        form.classList.add('d-none');
+                        // 更新後、コメント内容を変数に保存
+                        commentContents[commentId] = content;
+                    } else {
+                        // エラーハンドリング
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                });
+            });
+        });
+
+        // 削除リンクがクリックされたときの処理
+        document.querySelectorAll('.delete-comment').forEach(link => {
+            link.addEventListener('click', (event) => {
+                event.preventDefault();
+                const commentId = link.getAttribute('data-comment-id');
+                const commentElement = document.querySelector(`.comment-container[data-comment-id="${commentId}"]`);
+
+                // Ajaxリクエストの例 (必要な場合)
+                fetch(`/comments/${commentId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        // コメントをDOMから削除
+                        commentElement.remove();
+                    } else {
+                        // エラーハンドリング
+                        console.error('Failed to delete comment:', data.message);
+                    }
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                });
+            });
+        });
+    });
+</script>
+

--- a/resources/views/favorite/favorite_button.blade.php
+++ b/resources/views/favorite/favorite_button.blade.php
@@ -1,4 +1,4 @@
-<div class="d-flex w-75 pb-3 m-auto">
+<div class="d-flex w-75 pb-4 m-auto">
     @php
         $totalFavorites = 0;
         $totalFavorites += $post->favoriteUsers->count();

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,7 @@
         <title>Topic Posts</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     </head>
     <body>
         @include('commons.header')

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -30,6 +30,7 @@
             @foreach ($posts as $post)
                 @include('posts.post', ['user' => $user, 'post' => $post])
                 @include('favorite.favorite_button', ['post' => $post])
+                @include('comments.comment', ['post' => $post])
                 <hr>
             @endforeach
         </ul>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -27,6 +27,7 @@
     @foreach ($posts as $post)
         @include('posts.post', ['post' => $post])
         @include('favorite.favorite_button', ['post' => $post])
+        @include('comments.comment', ['post' => $post])
     @endforeach
 </ul>
 <div class="m-auto" style="width: fit-content">

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,9 +49,10 @@ Route::group(['middleware' => 'auth'], function () {
     });
     // コメント
     Route::prefix('comments')->group(function () {
-        Route::post('/','CommentsController@store')->name('comment.store');
-        Route::put('{comment_id}', 'CommentsController@update')->name('comment.update');
-        Route::delete('{comment_id}', 'CommentsController@destroy')->name('comment.destroy');
+        // Route::post('/','CommentsController@store')->name('comment.store');
+        Route::post('/{post_id}', 'CommentsController@store')->name('comment.store');
+        Route::put('{commentId}', 'CommentsController@update')->name('comment.update');
+        Route::delete('{commentId}', 'CommentsController@destroy')->name('comment.destroy');
     });
     // フォロー
     Route::group(['prefix' => 'users/{id}'],function(){

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,8 +41,14 @@ Route::group(['middleware' => 'auth'], function () {
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
     // いいね
-    Route::group(['prefix' => 'movies/{id}'],function(){
+    Route::group(['prefix' => 'posts/{id}'],function(){
         Route::post('favorite','FavoriteController@store')->name('favorite');
         Route::delete('unfavorite','FavoriteController@destroy')->name('unfavorite');
+    });
+    // コメント
+    Route::prefix('comments')->group(function () {
+        Route::post('/','CommentsController@store')->name('comment.store');
+        Route::put('{comment_id}', 'CommentsController@update')->name('comment.update');
+        Route::delete('{comment_id}', 'CommentsController@destroy')->name('comment.destroy');
     });
 });


### PR DESCRIPTION
# issue
- #1116 

# 概要
- 追加機能　コメント機能

# 動作確認手順
- コメント保存
いいねアイコン・badge下のコメントフォームからコメントを保存 (store同期通信）
保存時に空と500文字制限のバリデーションを実装（それぞれの条件でバリデーションが掛かることを確認）
ログインしているユーザーの投稿にはコメントフォームが表示されない事を確認
投稿に対するコメントがユーザー詳細ページでも確認できることを確認

- コメント編集・削除はAjax(edit、destroy非同期通信）で実装
コメント編集時にも空と500文字制限のバリデーションを実装（それぞれの条件でバリデーションが掛かることを確認）
コメント編集完了時にリロードなく、動的に編集が完了することを確認
コメント削除時にリロードすることがなく、動的に削除が完了することを確認
ログインユーザーの投稿に対するコメントをログインユーザーが変更出来ない事を確認
コメントを投稿したユーザー以外がコメントを編集、削除出来ない事を確認
コメント登録時、編集、削除時にバリデーションが表示されることを確認
登録時はコントローラーへ、編集、削除時はjavascriptで実装（３秒間表示した後、消える）

# その他伝達事項
- モデルリレーションで未使用のメソッド部分を削除
- フォームでコメント登録後に１行で突き抜けるバグを解消
- ルーティングのスネークスケース記述をキャメルケースに変更
- ajaxフラッシュメッセージ関数記述を一つに統一
- 投稿とコメントフォーム高さと最大文字数を統一
- ajax削除内if文else省略の記述に変更
- コメントajax削除部分else以降の記述
- PostsControllerの$postsの定義変更