### PR TITLE
フォローのデータベース関連(大川)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -18,16 +18,4 @@ class Controller extends BaseController
     {
         return $user->posts()->orderBy('id', 'desc')->paginate(10);
     }
-
-    /**
-     * 「$user」および、関連モデルのレコードを削除する。
-     */
-    protected function deleteUserRelations($user)
-    {
-        // posts
-        $user->posts()->delete();
-
-        // users
-        $user->delete();
-    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -61,8 +61,7 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
 
         \DB::transaction(function () use ($user) {
-            // 「$user」および、関連モデルのレコードを削除する。
-            $this->deleteUserRelations($user);
+            $user->delete();
         });
 
         return redirect('/');

--- a/app/User.php
+++ b/app/User.php
@@ -12,6 +12,22 @@ class User extends Authenticatable
     use Notifiable;
     use SoftDeletes;
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        self::deleting(function ($user) {
+            // フォロー情報の削除( 性能考慮で直接的な削除をする )
+            // from_user_idで絞って削除
+            \DB::table('follows')->where('from_user_id', $user->id)->delete();
+            // to_user_idで絞って削除
+            \DB::table('follows')->where('to_user_id', $user->id)->delete();
+
+            // 紐づいてるpostsの削除
+            $user->posts()->delete();
+        });
+    }
+
     /**
      * The attributes that are mass assignable.
      *
@@ -42,5 +58,114 @@ class User extends Authenticatable
     public function posts()
     {
         return $this->hasMany(Post::class);
+    }
+
+    /**
+     * 「フォロー中」のUserのリストを取得
+     */
+    public function followings()
+    {
+        // 「$this」のUserが「フォロー中」のUserのリストを取得
+
+        // belongsToMany(相手のモデル, ‘中間テーブル名’, ‘自モデルの外部キー名’, ‘相手モデルの外部キー名’)
+        
+        // 相手のモデル             - 相手もUser
+        // 中間テーブル名           - follows
+        // 自モデルの外部キー名     - from_user_id ( 自分「$this」が、フォローしている側だから )
+        // 相手モデルの外部キー名   - to_user_id   上記と逆の項目を相手側として指定
+
+        // 
+        // ->withPivot('id')
+        // ->orderBy('follows.id', 'desc')
+        // followsのidの降順、つまり、フォロー関係が作られたのが新しい順で
+        // 取得するために必要。
+        //
+        // ->withTimestamps()は、created_at、updated_atの設定を自動化させるため
+
+        return $this->belongsToMany(User::class, 'follows', 'from_user_id', 'to_user_id')
+                    ->withPivot('id')
+                    ->orderBy('follows.id', 'desc')
+                    ->withTimestamps();
+    }
+
+    /**
+     * 「フォロワー」のUserのリストを取得
+     */
+    public function followers()
+    {
+        // 「$this」のUserの「フォロワー」のUserのリストを取得
+        // 言い換えると、「$this」のUserが、フォローされている側となってるUserのリストを取得
+
+        // belongsToMany(相手のモデル, ‘中間テーブル名’, ‘自モデルの外部キー名’, ‘相手モデルの外部キー名’)
+        
+        // 相手のモデル             - 相手もUser
+        // 中間テーブル名           - follows
+        // 自モデルの外部キー名     - to_user_id ( 自分「$this」が、フォローされている側だから )
+        // 相手モデルの外部キー名   - from_user_id   上記と逆の項目を相手側として指定
+
+        // 
+        // ->withPivot('id')
+        // ->orderBy('follows.id', 'desc')
+        // followsのidの降順、つまり、フォロー関係が作られたのが新しい順で
+        // 取得するために必要。
+        //
+        // ->withTimestamps()は、created_at、updated_atの設定を自動化させるため
+
+        return $this->belongsToMany(User::class, 'follows', 'to_user_id', 'from_user_id')
+                    ->withPivot('id')
+                    ->orderBy('follows.id', 'desc')
+                    ->withTimestamps();
+    }
+
+    /**
+     * フォローする。
+     */
+    public function follow($other_user_id)
+    {
+        // 「$this」のUserが、$other_user_idのUserをフォローする。
+
+        $exist = $this->isFollowings($other_user_id);
+        if ($exist) {
+            return false;
+        } else {
+            $this->followings()->attach($other_user_id);
+            return true;
+        }
+    }
+
+    /**
+     * フォローを解除する。
+     */
+    public function unfollow($other_user_id)
+    {
+        // 「$this」のUserが、$other_user_idのUserをフォローを解除する。
+
+        $exist = $this->isFollowings($other_user_id);
+        if ($exist) {
+            $this->followings()->detach($other_user_id);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * 「フォロー中」かどうか
+     */
+    public function isFollowings($other_user_id)
+    {
+        // 「$this」のUserが「$other_user_id」のUserを「フォロー中」かどうか
+
+        return $this->followings()->where('to_user_id', $other_user_id)->exists();
+    }
+
+    /**
+     * 「フォロワー」かどうか
+     */
+    public function isFollowers($other_user_id)
+    {
+        // 「$other_user_id」のUserが「$this」のUserの「フォロワー」かどうか
+
+        return $this->followers()->where('from_user_id', $other_user_id)->exists();
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -120,15 +120,15 @@ class User extends Authenticatable
     /**
      * フォローする。
      */
-    public function follow($other_user_id)
+    public function follow($otherUserId)
     {
-        // 「$this」のUserが、$other_user_idのUserをフォローする。
+        // 「$this」のUserが、$otherUserIdのUserをフォローする。
 
-        $exist = $this->isFollowings($other_user_id);
+        $exist = $this->isFollowings($otherUserId);
         if ($exist) {
             return false;
         } else {
-            $this->followings()->attach($other_user_id);
+            $this->followings()->attach($otherUserId);
             return true;
         }
     }
@@ -136,13 +136,13 @@ class User extends Authenticatable
     /**
      * フォローを解除する。
      */
-    public function unfollow($other_user_id)
+    public function unfollow($otherUserId)
     {
-        // 「$this」のUserが、$other_user_idのUserをフォローを解除する。
+        // 「$this」のUserが、$otherUserIdのUserをフォローを解除する。
 
-        $exist = $this->isFollowings($other_user_id);
+        $exist = $this->isFollowings($otherUserId);
         if ($exist) {
-            $this->followings()->detach($other_user_id);
+            $this->followings()->detach($otherUserId);
             return true;
         } else {
             return false;
@@ -152,20 +152,20 @@ class User extends Authenticatable
     /**
      * 「フォロー中」かどうか
      */
-    public function isFollowings($other_user_id)
+    public function isFollowings($otherUserId)
     {
-        // 「$this」のUserが「$other_user_id」のUserを「フォロー中」かどうか
+        // 「$this」のUserが「$otherUserId」のUserを「フォロー中」かどうか
 
-        return $this->followings()->where('to_user_id', $other_user_id)->exists();
+        return $this->followings()->where('to_user_id', $otherUserId)->exists();
     }
 
     /**
      * 「フォロワー」かどうか
      */
-    public function isFollowers($other_user_id)
+    public function isFollowers($otherUserId)
     {
-        // 「$other_user_id」のUserが「$this」のUserの「フォロワー」かどうか
+        // 「$otherUserId」のUserが「$this」のUserの「フォロワー」かどうか
 
-        return $this->followers()->where('from_user_id', $other_user_id)->exists();
+        return $this->followers()->where('from_user_id', $otherUserId)->exists();
     }
 }

--- a/database/migrations/2024_08_25_183812_create_follows_table.php
+++ b/database/migrations/2024_08_25_183812_create_follows_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // ************************************************************************************
+        // 想定のデータ例)
+        // 1) 下記「id=1のデータ」 user_id=3がuser_id=5をフォローしている
+        // 2) 下記「id=2のデータ」 user_id=5がuser_id=3をフォローしている
+        // 3) 下記「id=3のデータ」 user_id=4がuser_id=5をフォローしている
+        // 4) 下記「id=4のデータ」 user_id=6がuser_id=5をフォローしている
+        // 5) 下記「id=5のデータ」 user_id=3がuser_id=4をフォローしている
+        //
+        // id  from_user_id  to_user_id  created_at        updated_at
+        // 1   3             5           フォローした日時   フォローした日時
+        // 2   5             3           フォローした日時   フォローした日時
+        // 3   4             5           フォローした日時   フォローした日時
+        // 4   6             5           フォローした日時   フォローした日時
+        // 5   3             4           フォローした日時   フォローした日時
+        //
+        // フォロー解除は、followsの物理削除とします。
+        // ************************************************************************************
+
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            // フォローしている側のUserのid
+            $table->bigInteger('from_user_id')->unsigned()->index();
+            // フォローされている側のUserのid
+            $table->bigInteger('to_user_id')->unsigned()->index();
+            $table->timestamps();
+
+            // 外部キー制約
+            $table->foreign('from_user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('to_user_id')->references('id')->on('users')->onDelete('cascade');
+
+            // ユニーク制約
+            $table->unique(['from_user_id', 'to_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}


### PR DESCRIPTION
## issue
- issueの紐づけはなく
- Closes Draftの「フォローのデータベース関連」

## 動作確認手順
https://www.dropbox.com/scl/fi/qqcom5l6uliqwp947w6qt/jikken00100.php?rlkey=3q4hwtygppwk3twt4jr31xqle&dl=0
の
jikken00100.php
を
web.phpにて、
```
    require_once __DIR__ . '/jikken00100.php';
    $jik = new Jikken00100();
    $jik->test00100();
```
を書いて、test00100()からtest00900()で
フォロー関連のデータベース処理をテストした。

https://www.dropbox.com/scl/fi/3oeyernlesq8hlpyhybl4/DB-UT.xlsx?rlkey=jdamhs9kzzyx9trpujn3gm1sj&dl=0
の
フォロー関連のDBのUT.xlsx
にて確認。

ユーザ退会の削除処理をdeletingに引っ越ししつつ、
followsテーブルの削除処理も追加


## 考慮してほしいこと
deletingの最後に
```
    protected static function boot()
    {
        parent::boot();

        self::deleting(function ($user) {
            // フォロー情報の削除( 性能考慮で直接的な削除をする )
            // from_user_idで絞って削除
            \DB::table('follows')->where('from_user_id', $user->id)->delete();
            // to_user_idで絞って削除
            \DB::table('follows')->where('to_user_id', $user->id)->delete();

            // 紐づいてるpostsの削除
            $user->posts()->delete();

//ロールバックテストでわざと例外を投げます
throw new \Exception('わざと例外を投げています。');
        });
    }
```
//ロールバックテストでわざと例外を投げます
throw new \Exception('わざと例外を投げています。');
で、エラーにしたら、ロールバックできてたので
```
        \DB::transaction(function () use ($user) {
            $user->delete();
        });
```
にしておけば、気になってたトランザクション制御は問題ないかと思うです
トランザクション制御が効いた状況で、deletingで実装できてると思います。

Userのモデルを基点に、フォロー中、フォロワーのリストや、カウント取得
Userのモデルを基点に、他のユーザがフォロー中か、フォロワーか
を判定する部品を準備した

項目名は、いろいろ考えたが
結局は、シンプルに、
from_user_id、to_user_idのほうがわかりやすいと思ったので
最終はそうした

フォロー中や、フォロワーはきっと新しくフォローが成立した順に
画面にリスト表示するじゃないかと思ったので
中間テーブルのfollowsのidの降順にしたかったが、
いくらやっても、Userのidの降順にしかならず、
調べていった結果、pivotなんとかの書き方をすれば
中間テーブルのfollowsのidの降順になった。
