### PR TITLE
 posts(投稿)テーブルのマイグレーションとシーダー作成の修正(大畑)

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\App\Use;
+
+class Post extends Model
+{
+    use SoftDeletes;
+    
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -38,4 +38,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/database/migrations/2024_08_21_022006_create_posts_table.php
+++ b/database/migrations/2024_08_21_022006_create_posts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('contents');
+            $table->bigInteger('users_id')->unsigned()->index();
+            $table->timestamps();
+            $table->softDeletes();
+            // 外部キー制約
+            $table->foreign('users_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/migrations/2024_08_21_022006_create_posts_table.php
+++ b/database/migrations/2024_08_21_022006_create_posts_table.php
@@ -16,8 +16,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('name');
-            $table->string('contents');
+            $table->string('content');
             $table->bigInteger('users_id')->unsigned()->index();
             $table->timestamps();
             $table->softDeletes();

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -14,68 +14,57 @@ class PostsTableSeeder extends Seeder
     {
         DB::table('posts')->insert([
             'user_id' => '1',
-            'name' => 'test1',
-            'contents' => '大会初日の結果',
+            'content' => '大会初日の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '1',
-            'name' => 'test1',
-            'contents' => '大会2日目の結果',
+            'content' => '大会2日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '1',
-            'name' => 'test1',
-            'contents' => '大会3日目の結果',
+            'content' => '大会3日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '2',
-            'name' => 'test2',
-            'contents' => '大会4日目の結果',
+            'content' => '大会4日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '2',
-            'name' => 'test2',
-            'contents' => '大会5日目の結果',
+            'content' => '大会5日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '2',
-            'name' => 'test2',
-            'contents' => '大会6日目の結果',
+            'content' => '大会6日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '3',
-            'name' => 'test3',
-            'contents' => '大会7日目の結果',
+            'content' => '大会7日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '3',
-            'name' => 'test3',
-            'contents' => '大会8日目の結果',
+            'content' => '大会8日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '3',
-            'name' => 'test3',
-            'contents' => '大会9日目の結果',
+            'content' => '大会9日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '4',
-            'name' => 'test4',
-            'contents' => '大会10日目の結果',
+            'content' => '大会10日目の結果',
         ]);
 
         DB::table('posts')->insert([
             'user_id' => '4',
-            'name' => 'test4',
-            'contents' => '大会11日目の結果',
+            'content' => '大会11日目の結果',
         ]);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('posts')->insert([
+            'user_id' => '1',
+            'name' => 'test1',
+            'contents' => '大会初日の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '1',
+            'name' => 'test1',
+            'contents' => '大会2日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '1',
+            'name' => 'test1',
+            'contents' => '大会3日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '2',
+            'name' => 'test2',
+            'contents' => '大会4日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '2',
+            'name' => 'test2',
+            'contents' => '大会5日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '2',
+            'name' => 'test2',
+            'contents' => '大会6日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '3',
+            'name' => 'test3',
+            'contents' => '大会7日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '3',
+            'name' => 'test3',
+            'contents' => '大会8日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '3',
+            'name' => 'test3',
+            'contents' => '大会9日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '4',
+            'name' => 'test4',
+            'contents' => '大会10日目の結果',
+        ]);
+
+        DB::table('posts')->insert([
+            'user_id' => '4',
+            'name' => 'test4',
+            'contents' => '大会11日目の結果',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes #95

## 概要
- posts（投稿）テーブルのマイグレーションとシーダー作成

## 動作確認手順
- 下記コマンドを実行
```
docker exec laravel_app bash -c "cd /var/www/html/laravelapp && php artisan migrate --seed"
```

- Adminerにて`users`テーブルに5つのレコードが追加されることを確認
http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=users

### 考慮して欲しいこと

- 状況に応じて、下記コマンドで確認する必要あり
```
docker exec laravel_app bash -c "cd /var/www/html/laravelapp && php artisan migrate:fresh --seed"
```

## 確認して欲しいこと