### PR TITLE
#1086 フォローによるタイムライン変更(あちょこ)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -49,4 +49,27 @@ class UsersController extends Controller
         }
         return redirect()->route('posts.index')->with('redMessage', '退会が完了しました');//withメソッドを使用してユーザー退会フラッシュメッセージを記述
     }
+
+    public function followings($id)
+    {
+        $user = User::findOrFail($id);
+        $followings = $user->followings()->orderBy('id','desc')->paginate(10);
+        $data = [
+            'user' => $user,
+            'followings' => $followings,
+        ];
+        return view('follow.followings' ,$data);
+    }
+
+    public function followers($id)
+    {
+        $user = User::findOrFail($id);
+        $followers = $user->followers()->orderBy('id','desc')->paginate(10);
+        $data = [
+            'user' => $user,
+            'followers' => $followers,
+        ];
+        return view('follow.followers' ,$data);
+    }
 }
+    

--- a/app/User.php
+++ b/app/User.php
@@ -82,7 +82,18 @@ class User extends Authenticatable
         return $this->following()->where('followed_user_id', $userId)->exists();
     }
     
-    
+    // ユーザーがフォローしているユーザーの一覧を取得するメソッド
+    public function followings()
+    {
+        return $this->belongsToMany(User::class, 'follows', 'user_id', 'followed_user_id')->withTimestamps();
+    }
+
+    // ユーザーをフォローしているユーザーの一覧を取得するメソッド
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'follows', 'followed_user_id', 'user_id')->withTimestamps();
+    }
+
     public static function boot()
     {
         parent::boot();

--- a/resources/views/follow/followers.blade.php
+++ b/resources/views/follow/followers.blade.php
@@ -22,7 +22,18 @@
                 <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/' . $user->id . '/followings') ? 'active' : '' }}">フォロー中</a></li>
                 <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/' . $user->id . '/followers') ? 'active' : '' }}">フォロワー</a></li>
             </ul>
-        @include('posts.posts', ['posts' => $posts])
+            <ul class="list-unstyled">
+            @foreach($followers as $follower)
+            <li class="mb-3 text-center">
+                 <div class="text-left d-inline-block w-75 mb-2">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="">
+                    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a></p>
+                 </div>
+            </li>   
+            @endforeach
+            <div class="text-right">{{ $followers->links('pagination::bootstrap-4') }}</div>
+            </ul> 
         </div>
-    </div>
+    </div>    
+    </ul>    
 @endsection

--- a/resources/views/follow/followings.blade.php
+++ b/resources/views/follow/followings.blade.php
@@ -22,7 +22,18 @@
                 <li class="nav-item"><a href="{{ route('followings', $user->id) }}" class="nav-link {{ Request::is('users/' . $user->id . '/followings') ? 'active' : '' }}">フォロー中</a></li>
                 <li class="nav-item"><a href="{{ route('followers', $user->id) }}" class="nav-link {{ Request::is('users/' . $user->id . '/followers') ? 'active' : '' }}">フォロワー</a></li>
             </ul>
-        @include('posts.posts', ['posts' => $posts])
+            <ul class="list-unstyled">
+            @foreach($followings as $following)
+            <li class="mb-3 text-center">
+                 <div class="text-left d-inline-block w-75 mb-2">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="">
+                    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $following->id) }}">{{ $following->name }}</a></p>
+                 </div>
+            </li>   
+            @endforeach
+            <div class="text-right">{{ $followings->links('pagination::bootstrap-4') }}</div>
+            </ul> 
         </div>
-    </div>
+    </div>    
+    </ul>    
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,9 +40,11 @@ Route::group(['middleware' => 'auth'], function () {
         Route::put('{id}', 'PostsController@update')->name('post.update');
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
-    //フォロー
+    //フォロー、フォロワー
     Route::group(['prefix' => 'user/{id}'],function(){
         Route::post('follows','FollowController@store')->name('follow');
         Route::delete('unfollow','FollowController@destroy')->name('unfollow');
+        Route::get('followings','UsersController@followings')->name('followings');
+        Route::get('followers','UsersController@followers')->name('followers');
     });
 });


### PR DESCRIPTION
## issue
- Closes #1086

## 概要
- フォロー機能（タイムライン（ユーザー詳細画面）の変更）

## 動作確認手順
- http://localhost:8080/ へ遷移する
- 任意のユーザーでログイン
- ユーザの詳細画面へ遷移する
- タブが３つ（タイムライン、フォロー中、フォロワー）あるところのフォロー中を押すとのタブがアクティブになり、ログインしたユーザがフォローした人の一覧が降順で表示され、フォロワーのタブを押すとログインしたユーザをフォローした人が降順で表示される

## 確認してほしいこと
- モデルの記述方法は正しいか
- 全体的にレビュー頂けると嬉しいです
- 段々コードが増えてきてゴチャついてきた様に思うので綺麗に出来る部分があれば指摘して欲しいです