### PR TITLE
#125 ユーザ退会(大川)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -18,4 +18,16 @@ class Controller extends BaseController
     {
         return $user->posts()->orderBy('id', 'desc')->paginate(10);
     }
+
+    /**
+     * 「$user」および、関連モデルのレコードを削除する。
+     */
+    protected function deleteUserRelations($user)
+    {
+        // posts
+        $user->posts()->delete();
+
+        // users
+        $user->delete();
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -52,4 +52,19 @@ class UsersController extends Controller
         
         return view('users.show', $data);
     }
+
+    /**
+     *  削除
+     */
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+
+        \DB::transaction(function () use ($user) {
+            // 「$user」および、関連モデルのレコードを削除する。
+            $this->deleteUserRelations($user);
+        });
+
+        return redirect('/');
+    }
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -11,6 +11,7 @@
     </div>
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
+            @include('commons.error_messages')
             <form method="POST" action="{{ route('signup.post') }}">
                 @csrf
                 <div class="form-group">

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,3 +33,12 @@ Route::group(['prefix' => 'users/{id}'],function(){
     Route::get('followers','UsersController@followers')->name('user.followers');
     // *******************
 });
+
+// ログイン後
+Route::group(['middleware' => 'auth'], function() {
+    // 「ユーザ」
+    Route::prefix('users')->group(function(){
+        // 削除
+        Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ Route::group(['middleware' => 'auth'], function() {
     Route::prefix('users')->group(function(){
         // 削除
         Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
+    });
     // 「投稿」
     Route::prefix('posts')->group(function(){
         // 登録


### PR DESCRIPTION
## issue
- Closes #125

## 動作確認手順
https://www.dropbox.com/scl/fi/mhmq6yjcj53qbeb3ge8wu/UT.xlsx?rlkey=zirbyg9fcfy6iayhn4j5lu1fm&dl=0
の
ユーザ退会のUT.xlsx
にて、UTをしました。
前、タスクと同様のテストドライバーのモジュールにローカル配置してます。（　それらは、現タスクでプッシュしません )
ユーザ編集もどきのテストドライバーから退会ボタンを押して
動作確認してます。
退会時に、usersと紐づくpostsが論理削除され
お手本サイトどうよう、退会したユーザの
メールアドレスでのユーザ登録は、
メールアドレス重複エラーで登録できない
を確認しています。


## 考慮してほしいこと
他のissueがdevelop_a_haduki_draにマージされたら
このissueは、web.phpのところでコンフリクトになるのは
想定しているのであるが、
一旦は、このプルリクを作成時点では、コンフリクトなしなので
その件、除いてのレビューをお願いします
このコンフリクト以外での対応すべき要素を先につぶしたい。
その後、コンフリクト対応します。


usersの論理削除に先だって、
postsの論理削除の件で、
User側でのdeletingなどのイベントでのハンドラーで
postsの論理削除をする方式もあったのですが
DBトランザクションが効かせるかというのが気になった
( あきらかに、そのイベントハンドラーで書いたらUserの論理削除はトランザクションの外に出てしまうように感じた )
それから、将来的に、フォロー関連が増えた時に
それの論理削除みたいなことも、
突っ込める受け皿の実装を考慮したかった。

下記の実装にしました。
app/Http/Controllers/Controller.php
にて

```

    /**
     * 「$user」および、関連モデルのレコードを削除する。
     */
    protected function deleteUserRelations($user)
    {
        // posts
        $user->posts()->delete();

        // users
        $user->delete();
    }

```
を実装した。


このメソッドではトランザクションの実装はしない
トランザクションの実装として、上記、メソッド以外に
他もしなければならなくなったときなどの
柔軟性がなくなるから


app/Http/Controllers/UsersController.php
で、上記をトランザクション内で実行し、
return redirect('/');でトップ画面に遷移する

```
    /**
     *  削除
     */
    public function destroy($id)
    {
        $user = User::findOrFail($id);

        \DB::transaction(function () use ($user) {
            // 「$user」および、関連モデルのレコードを削除する。
            $this->deleteUserRelations($user);
        });

        return redirect('/');
    }
```

他、

slackの412でメッセージ送信したとおり
@include('commons.error_messages')
は、個別画面でないと位置調整が困難である
ユーザ登録は、メールアドレスの重複チェックがあり
ユーザ退会　時の論理削除したユーザの
メールアドレスでのユーザ登録時に、
メールアドレスの重複チェックのバリデーションエラーがでるかの調査
との兼ね合いがあり
「ユーザ登録のresources/views/auth/register.blade.php」
に、
@include('commons.error_messages')
の追加を、当issueでのプッシュ対象にしてます。
現時点では、上記の調査の流れより
ユーザ退会が最も関連性が高いため
