### PR TITLE
#97 共通ファイル&ヘッダー・フッター & トップページのタイトルのみ表示「Topic Posts」(おおつき)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "php": "^7.2.5|^8.0",
         "fideloper/proxy": "^4.4",
         "laravel/framework": "^6.20.26",
-        "laravel/tinker": "^2.5"
+        "laravel/tinker": "^2.5",
+        "thomaswelton/laravel-gravatar": "~1.0"
     },
     "require-dev": {
         "facade/ignition": "^1.16.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e4a9dd2476552506dba12be3b05aeec",
+    "content-hash": "2be5b46626a338c96827315da91b750c",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -3742,6 +3742,133 @@
             "time": "2022-05-21T10:00:54+00:00"
         },
         {
+            "name": "thomaswelton/gravatarlib",
+            "version": "0.1.1",
+            "target-dir": "thomaswelton/GravatarLib",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thomaswelton/gravatarlib.git",
+                "reference": "8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thomaswelton/gravatarlib/zipball/8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8",
+                "reference": "8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "suggest": {
+                "twig/twig": ">=1.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "thomaswelton\\GravatarLib\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Thompson",
+                    "email": "sam@emberlabs.org"
+                },
+                {
+                    "name": "Damian Bushong",
+                    "email": "damian@emberlabs.org"
+                },
+                {
+                    "name": "Thomas Welton",
+                    "email": "thomaswelton@me.com"
+                }
+            ],
+            "description": "A lightweight PHP 5.3 OOP library providing easy gravatar integration.",
+            "keywords": [
+                "gravatar",
+                "templating",
+                "twig"
+            ],
+            "support": {
+                "issues": "https://github.com/thomaswelton/gravatarlib/issues",
+                "source": "https://github.com/thomaswelton/gravatarlib/tree/0.1.1"
+            },
+            "time": "2024-08-18T14:10:18+00:00"
+        },
+        {
+            "name": "thomaswelton/laravel-gravatar",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thomaswelton/laravel-gravatar.git",
+                "reference": "bdfa24847a5602aa9273967c8b6d5e3ec6860ed1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thomaswelton/laravel-gravatar/zipball/bdfa24847a5602aa9273967c8b6d5e3ec6860ed1",
+                "reference": "bdfa24847a5602aa9273967c8b6d5e3ec6860ed1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.0|^6.0|^7.0|^8.0",
+                "php": ">=5.4.0",
+                "thomaswelton/gravatarlib": "0.1.x"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.*",
+                "phpunit/phpunit": "4.8.*"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Thomaswelton\\LaravelGravatar\\LaravelGravatarServiceProvider"
+                    ],
+                    "aliases": {
+                        "Gravatar": "Thomaswelton\\LaravelGravatar\\Facades\\Gravatar"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Thomaswelton\\LaravelGravatar\\": "src/",
+                    "Thomaswelton\\Tests\\LaravelGravatar\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "ThomasWelton",
+                    "email": "thomaswelton@me.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Antoine Augusti",
+                    "email": "antoine.augusti@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel 5 Gravatar helper",
+            "homepage": "https://github.com/thomaswelton/laravel-gravatar",
+            "keywords": [
+                "gravatar",
+                "laravel",
+                "laravel5"
+            ],
+            "support": {
+                "issues": "https://github.com/thomaswelton/laravel-gravatar/issues",
+                "source": "https://github.com/thomaswelton/laravel-gravatar/tree/1.3.0"
+            },
+            "abandoned": "creativeorange/gravatar",
+            "time": "2020-10-12T14:45:23+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "2.2.4",
             "source": {
@@ -6558,5 +6685,5 @@
         "php": "^7.2.5|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,0 +1,3 @@
+body {
+    min-height: 100vh;
+}

--- a/resources/views/commons/error_messages.blade.php
+++ b/resources/views/commons/error_messages.blade.php
@@ -1,0 +1,7 @@
+@if (count($errors) > 0)
+    <ul class="alert alert-danger" role="alert">
+        @foreach ($errors->all() as $error)
+            <li class="ml-4">{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif

--- a/resources/views/commons/footer.blade.php
+++ b/resources/views/commons/footer.blade.php
@@ -1,0 +1,5 @@
+<footer class="mt-5">
+    <nav class="navbar navbar-dark bg-info justify-content-center">
+        <span class="navbar-brand">©Gut Familie, All rights reserved.</span>
+    </nav>
+</footer>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,0 +1,20 @@
+<header class="mb-5">
+    <nav class="navbar navbar-expand-sm navbar-dark bg-info">
+        <a class="navbar-brand" href="/">{{ config('app.TopicPostsTitle') }}</a>
+        <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="nav-bar">
+            <ul class="navbar-nav mr-auto"></ul>
+            <ul class="navbar-nav">
+                @if (Auth::check())
+                    <li class="nav-item"><a href="{{ route('user.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
+                    <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
+                @else
+                    <li class="nav-item"><a href="{{ route('login') }}" class="nav-link text-light">ログイン</a></li>
+                    <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>
+                @endif
+            </ul>
+        </div>
+    </nav>
+</header>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,7 +10,6 @@
     <body class="d-flex flex-column">
         @include('commons.header')
         <div class="container mb-auto">
-            @include('commons.error_messages')
             @yield('content')
         </div>
         @include('commons.footer')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="utf-8">
+        <title>{{ config('app.TopicPostsTitle') }}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link rel="stylesheet" href="{{ asset('/css/styles.css') }}">
+    </head>
+    <body class="d-flex flex-column">
+        @include('commons.header')
+        <div class="container mb-auto">
+            @include('commons.error_messages')
+            @yield('content')
+        </div>
+        @include('commons.footer')
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script defer src="https://use.fontawesome.com/releases/v5.7.2/js/all.js"></script>
+    </body>
+</html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,100 +1,20 @@
-<!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-
-        <title>Laravel</title>
-
-        <!-- Fonts -->
-        <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@200;600&display=swap" rel="stylesheet">
-
-        <!-- Styles -->
-        <style>
-            html, body {
-                background-color: #fff;
-                color: #636b6f;
-                font-family: 'Nunito', sans-serif;
-                font-weight: 200;
-                height: 100vh;
-                margin: 0;
-            }
-
-            .full-height {
-                height: 100vh;
-            }
-
-            .flex-center {
-                align-items: center;
-                display: flex;
-                justify-content: center;
-            }
-
-            .position-ref {
-                position: relative;
-            }
-
-            .top-right {
-                position: absolute;
-                right: 10px;
-                top: 18px;
-            }
-
-            .content {
-                text-align: center;
-            }
-
-            .title {
-                font-size: 84px;
-            }
-
-            .links > a {
-                color: #636b6f;
-                padding: 0 25px;
-                font-size: 13px;
-                font-weight: 600;
-                letter-spacing: .1rem;
-                text-decoration: none;
-                text-transform: uppercase;
-            }
-
-            .m-b-md {
-                margin-bottom: 30px;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="flex-center position-ref full-height">
-            @if (Route::has('login'))
-                <div class="top-right links">
-                    @auth
-                        <a href="{{ url('/home') }}">Home</a>
-                    @else
-                        <a href="{{ route('login') }}">Login</a>
-
-                        @if (Route::has('register'))
-                            <a href="{{ route('register') }}">Register</a>
-                        @endif
-                    @endauth
-                </div>
-            @endif
-
-            <div class="content">
-                <div class="title m-b-md">
-                    Laravel
-                </div>
-
-                <div class="links">
-                    <a href="https://laravel.com/docs">Docs</a>
-                    <a href="https://laracasts.com">Laracasts</a>
-                    <a href="https://laravel-news.com">News</a>
-                    <a href="https://blog.laravel.com">Blog</a>
-                    <a href="https://nova.laravel.com">Nova</a>
-                    <a href="https://forge.laravel.com">Forge</a>
-                    <a href="https://vapor.laravel.com">Vapor</a>
-                    <a href="https://github.com/laravel/laravel">GitHub</a>
+@extends('layouts.app')
+@section('content')
+    <div class="center jumbotron bg-info">
+        <div class="text-center text-white mt-2 pt-1">
+            <h1><i class="fab fa-telegram fa-lg pr-3"></i>{{ config('app.TopicPostsTitle') }}</h1>
+        </div>
+    </div>
+    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+    <div class="w-75 m-auto">エラーメッセージが入る場所</div>
+    <div class="text-center mb-3">
+        <form method="" action="" class="d-inline-block w-75">
+            <div class="form-group">
+                <textarea class="form-control" name="" rows=""></textarea>
+                <div class="text-left mt-3">
+                    <button type="submit" class="btn btn-primary">投稿する</button>
                 </div>
             </div>
-        </div>
-    </body>
-</html>
+        </form>
+    </div>
+@endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,11 +6,12 @@
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-    <div class="w-75 m-auto">エラーメッセージが入る場所</div>
+    <div class="w-75 m-auto">@include('commons.error_messages')</div>
     <div class="text-center mb-3">
-        <form method="" action="" class="d-inline-block w-75">
+        <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+            @csrf
             <div class="form-group">
-                <textarea class="form-control" name="" rows=""></textarea>
+                <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
                 <div class="text-left mt-3">
                     <button type="submit" class="btn btn-primary">投稿する</button>
                 </div>


### PR DESCRIPTION
## issue
- Closes #97 

## 概要
- 共通ファイル&ヘッダー・フッター & トップページのタイトルのみ表示「Topic Posts」

## 動作確認手順
- ヘッダー・フッター & トップページの表示
- 新規ユーザ登録で誤入力した際にエラーメッセージが表示
- ヘッダー内リンクについてログイン前、ログイン後で想定の遷移

## 考慮して欲しいこと
- ページ内コンテンツが少ない場合、モックアップのままだとフッターが浮くので、
  一番下(固定ではない)に配置したかったため以下を記載

  views/layouts/app.blade.php
  body, containerにbootstrapのclassを追加
  ```
      <body class="d-flex flex-column">
        @include('commons.header')
        <div class="container mb-auto">
            @yield('content')
        </div>
  ```

  public/css/styles.css
  ```
  body {
    min-height: 100vh;
  }
  ```