### PR TITLE
ヘッダー有効化とバリデーション

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,4 +1,5 @@
 @extends('layouts.app')
+
 @section('content')
 @include('commons.error_messages')
 <div class="text-center">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,5 +1,6 @@
-{{-- @extends('layouts.app') --}}
-{{-- @section('content') --}}
+@extends('layouts.app')
+@section('content')
+@include('commons.error_messages')
 <div class="text-center">
   <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
 </div>
@@ -33,4 +34,4 @@
       </form>
   </div>
 </div>
-{{-- @endsection --}}
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,6 @@
 @extends('layouts.app')
 
 @section('content')
-@include('commons.error_messages')
 <div class="text-center">
   <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
 </div>
@@ -13,6 +12,7 @@
 </div>
 <div class="row mt-5 mb-5">
   <div class="col-sm-6 offset-sm-3">
+      @include('commons.error_messages')
       <form method="POST" action="{{ route('signup.post') }}">
           @csrf
           <div class="form-group">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,7 +9,6 @@
     <body>
         @include('commons.header')
         <div class="container">
-            @include('commons.error_messages')
             @yield('content')
         </div>
         @include('commons.footer')

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,4 +1,5 @@
 @extends('layouts.app')
+
 @section('content')
 <div class="row">
     <aside class="col-sm-4 mb-5">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,5 +1,5 @@
-{{-- @extends('layouts.app') --}}
-{{-- @section('content') --}}
+@extends('layouts.app')
+@section('content')
 <div class="row">
     <aside class="col-sm-4 mb-5">
         <div class="card bg-info">
@@ -37,4 +37,4 @@
     </div>
 </div>
 <script src="{{ asset('/js/confirmDelete.js') }}" defer></script>
-{{-- @endsection --}}
+@endsection


### PR DESCRIPTION
## issue
- Closes #107 #115 

## 概要
- ユーザ新規登録・詳細画面のヘッダー有効化とバリデーション

## 動作確認手順
- [ ] 下記URLにアクセスし、ヘッダー等レイアウトが整っていることを確認
http://localhost:8080/signup
- [ ] 何も入力せずに「新規登録」ボタンを押下すると
画像のようにバリデーションエラーメッセージが出現することを確認
<img width="1440" alt="スクリーンショット 2024-08-29 8 17 18" src="https://github.com/user-attachments/assets/fe67602a-b375-47cb-9665-05bc47e08f61">

- [ ] 登録完了後、下記URLからユーザ詳細画面に遷移してヘッダー等レイアウトが整っていることを確認
http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=posts
<img width="1440" alt="スクリーンショット 2024-08-29 8 22 41" src="https://github.com/user-attachments/assets/a63d0338-e6da-4327-9533-8cbf42b65a23">

## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- 特になし