### PR TITLE
#107 ユーザ新規登録(大川)

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -29,7 +29,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.

--- a/config/app.php
+++ b/config/app.php
@@ -228,4 +228,6 @@ return [
 
     ],
 
+    //TOPIC_POSTS_TITLE
+    'TopicPostsTitle' => env('TOPIC_POSTS_TITLE', 'Topic Posts'),
 ];

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+@section('content')
+    <div class="text-center">
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>{{ config('app.TopicPostsTitle') }}</h1>
+    </div>
+    <div class="text-center mt-3">
+        <p class="text-left d-inline-block">新規ユーザ登録すると投稿で<br>コミュニケーションができるようになります。</p>
+    </div>
+    <div class="text-center">
+        <h3 class="login_title text-left d-inline-block mt-5">新規ユーザ登録</h3>
+    </div>
+    <div class="row mt-5 mb-5">
+        <div class="col-sm-6 offset-sm-3">
+            <form method="POST" action="{{ route('signup.post') }}">
+                @csrf
+                <div class="form-group">
+                    <label for="name">名前</label>
+                    <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}">
+                </div>
+                <div class="form-group">
+                    <label for="email">メールアドレス</label>
+                    <input id="email" type="text" class="form-control" name="email" value="{{ old('email') }}">
+                </div>
+                <div class="form-group">
+                    <label for="password">パスワード</label>
+                    <input id="password" type="password" class="form-control" name="password" value="{{ old('password') }}">
+                </div>
+                <div class="form-group">
+                    <label for="password_confirmation">パスワード確認</label>
+                    <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" value="{{ old('password_confirmation') }}">
+                </div>
+                <button type="submit" class="btn btn-primary mt-2">新規登録</button>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,3 +14,7 @@
 Route::get('/', function () {
     return view('welcome');
 });
+
+// ユーザ新規登録
+Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
+Route::post('signup', 'Auth\RegisterController@register')->name('signup.post'); 


### PR DESCRIPTION
## issue
- Closes #107 

## 動作確認手順
https://www.dropbox.com/scl/fi/k74pqbznw97xpm7k0f9ww/UT.xlsx?rlkey=a05gp90ryo7svzvuy5ggwyry5&dl=0
の
ユーザ新規登録のUT.xlsx
（ webで開いた時に、読み込みに数十秒まつ必要あるかも、ダウンロードしてからローカルで見た方が。 )
にて、UTしました。
412のチャットで書きましたが、周辺モジュールが未だないので、
Laravel応用講座の
resources/views/layouts/app.blade.php
resources/views/commons/header.blade.php
resources/views/commons/error_messages.blade.php
resources/views/commons/footer.blade.php
をローカル環境にコピペして、周辺環境整えて、これらをテストドライバーとして動作確認してます。
これらは、現タスクではプッシュしません。
これに、相当するものがタスクであがってきたら、ローカルのこれらを消して、それを取り込みます

## 考慮してほしいこと
#94 users（ユーザ）テーブルのマイグレーションとシーダー作成(大川)
時点では、
database/seeds/UsersTableSeeder.php
は、
DB::table('users')->insert([
した時は、created_at、updated_atは指定しないとNULLで登録されるため、now()を指定してました
が、
RegisterController.php
User::create([　であるため、created_at、updated_atは指定なしでも、自動で値入ります。( 動確済 )
のでこれでよしとした。

config/app.php
    //TOPIC_POSTS_TITLE
    'TopicPostsTitle' => env('TOPIC_POSTS_TITLE', 'Topic Posts'),
での、
resources/views/auth/register.blade.php
<h1><i class="fab fa-telegram fa-lg pr-3"></i>{{ config('app.TopicPostsTitle') }}</h1>
で、.envに定義で、タイトル文言を可変にできるので、
一旦、そうしておきます
ただし、このやり方だと、HTMLを指定できないです。
TOPIC_POSTS_TITLE=いい感じのツィートしとこうよ
を
TOPIC_POSTS_TITLE=<span style="color: red">いい感じのツィートしとこうよ</span>
としても、{{ config('app.TopicPostsTitle') }}のところで、エスケープされるなどしてうまくいかないようですが
その必要性があるのかどうかも、現時点不明なので、
その必要があれば、grepして、
カスタムディレクティブなど別の方法で置き換えていけばよいかと思いましたので、
一旦は、これでよいかと思いました

