### PR TITLE
#95 posts（投稿）テーブルのマイグレーションとシーダー作成(中川)

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -5,12 +5,12 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Posts extends Model
+class Post extends Model
 {
     use SoftDeletes;
 
     public function user()
     {
-        return $this->belongsTo(Posts::class);
+        return $this->belongsTo(Users::class);
     }    
 }

--- a/app/Posts.php
+++ b/app/Posts.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Posts extends Model
+{
+    use SoftDeletes;
+
+    public function user()
+    {
+        return $this->belongsTo(Posts::class);
+    }    
+}

--- a/database/migrations/2024_06_16_000000_create_posts_table.php
+++ b/database/migrations/2024_06_16_000000_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('content');
+            $table->timestamps();
+            $table->softDeletes();
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
          $this->call(UsersTableSeeder::class);
+         $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {    
+        DB::table('posts')->insert([
+            'content' => 'test1',
+            'user_id' => 1,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test2',
+            'user_id' => 2,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test3',
+            'user_id' => 3,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test4',
+            'user_id' => 4,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test5',
+            'user_id' => 1,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test6',
+            'user_id' => 2,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test7',
+            'user_id' => 3,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test8',
+            'user_id' => 4,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test9',
+            'user_id' => 1,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test10',
+            'user_id' => 2,
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'test11',
+            'user_id' => 3,
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes [posts（投稿）テーブルのマイグレーションとシーダー作成 #95](https://github.com/yukihiroLaravel/joint_develop/issues/95)

## 概要
- posts（投稿）テーブルのマイグレーションとシーダー作成

## 動作確認手順
- 下記コマンドを実行
php artisan migrate --seed
 - Adminerでpostsテーブルに11個のレコードが保存されていることを確認

## 考慮して欲しいこと
- 状況に応じて、下記コマンドで動作確認する必要あり。
php artisan migrate:fresh --seed
usersテーブルのidカラムに2～４が登録されている状態で確認