### PR TITLE
ユーザー詳細のレビュー対応時の削除や先祖返りを修正(大川)

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Post extends Model
+{
+    use SoftDeletes;
+    
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -38,4 +38,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/database/migrations/2024_08_19_134240_create_posts_table.php
+++ b/database/migrations/2024_08_19_134240_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('content');
+            $table->timestamps();
+            $table->softDeletes();
+            //外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,7 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
+
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //テスト代入件数　30件
+
+        for($i = 1; $i < 31; $i++){
+            DB::table('posts')->insert([
+                'user_id'=> $i,
+                'content'=> $i.'番です',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+        
+    } 
+}


### PR DESCRIPTION
# ユーザー詳細のレビュー対応時の削除や先祖返りを修正
ユーザー詳細のレビュー対応時になにかをミスったのか
原因不明で、大変申し訳ございませんが、
下記のものが削除されたり、先祖返りしてましたので、
その修正のためのプルリクエストを行いました。
紐づいてるIssueは特にありません。
********************
app/Post.php
が削除されてしまった分の復元
********************
app/User.php
が先祖返りした分の復活
********************
database/migrations/2024_08_19_134240_create_posts_table.php
が削除されてしまった分の復元
********************
database/seeds/DatabaseSeeder.php
が先祖返りした分の復活
********************
database/seeds/PostsTableSeeder.php
が削除されてしまった分の復元
*******************
↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
php artisan migrate:fresh --seed
動きました

