### PR TITLE
#95 posts（投稿）テーブルのマイグレーションとシーダー作成(ゆうじ)

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Post extends Model
+{
+    use SoftDeletes;
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -38,4 +38,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/database/migrations/2024_08_20_215515_create_posts_table.php
+++ b/database/migrations/2024_08_20_215515_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('post');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->timestamps();
+            $table->softDeletes();
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\User;
+use App\Post;
+use Faker\Factory as Faker;
+
+class PostsTableSeeder extends Seeder
+{
+    public function run()
+    {
+        $faker = Faker::create('ja_JP'); // 日本語のFakerインスタンスを作成
+
+        $users = User::all();
+
+        foreach ($users as $user) {
+            Post::create([
+                'user_id' => $user->id,
+                'post' => $faker->realText(50, 5), // ランダムな日本語テキストを生成
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## issue
- Closes #95

## 概要
- posts（投稿）テーブルのマイグレーションとシーダー作成

## 動作確認手順
- 下記コマンドを実行
```
php artisan migrate --seed"
```

- Adminerにて`users`テーブルのレコードと同数のレコードが`posts`テーブルに追加されることを確認(postカラムの内容は日本語で50文字のランダム文章が作成される)
http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=users

### 考慮して欲しいこと
> `users`テーブルにレコードが既に存在する場合はより多くの`posts`レコードが作成される為、
> その場合は`:fresh`を付与することで分かりやすくなると思います。

- 状況に応じて、下記コマンドで確認する必要あり
```
php artisan migrate:fresh --seed"
```

## 確認して欲しいこと
- 今回は特にありません。
