### PR TITLE
#1128 バックエンドの全体修正（2回目）（ゆうへい）

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -55,7 +55,7 @@ class LoginController extends Controller
 
         $request->session()->regenerateToken();
 
-        // ログアウト成功時、トップ画面へ遷移し、フラッシュメッセージを表示
+        // ログアウト成功時、トップページへ遷移し、フラッシュメッセージを表示
         return redirect()->route('top')->with('success', 'ログアウトしました。');
     }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -77,7 +77,7 @@ class RegisterController extends Controller
     // RegistersUsersトレイトのregisteredメソッドをオーバーライド
     protected function registered(Request $request, $user)
     {
-        // ユーザ新規登録成功時、トップ画面へ遷移し、フラッシュメッセージを表示
+        // ユーザ新規登録成功時、トップページへ遷移し、フラッシュメッセージを表示
         return redirect()->route('top')->with('success', 'ユーザ新規登録に成功しました');
     }
 }

--- a/app/Http/Controllers/FavoriteController.php
+++ b/app/Http/Controllers/FavoriteController.php
@@ -6,14 +6,17 @@ use Illuminate\Http\Request;
 
 class FavoriteController extends Controller
 {
-    public function store($id) //ユーザが$idの投稿に対して、いいね！を実行
+    // ユーザが$idの投稿に対して、いいねを実行
+    public function store($id)
     {
-        \Auth::user()->favorite($id); // 認証されているユーザーが指定した投稿（Post）をお気に入りに追加
+        \Auth::user()->favorite($id); // 認証されているユーザが指定した投稿をいいねに追加
         return back(); // 元のページにリダイレクト
     }
-    public function destroy($id) //ユーザが$idの投稿に対して、いいね！を解除
+
+    // ユーザが$idの投稿に対して、いいね！を解除
+    public function destroy($id)
     {
-        \Auth::user()->unfavorite($id); // 認証されているユーザーが指定した投稿（Post）のお気に入りを解除
-        return back();// 元のページにリダイレクト
+        \Auth::user()->unfavorite($id); // 認証されているユーザが指定した投稿のいいねを解除
+        return back(); // 元のページにリダイレクト
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,13 +4,13 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Post; //Postモデルを使用する為のインポート、投稿データを取得する為に使用
-use App\User; //Userモデルを使用する為のインポート、ユーザデータを取得する為に使用
 use App\Http\Requests\PostRequest; //フォームリクエストの宣言（バリデーションを切り分ける）
 use Illuminate\Support\Facades\Auth; // Authファサードをインポート
 use Illuminate\Support\Facades\Log;
 
 class PostsController extends Controller
 {
+    // 投稿一覧ページ
     public function index(Request $request)
     {
         // 検索キーワードを取得
@@ -37,6 +37,7 @@ class PostsController extends Controller
         return view('welcome', compact('posts', 'keyword'));
     }
 
+    // 投稿保存処理
     // 通常のRequestクラスの代わりにPostRequestクラスをメソッドの引数として指定
     public function store(PostRequest $request) // これにより、メソッドが呼び出される前に自動的にリクエストデータがバリデーションされる
     {
@@ -46,6 +47,16 @@ class PostsController extends Controller
         $post->save();
 
         return back()->with('success', 'ポストの投稿に成功しました。');
+    }
+
+    // 投稿詳細ページ
+    public function show($id)
+    {
+        //テーブルpostからidが$IDのレコードを探し出す
+        $post = Post::findOrFail($id);
+
+        // viewとしてshow.bladeの呼び出す with()メソッドをつなげてshow.blade内で$post変数として使用
+        return view('posts.show')->with('post', $post);
     }
 
     // 投稿編集ページ
@@ -77,7 +88,7 @@ class PostsController extends Controller
         return redirect()->route('top')->with('success', 'ポストの更新に成功しました。');
     }
 
-    // 投稿削除
+    // 投稿削除処理
     public function destroy($id)
     {
         $post = post::findOrFail($id);
@@ -89,12 +100,5 @@ class PostsController extends Controller
         }
 
         return back();
-    }
-
-    // 投稿詳細遷移
-    public function show($id)
-    {
-        $post = Post::findOrFail($id); //テーブルpostからidが$IDのレコードを探し出す
-        return view('posts.show')->with('post', $post);// viewとしてshow.bladeの呼び出す　with()メソッドをつなげてshow.blade内で$post変数として使用　
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -5,14 +5,13 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Requests\UserRequest;
 use App\User;
-use App\Post;
 use Illuminate\Support\Facades\Hash;
 use App\Services\UserService;
 use Illuminate\Support\Facades\Log;
 
 class UsersController extends Controller
 {
-    // ユーザ詳細
+    // ユーザ詳細ページ
     public function show(Request $request, $id)
     {
         $user = User::findOrFail($id);
@@ -55,17 +54,17 @@ class UsersController extends Controller
         return view('follow.follow_list', compact('user', 'users', 'counts'));
     }
 
-    // ユーザ編集画面
+    // ユーザ編集ページ
     public function edit($id)
     {
         $user = User::findOrFail($id);
 
-        // ユーザが認証しており、且つ認証しているユーザのidとリクエストのidが一致している場合、ユーザ編集画面を表示
+        // ユーザが認証しており、且つ認証しているユーザのidとリクエストのidが一致している場合、ユーザ編集ページを表示
         if (\Auth::check() && \Auth::id() == $id) {
             return view('users.edit', ['user' => $user]);
         }
 
-        abort(404); // デモ画面は、ログイン画面に遷移させていたが、挙動がうまくいかなかったため、404エラーを返すように実装
+        abort(404); // デモ画面は、ログインページに遷移させていたが、挙動がうまくいかなかったため、404エラーを返すように実装
     }
 
     // ユーザ更新処理
@@ -81,7 +80,7 @@ class UsersController extends Controller
         return redirect()->route('users.show', ['id' => $user->id]);
     }
 
-    // ユーザ削除
+    // ユーザ削除処理
     protected function destroy($id)
     {
         // 指定されたユーザIDを取得
@@ -90,7 +89,7 @@ class UsersController extends Controller
         // ログインユーザのIDと指定されたIDが一致する場合のみユーザを削除
         if (\Auth::id() === $user->id) {
             $user->delete(); // ユーザを削除
-            return redirect()->route('top')->with('success', '退会処理が完了しました'); // 一覧画面へリダイレクト
+            return redirect()->route('top')->with('success', '退会処理が完了しました'); // トップページへリダイレクト
         } else {
             // ユーザ削除の条件を満たしていない場合はエラーメッセージを表示
             return back()->with('error', 'ユーザの削除は許可されていません');

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -31,13 +31,4 @@ class UserRequest extends FormRequest
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ];
     }
-
-    public function attributes()
-    {
-        return [
-            'name' => '名前',
-            'email' => 'メールアドレス',
-            'password' => 'パスワード',
-        ];
-    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -5,12 +5,12 @@ namespace App;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\SoftDeletes; //laravelに備え付けの論理削除を使えるようにする記述
+use Illuminate\Database\Eloquent\SoftDeletes; // Laravelに備え付けの論理削除を使えるようにする記述
 
 class User extends Authenticatable
 {
     use Notifiable;
-    use SoftDeletes; //クラス内で呼び出す宣言
+    use SoftDeletes; // クラス内で呼び出す宣言
 
     /**
      * The attributes that are mass assignable.
@@ -64,8 +64,10 @@ class User extends Authenticatable
         if ($this->id == $userId || $this->isFollowing($userId)) {
             return false;
         }
+
         // 対象ユーザをフォロー
         $this->followings()->attach($userId);
+
         return true;
     }
 
@@ -76,8 +78,10 @@ class User extends Authenticatable
         if ($this->id == $userId || !$this->isFollowing($userId)) {
             return false;
         }
+
         // フォロー中なら解除
         $this->followings()->detach($userId);
+
         return true;
     }
 
@@ -87,8 +91,7 @@ class User extends Authenticatable
         return $this->followings()->where('followed_id', $userId)->exists();
     }
 
-    // 退会ユーザ所有の投稿削除
-    // ユーザデータ削除後に投稿データを削除
+    // 退会ユーザ所有の投稿削除（ユーザデータ削除後に投稿データを削除）
     public static function boot()
     {
         parent::boot();
@@ -97,44 +100,58 @@ class User extends Authenticatable
             $user->posts()->delete();
         });
     }
-    // いいね機能 
+
+    // いいね機能
     public function favorites()
     {
         return $this->belongsToMany(Post::class, 'favorites', 'user_id', 'post_id')->withTimestamps();
     }
-    // ユーザーが特定の投稿をお気に入りに追加
+
+    // ユーザが特定の投稿をいいねに追加
     public function favorite($postId)
-    {   
+    {
         $post = Post::findOrFail($postId);
+
         // 投稿が自分のものであるかを確認
         if ($post->user_id == $this->id) {
-            return false; // 自分の投稿の場合、falseを返す
+            // 自分の投稿の場合、falseを返す
+            return false;
         }
-        $exist = $this->isFavorite($postId); // 投稿が既にお気に入りに追加されているかどうかを確認
+
+        // 投稿が既にいいねに追加されているかどうかを確認
+        $exist = $this->isFavorite($postId);
         if ($exist) {
             return false;
         } else {
-            $this->favorites()->attach($postId); // お気に入りに追加
+            // いいねに追加
+            $this->favorites()->attach($postId);
             return true;
         }
     }
-    // ユーザーが特定の投稿をお気に入りから削除
+
+    // ユーザが特定の投稿をいいねから削除
     public function unfavorite($postId)
     {
         $post = Post::findOrFail($postId);
+
         // 投稿が自分のものであるかを確認
         if ($post->user_id == $this->id) {
-            return false; // 自分の投稿の場合、falseを返す
+            // 自分の投稿の場合、falseを返す
+            return false;
         }
-        $exist = $this->isFavorite($postId); //投稿が既にお気に入りに追加されているかどうかを確認
+
+        // 投稿が既にいいねに追加されているかどうかを確認
+        $exist = $this->isFavorite($postId);
         if ($exist) {
-            $this->favorites()->detach($postId); //既にお気に入りに追加されている場合は、お気に入りから削除
+            // 既にいいねに追加されている場合は、いいねから削除
+            $this->favorites()->detach($postId);
             return true;
         } else {
             return false;
         }
     }
-    // 特定の投稿がユーザーのお気に入りに追加されているかどうかを確認
+
+    // 特定の投稿がユーザのいいねに追加されているかどうかを確認
     public function isFavorite($postId)
     {
         return $this->favorites()->where('post_id', $postId)->exists();

--- a/database/migrations/2024_05_17_023346_create_favorites_table.php
+++ b/database/migrations/2024_05_17_023346_create_favorites_table.php
@@ -15,12 +15,16 @@ class CreateFavoritesTable extends Migration
     {
         Schema::create('favorites', function (Blueprint $table) {
             $table->bigIncrements('id');
+
             $table->bigInteger('user_id')->unsigned()->index();
+            $table->foreign('user_id')->references('id')->on('users')
+                  ->onUpdate('cascade')->onDelete('cascade');
+
             $table->bigInteger('post_id')->unsigned()->index();
+            $table->foreign('post_id')->references('id')->on('posts')
+                  ->onUpdate('cascade')->onDelete('cascade');
+
             $table->timestamps();
-            // 外部キー制約
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
             $table->unique(['user_id','post_id']);
         });
     }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -654,10 +654,10 @@ class PostsTableSeeder extends Seeder
                 $hobby = $hobbies[array_rand($hobbies)];
                 // 選ばれた趣味に対応するランダムなコメントを取得
                 $comment = $hobby_comments[$hobby][array_rand($hobby_comments[$hobby])];
-                
+
                 // 現在から過去1週間の範囲でランダムな日時を生成
                 $createdAt = Carbon::now()->subDays(rand(0, 7))->subHours(rand(0, 23))->subMinutes(rand(0, 59));
-                
+
                 $posts[] = [
                     'user_id' => $userId, // 1から100までのユーザIDを割り当て
                     'content' => $comment, // ランダムなコメントを追加
@@ -671,4 +671,3 @@ class PostsTableSeeder extends Seeder
         DB::table('posts')->insert($posts);
     }
 }
-

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -146,6 +146,7 @@ return [
         'name' => '名前',
         'email' => 'メールアドレス',
         'password' => 'パスワード',
+        'content' => '本文',
     ],
 
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,7 @@ Route::group(['prefix' => 'users/{id}'],function(){
     Route::get('followers','UsersController@followers')->name('followers');
 });
 
-// ユーザ編集画面・更新(ログインユーザのみ、prefixでグループ化)
+// ユーザ編集ページ・更新(ログインユーザのみ、prefixでグループ化)
 Route::group(['middleware' => 'auth'], function(){
     Route::prefix('users')->group(function() {
         Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
@@ -64,4 +64,3 @@ Route::group(['prefix' => 'posts', 'middleware' => 'auth'], function () {
 // いいね機能
 Route::post('{id}/favorite','FavoriteController@store')->name('favorite');
 Route::delete('{id}/unfavorite','FavoriteController@destroy')->name('unfavorite');
-


### PR DESCRIPTION
## issue
- Closes #1128 

## 概要
- バックエンドの全体修正（2回目）を行いました。
  - いいね機能と投稿詳細のコードを改善しました。
  - バリデーションの文言を一部改善しました。
  - `app/Http/Requests/UserRequest.php`の`attributes`メソッドを削除しました。
  - コメントアウトの整備しました。
  - 不要なuse文を削除しました。
  - 必要に応じで、改行やスペース、インデントを調整しました。
  - 一部の文言を統一しました。（例：ユーザー→ユーザ、画面→ページ）
  - その他、軽微な修正を行いました。

## 動作確認手順
- `php artisan migrate:fresh --seed`コマンドを実行する。
- http://localhost:8080/ にアクセスする。

## 考慮して欲しいこと
- フロントエンドの全体修正（2回目）は未対応。

## 確認して欲しいこと
- デグレが発生していないか。
- その他、バックエンドの全体修正（2回目）にて対応すべきことはあるか。