### PR TITLE
#95 posts（投稿）テーブルのマイグレーションとシーダー作成（しみず）

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Post extends Model
 {
     use SoftDeletes;
+    
     public function user()
     {
         return $this->belongsTo(User::class);

--- a/app/Post.php
+++ b/app/Post.php
@@ -5,7 +5,7 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Posts extends Model
+class Post extends Model
 {
     use SoftDeletes;
     public function user()

--- a/app/Posts.php
+++ b/app/Posts.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Posts extends Model
+{
+    use SoftDeletes;
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -38,4 +38,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Posts:class);
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -41,6 +41,6 @@ class User extends Authenticatable
 
     public function posts()
     {
-        return $this->hasMany(Posts:class);
+        return $this->hasMany(Post::class);
     }
 }

--- a/database/migrations/2024_08_19_134240_create_posts_table.php
+++ b/database/migrations/2024_08_19_134240_create_posts_table.php
@@ -15,8 +15,8 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('user_id')->unsigned()->index()->nullable();
-            $table->string('post');
+            $table->bigInteger('user_id')->unsigned()->index()
+            $table->string('content');
             $table->timestamps();
             $table->softDeletes();
             //外部キー制約

--- a/database/migrations/2024_08_19_134240_create_posts_table.php
+++ b/database/migrations/2024_08_19_134240_create_posts_table.php
@@ -15,7 +15,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('user_id')->unsigned()->index()
+            $table->bigInteger('user_id')->unsigned()->index();
             $table->string('content');
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2024_08_19_134240_create_posts_table.php
+++ b/database/migrations/2024_08_19_134240_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index()->nullable();
+            $table->string('post');
+            $table->timestamps();
+            $table->softDeletes();
+            //外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,6 +12,7 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,4 +13,5 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
     }
+
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -11,12 +11,12 @@ class PostsTableSeeder extends Seeder
      */
     public function run()
     {
-        //テスト代入件数　10件
+        //テスト代入件数　30件
 
-        for($i = 1; $i < 11; $i++){
+        for($i = 1; $i < 31; $i++){
             DB::table('posts')->insert([
                 'user_id'=> $i,
-                'post'=> $i.'番です',
+                'content'=> $i.'番です',
                 'created_at' => now(),
                 'updated_at' => now(),
             ]);

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //テスト代入件数　10件
+
+        for($i = 1; $i < 11; $i++){
+            DB::table('posts')->insert([
+                'user_id'=> $i,
+                'post'=> $i.'番です',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+        
+    } 
+}


### PR DESCRIPTION
## issue
- Closes #95

## 概要
- Postテーブルのマイグレーションとシーダー作成

## 動作確認手順
- 下記のコマンドを実行  
php artisan db:seed --class=UsersTableSeeder
php artisan db:seed --class=PostsTableSeeder
を実行。
Adminerでポストテーブルに10個のレコードが保存されていることを確認。

## 考慮して欲しいこと
- 状況に応じて下記コマンドで動作確認してください。
php artisan migration:fresh --seed