### PR TITLE
フォロー機能(有田)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -34,4 +34,43 @@ class UsersController extends Controller
         }
         return back()->with('error', 'ユーザの退会処理に失敗しました。<br>再度ログインしてからやり直してください。');
     }
+
+    public function follow($id)
+    {
+        $user = User::findOrFail($id);
+        \Auth::user()->follow($user->id);
+
+        return back()->with('status', $user->name .'をフォローしました。');
+    }
+
+    public function unfollow($id)
+    {
+        $user = User::findOrFail($id);
+        \Auth::user()->unfollow($user->id);
+
+        return back()->with('status', $user->name .'のフォローを解除しました。');
+    }
+
+    public function followings($id)
+    {
+        $user = User::findOrFail($id);
+        $followings = $user->followings()->orderBy('updated_at', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'followings' => $followings,
+        ];
+
+        return view('users.show', $data);
+    }
+
+    public function followers($id)
+    {
+        $user = User::findOrFail($id);
+        $followers = $user->followers()->orderBy('updated_at', 'desc')->paginate(10);
+        $data=[
+            'user' => $user,
+            'followers' => $followers,
+        ];
+        return view('users.show', $data);
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -35,7 +35,7 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
         \Auth::user()->follow($user->id);
 
-        return back()->with('status', $user->name .'をフォローしました。');
+        return back()->with('status', $user->name .'さんをフォローしました。');
     }
 
     public function unfollow($id)
@@ -43,7 +43,7 @@ class UsersController extends Controller
         $user = User::findOrFail($id);
         \Auth::user()->unfollow($user->id);
 
-        return back()->with('status', $user->name .'のフォローを解除しました。');
+        return back()->with('status', $user->name .'さんのフォローを解除しました。');
     }
 
     public function followings($id)

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,38 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    // フォローしているユーザー
+    public function followings()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'user_id', 'follower_id');
+    }
+
+    // フォロワー
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'follower_id', 'user_id');
+    }
+
+    // フォローしているかどうかの確認
+    public function isFollowing($userId)
+    {
+        return $this->followings()->where('follower_id', $userId)->exists();
+    }
+
+    // フォローする
+    public function follow($userId)
+    {
+        if (!$this->isFollowing($userId)) {
+            $this->followings()->attach($userId);
+        }
+    }
+
+    // フォローを解除する
+    public function unfollow($userId)
+    {
+        if ($this->isFollowing($userId)) {
+            $this->followings()->detach($userId);
+        }
+    }
 }

--- a/database/migrations/2024_09_01_215008_create_followers_table.php
+++ b/database/migrations/2024_09_01_215008_create_followers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('followers', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id'); // フォローする側のユーザーID
+            $table->unsignedBigInteger('follower_id'); // フォローされる側のユーザーID
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('follower_id')->references('id')->on('users')->onDelete('cascade');
+
+            $table->unique(['user_id', 'follower_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('followers');
+    }
+}

--- a/public/css/followButton.css
+++ b/public/css/followButton.css
@@ -1,0 +1,55 @@
+/* フォロー中ボタンのスタイル */
+.follow-btn {
+  display: flex; /* ボタン内のコンテンツをフレックスボックスで配置 */
+  justify-content: center; /* 水平に中央揃え */
+  transition: background-color 0.5s, color 0.5s; /* 背景色と文字色が0.5秒で変化する */
+  padding: 5px 20px; /* ボタンの上下に5px、左右に20pxの余白を追加 */
+}
+
+/* フォロー中ボタンをホバーした際のスタイル */
+.follow-btn:hover {
+  background-color: rgb(252, 31, 31); /* 背景色を赤色に変更 */
+  border-color: rgb(252, 31, 31); /* ボーダーも赤色に変更 */
+}
+
+/* ホバーするまで非表示「フォロー解除」テキスト */
+.follow-btn span:nth-child(1) {
+  position: absolute; /* 絶対位置に配置 */
+  display: none; /* 初期状態では表示しない */
+}
+
+/* ホバー時に「フォロー解除」テキストを表示 */
+.follow-btn:hover span:nth-child(1) {
+  display: inline-block; /* ホバー時に表示する */
+}
+
+/* ホバー時に「フォロー中」テキストを透明にする */
+.follow-btn:hover span:nth-child(2) {
+  opacity: 0; /* ホバー時に透明にして非表示に見せる */
+}
+
+/* ポップアップウィンドウのスタイル */
+.floating-confirm {
+  position: fixed; /* ウィンドウを固定し、スクロールしても位置を維持する */
+  top: 50%; /* 画面の垂直方向で中央に配置 */
+  left: 50%; /* 画面の水平方向で中央に配置 */
+  transform: translate(-50%, -50%); /* 上記のtopとleftが画面の中央を基準に動くように調整 */
+  background-color: white; /* ウィンドウの背景色を白に */
+  border-radius: 10px; /* ウィンドウの角を丸くする */
+  padding: 20px; /* ウィンドウ内のコンテンツに余白を追加 */
+  width: 300px; /* ウィンドウの幅を300pxに指定 */
+  text-align: center; /* テキストを中央揃えに */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* ウィンドウに影をつけて立体感を演出 */
+  z-index: 1001; /* 他の要素より前面に表示 */
+}
+
+/* グレーアウト用のオーバーレイ（背景） */
+#overlay {
+  position: fixed; /* 画面全体を覆うように固定 */
+  top: 0; /* ページの最上部から開始 */
+  left: 0; /* ページの最左端から開始 */
+  width: 100%; /* 横幅を画面全体に広げる */
+  height: 100%; /* 高さも画面全体を覆うように設定 */
+  background-color: rgba(0, 0, 0, 0.5); /* 半透明の黒い背景 */
+  z-index: 1000; /* ポップアップのすぐ後ろに表示する */
+}

--- a/public/js/confirmDelete.js
+++ b/public/js/confirmDelete.js
@@ -1,7 +1,7 @@
 // confirmDelete.js
 
 document.addEventListener('DOMContentLoaded', function () {
-    const deleteButton = document.querySelector('.btn-danger');
+    const deleteButton = document.querySelector('.delete-account');
     
     if (deleteButton) {
         deleteButton.addEventListener('click', function (event) {
@@ -23,3 +23,4 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 });
+

--- a/public/js/confirmUnfollow.js
+++ b/public/js/confirmUnfollow.js
@@ -1,0 +1,47 @@
+// confirmUnfollow.js
+
+document.addEventListener('DOMContentLoaded', function() {
+  const followButtons = document.querySelectorAll('.follow-btn');
+  const confirmUnfollow = document.getElementById('confirm-unfollow');
+  const unfollowForm = document.getElementById('unfollow-form');
+  const unfollowMessage = document.getElementById('unfollow-message');
+  const overlay = document.getElementById('overlay');
+  const cancelUnfollow = document.getElementById('cancel-unfollow');
+
+  let activeFollowButton = null;
+
+  followButtons.forEach(button => {
+      button.addEventListener('click', function() {
+          const followerName = this.dataset.followerName;
+          const followerId = this.dataset.followerId;
+
+          // 確認メッセージを設定
+          unfollowMessage.textContent = followerName;
+
+          // フォームのアクションURLを設定
+          unfollowForm.action = `/users/${followerId}/unfollow`;
+
+          // ポップアップとオーバーレイを表示
+          confirmUnfollow.style.display = 'block';
+          overlay.style.display = 'block';
+
+          // アクティブなボタンを記録
+          activeFollowButton = this;
+      });
+  });
+
+  // キャンセルボタンでポップアップを閉じる
+  cancelUnfollow.addEventListener('click', function() {
+      confirmUnfollow.style.display = 'none';
+      overlay.style.display = 'none';
+      activeFollowButton = null;
+  });
+
+  // オーバーレイをクリックした場合にもポップアップを閉じる
+  overlay.addEventListener('click', function() {
+      confirmUnfollow.style.display = 'none';
+      overlay.style.display = 'none';
+      activeFollowButton = null;
+  });
+});
+

--- a/resources/views/commons/follow_button.blade.php
+++ b/resources/views/commons/follow_button.blade.php
@@ -1,0 +1,36 @@
+<div class="d-inline-block">
+    @if (Auth::check() && Auth::id() !== $userId)  {{-- 自分自身でないかを確認 --}}
+        @if (Auth::user()->isFollowing($userId))
+            {{-- フォロー中ボタン --}}
+            <button type="button" 
+                    class="btn {{ $buttonClass ?? 'btn-outline-secondary' }} rounded-pill follow-btn"
+                    data-follower-name="{{ $userName }}" 
+                    data-follower-id="{{ $userId }}">
+                <span>フォロー解除</span>
+                <span>フォロー中</span>
+            </button>
+            {{-- フォロー解除の確認ポップアップ --}}
+            <div id="confirm-unfollow" class="floating-confirm" style="display: none;">
+                <div class="confirm-content">
+                    <p><span id="unfollow-message"></span>さんをフォロー解除しますか？</p>
+                    <form method="POST" action="" id="unfollow-form">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">フォロー解除</button>
+                        <button type="button" class="btn btn-secondary" id="cancel-unfollow">キャンセル</button>
+                    </form>
+                </div>
+            </div>
+            {{-- グレーアウト用の背景 --}}
+            <div id="overlay" style="display: none;"></div>
+        @else
+            {{-- フォローするボタン --}}
+            <form method="POST" action="{{ route('follow', $userId) }}" class="d-inline">
+                @csrf
+                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+            </form>
+        @endif
+    @elseif(!Auth::check())  {{-- ログインしていない場合 --}}
+        <a href="{{ route('login') }}" class="btn btn-outline-primary rounded-pill">フォローする</a>
+    @endif
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,7 @@
         <title>Topic Posts</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link rel="stylesheet" href="{{ asset('/css/followButton.css') }}">
     </head>
     <body>
         @include('commons.header')

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -6,25 +6,8 @@
                 <p class="mt-3 mb-0 d-inline-block">
                     <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>　
                 </p>
-                <!-- フォローボタン -->
-                <div class="d-inline-block">
-                    @if (Auth::check() && Auth::id() !== $post->user_id)  {{-- 自分自身でないかを確認 --}}
-                        @if (Auth::user()->isFollowing($post->user_id))
-                            <form method="POST" action="{{ route('unfollow', $post->user_id) }}" class="d-inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
-                            </form>
-                        @else
-                            <form method="POST" action="{{ route('follow', $post->user_id) }}" class="d-inline">
-                                @csrf
-                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
-                            </form>
-                        @endif
-                    @elseif(!Auth::check())  {{-- ログインしていない場合 --}}
-                        <a href="{{ route('login') }}" class="btn btn-outline-primary rounded-pill">フォローする</a>
-                    @endif
-                </div>
+                {{-- フォローボタン共通コンポーネント --}}
+                @include('commons.follow_button', ['userId' => $post->user_id, 'userName' => $post->user->name])
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">
@@ -46,3 +29,5 @@
 <div class="m-auto" style="width: fit-content">
     {{ $posts->links('pagination::bootstrap-4') }}
 </div>
+
+<script src="{{ asset('/js/confirmUnfollow.js') }}" defer></script>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -3,7 +3,9 @@
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>　</p>
+                <p class="mt-3 mb-0 d-inline-block">
+                    <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>　
+                </p>
                 <!-- フォローボタン -->
                 <div class="d-inline-block">
                     @if (Auth::check() && Auth::id() !== $post->user_id)  {{-- 自分自身でないかを確認 --}}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -3,21 +3,40 @@
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a></p>
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>　</p>
+                <!-- フォローボタン -->
+                <div class="d-inline-block">
+                    @if (Auth::check() && Auth::id() !== $post->user_id)  {{-- 自分自身でないかを確認 --}}
+                        @if (Auth::user()->isFollowing($post->user_id))
+                            <form method="POST" action="{{ route('unfollow', $post->user_id) }}" class="d-inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
+                            </form>
+                        @else
+                            <form method="POST" action="{{ route('follow', $post->user_id) }}" class="d-inline">
+                                @csrf
+                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                            </form>
+                        @endif
+                    @elseif(!Auth::check())  {{-- ログインしていない場合 --}}
+                        <a href="{{ route('login') }}" class="btn btn-outline-primary rounded-pill">フォローする</a>
+                    @endif
+                </div>
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{ $post->post }}</p>
                     <p class="text-muted">{{ $post->created_at }}</p>
                 </div>
-                 @if (Auth::id() === $post->user_id)
+                @if (Auth::id() === $post->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
                         <a href="" class="btn btn-primary">編集する</a>
                     </div>
-                 @endif
+                @endif
             </div>
         </li>
     @endforeach

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -1,0 +1,33 @@
+<div class="container">
+    <h5 class="mt-5 mb-4">フォロワー</h5>
+    <ul class="list-unstyled">
+        @foreach ($followers as $follower)
+            <li class="media mb-4">
+                <img class="mr-3 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="{{ $follower->name }}のアバター画像">
+                <div class="media-body">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a></h5>
+                        @if (Auth::check() && Auth::id() !== $follower->id)  {{-- 自分自身でないかを確認 --}}
+                            @if (Auth::user()->isFollowing($follower->id))
+                                <form method="POST" action="{{ route('unfollow', $follower->id) }}" class="d-inline">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
+                                </form>
+                            @endif
+                        @else
+                            <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline">
+                                @csrf
+                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                            </form>
+                        @endif
+                    </div>
+                    <p class="mb-0 text-muted">{{ $follower->email }}</p>
+                </div>
+            </li>
+        @endforeach
+        <div class="mt-3">
+            {{ $followers->links('pagination::bootstrap-4') }}
+        </div>
+    </ul>
+</div>

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -3,21 +3,39 @@
     <div class="list-group-item">
         <li class="media mb-2">
             <img class="mr-3 rounded-circle" 
-                  src="{{ Gravatar::src($follower->email, 55) }}" alt="{{ $follower->name }}のアバター画像">
+                    src="{{ Gravatar::src($follower->email, 55) }}" alt="{{ $follower->name }}のアバター画像">
             <div class="media-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a></h5>
                     @if (Auth::check() && Auth::id() !== $follower->id)  {{-- 自分自身でないかを確認 --}}
                         @if (Auth::user()->isFollowing($follower->id))
-                            <form method="POST" action="{{ route('unfollow', $follower->id) }}" class="d-inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
-                            </form>
+                            {{-- フォロー中ボタン --}}
+                            <button type="button" 
+                                    class="btn btn-outline-secondary rounded-pill follow-btn"
+                                    data-follower-name="{{ $follower->name }}" 
+                                    data-follower-id="{{ $follower->id }}">
+                                <span>フォロー解除</span>
+                                <span>フォロー中</span>
+                            </button>
+                            {{-- フォロー解除の確認ポップアップ --}}
+                            <div id="confirm-unfollow" class="floating-confirm" style="display: none;">
+                                <div class="confirm-content">
+                                    <p><span id="unfollow-message"></span>さんをフォロー解除しますか？</p>
+                                    <form method="POST" action="" id="unfollow-form">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger">フォロー解除</button>
+                                        <button type="button" class="btn btn-secondary" id="cancel-unfollow">キャンセル</button>
+                                    </form>
+                                </div>
+                            </div>
+                            {{-- グレーアウト用の背景 --}}
+                            <div id="overlay" style="display: none;"></div>
                         @else
+                            {{-- フォローするボタン --}}
                             <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline">
                                 @csrf
-                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                                <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
                             </form>
                         @endif
                     @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
@@ -33,3 +51,4 @@
     {{ $followers->links('pagination::bootstrap-4') }}
 </div>
 
+<script src="{{ asset('/js/confirmUnfollow.js') }}" defer></script>

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -2,7 +2,8 @@
 @foreach ($followers as $follower)
     <div class="list-group-item">
         <li class="media mb-2">
-            <img class="mr-3 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="{{ $follower->name }}のアバター画像">
+            <img class="mr-3 rounded-circle" 
+                  src="{{ Gravatar::src($follower->email, 55) }}" alt="{{ $follower->name }}のアバター画像">
             <div class="media-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a></h5>

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -14,12 +14,14 @@
                                     @method('DELETE')
                                     <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
                                 </form>
+                            @else
+                                <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline">
+                                    @csrf
+                                    <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                                </form>
                             @endif
-                        @else
-                            <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline">
-                                @csrf
-                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
-                            </form>
+                        @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
+                            <a href="{{-- route('login') --}}" class="btn btn-outline-primary rounded-pill">フォローする</a>
                         @endif
                     </div>
                     <p class="mb-0 text-muted">{{ $follower->email }}</p>

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -1,35 +1,34 @@
-<div class="container">
-    <h5 class="mt-5 mb-4">フォロワー</h5>
-    <ul class="list-unstyled">
-        @foreach ($followers as $follower)
-            <li class="media mb-4">
-                <img class="mr-3 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="{{ $follower->name }}のアバター画像">
-                <div class="media-body">
-                    <div class="d-flex justify-content-between align-items-center">
-                        <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a></h5>
-                        @if (Auth::check() && Auth::id() !== $follower->id)  {{-- 自分自身でないかを確認 --}}
-                            @if (Auth::user()->isFollowing($follower->id))
-                                <form method="POST" action="{{ route('unfollow', $follower->id) }}" class="d-inline">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
-                                </form>
-                            @else
-                                <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline">
-                                    @csrf
-                                    <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
-                                </form>
-                            @endif
-                        @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
-                            <a href="{{-- route('login') --}}" class="btn btn-outline-primary rounded-pill">フォローする</a>
+<h5 class="mt-5 mb-4">フォロワー</h5>
+@foreach ($followers as $follower)
+    <div class="list-group-item">
+        <li class="media mb-2">
+            <img class="mr-3 rounded-circle" src="{{ Gravatar::src($follower->email, 55) }}" alt="{{ $follower->name }}のアバター画像">
+            <div class="media-body">
+                <div class="d-flex justify-content-between align-items-center">
+                    <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a></h5>
+                    @if (Auth::check() && Auth::id() !== $follower->id)  {{-- 自分自身でないかを確認 --}}
+                        @if (Auth::user()->isFollowing($follower->id))
+                            <form method="POST" action="{{ route('unfollow', $follower->id) }}" class="d-inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
+                            </form>
+                        @else
+                            <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline">
+                                @csrf
+                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                            </form>
                         @endif
-                    </div>
-                    <p class="mb-0 text-muted">{{ $follower->email }}</p>
+                    @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
+                        <a href="{{ route('login') }}" class="btn btn-outline-primary rounded-pill">フォローする</a>
+                    @endif
                 </div>
-            </li>
-        @endforeach
-        <div class="mt-3">
-            {{ $followers->links('pagination::bootstrap-4') }}
-        </div>
-    </ul>
+                <p class="mb-0 text-muted">{{ $follower->email }}</p>
+            </div>
+        </li>
+    </div>
+@endforeach
+<div class="mt-3">
+    {{ $followers->links('pagination::bootstrap-4') }}
 </div>
+

--- a/resources/views/users/followers.blade.php
+++ b/resources/views/users/followers.blade.php
@@ -7,40 +7,8 @@
             <div class="media-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a></h5>
-                    @if (Auth::check() && Auth::id() !== $follower->id)  {{-- 自分自身でないかを確認 --}}
-                        @if (Auth::user()->isFollowing($follower->id))
-                            {{-- フォロー中ボタン --}}
-                            <button type="button" 
-                                    class="btn btn-outline-secondary rounded-pill follow-btn"
-                                    data-follower-name="{{ $follower->name }}" 
-                                    data-follower-id="{{ $follower->id }}">
-                                <span>フォロー解除</span>
-                                <span>フォロー中</span>
-                            </button>
-                            {{-- フォロー解除の確認ポップアップ --}}
-                            <div id="confirm-unfollow" class="floating-confirm" style="display: none;">
-                                <div class="confirm-content">
-                                    <p><span id="unfollow-message"></span>さんをフォロー解除しますか？</p>
-                                    <form method="POST" action="" id="unfollow-form">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="btn btn-danger">フォロー解除</button>
-                                        <button type="button" class="btn btn-secondary" id="cancel-unfollow">キャンセル</button>
-                                    </form>
-                                </div>
-                            </div>
-                            {{-- グレーアウト用の背景 --}}
-                            <div id="overlay" style="display: none;"></div>
-                        @else
-                            {{-- フォローするボタン --}}
-                            <form method="POST" action="{{ route('follow', $follower->id) }}" class="d-inline">
-                                @csrf
-                                <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
-                            </form>
-                        @endif
-                    @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
-                        <a href="{{ route('login') }}" class="btn btn-outline-primary rounded-pill">フォローする</a>
-                    @endif
+                    {{-- フォローボタン共通コンポーネント --}}
+                    @include('commons.follow_button', ['userId' => $follower->id, 'userName' => $follower->name])
                 </div>
                 <p class="mb-0 text-muted">{{ $follower->email }}</p>
             </div>

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -14,12 +14,14 @@
                                     @method('DELETE')
                                     <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
                                 </form>
+                            @else
+                                <form method="POST" action="{{ route('follow', $following->id) }}" class="d-inline">
+                                    @csrf
+                                    <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                                </form>
                             @endif
-                        @else
-                            <form method="POST" action="{{ route('follow', $following->id) }}" class="d-inline">
-                                @csrf
-                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
-                            </form>
+                        @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
+                            <a href="{{-- route('login') --}}" class="btn btn-outline-primary rounded-pill">フォローする</a>
                         @endif
                     </div>
                     <p class="mb-0 text-muted">{{ $following->email }}</p>

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -1,0 +1,33 @@
+<div class="container">
+    <h5 class="mt-5 mb-4">フォローしているユーザー</h5>
+    <ul class="list-unstyled">
+        @foreach ($followings as $following)
+            <li class="media mb-4">
+                <img class="mr-3 rounded-circle" src="{{ Gravatar::src($following->email, 55) }}" alt="{{ $following->name }}のアバター画像">
+                <div class="media-body">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $following->id) }}">{{ $following->name }}</a></h5>
+                        @if (Auth::check() && Auth::id() !== $following->id)  {{-- 自分自身でないかを確認 --}}
+                            @if (Auth::user()->isFollowing($following->id))
+                                <form method="POST" action="{{ route('unfollow', $following->id) }}" class="d-inline">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
+                                </form>
+                            @endif
+                        @else
+                            <form method="POST" action="{{ route('follow', $following->id) }}" class="d-inline">
+                                @csrf
+                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                            </form>
+                        @endif
+                    </div>
+                    <p class="mb-0 text-muted">{{ $following->email }}</p>
+                </div>
+            </li>
+        @endforeach
+        <div class="mt-3">
+            {{ $followings->links('pagination::bootstrap-4') }}
+        </div>
+    </ul>
+</div>

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -9,15 +9,33 @@
                     <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $following->id) }}">{{ $following->name }}</a></h5>
                     @if (Auth::check() && Auth::id() !== $following->id)  {{-- 自分自身でないかを確認 --}}
                         @if (Auth::user()->isFollowing($following->id))
-                            <form method="POST" action="{{ route('unfollow', $following->id) }}" class="d-inline">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
-                            </form>
+                            {{-- フォロー中ボタン --}}
+                            <button type="button" 
+                                    class="btn btn-outline-secondary rounded-pill follow-btn"
+                                    data-follower-name="{{ $following->name }}" 
+                                    data-follower-id="{{ $following->id }}">
+                                <span>フォロー解除</span>
+                                <span>フォロー中</span>
+                            </button>
+                            {{-- フォロー解除の確認ポップアップ --}}
+                            <div id="confirm-unfollow" class="floating-confirm" style="display: none;">
+                                <div class="confirm-content">
+                                    <p><span id="unfollow-message"></span>さんをフォロー解除しますか？</p>
+                                    <form method="POST" action="" id="unfollow-form">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger">フォロー解除</button>
+                                        <button type="button" class="btn btn-secondary" id="cancel-unfollow">キャンセル</button>
+                                    </form>
+                                </div>
+                            </div>
+                            {{-- グレーアウト用の背景 --}}
+                            <div id="overlay" style="display: none;"></div>
                         @else
+                            {{-- フォローするボタン --}}
                             <form method="POST" action="{{ route('follow', $following->id) }}" class="d-inline">
                                 @csrf
-                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                                <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
                             </form>
                         @endif
                     @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
@@ -32,3 +50,5 @@
 <div class="mt-3">
     {{ $followings->links('pagination::bootstrap-4') }}
 </div>
+
+<script src="{{ asset('/js/confirmUnfollow.js') }}" defer></script>

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -7,40 +7,8 @@
             <div class="media-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $following->id) }}">{{ $following->name }}</a></h5>
-                    @if (Auth::check() && Auth::id() !== $following->id)  {{-- 自分自身でないかを確認 --}}
-                        @if (Auth::user()->isFollowing($following->id))
-                            {{-- フォロー中ボタン --}}
-                            <button type="button" 
-                                    class="btn btn-outline-secondary rounded-pill follow-btn"
-                                    data-follower-name="{{ $following->name }}" 
-                                    data-follower-id="{{ $following->id }}">
-                                <span>フォロー解除</span>
-                                <span>フォロー中</span>
-                            </button>
-                            {{-- フォロー解除の確認ポップアップ --}}
-                            <div id="confirm-unfollow" class="floating-confirm" style="display: none;">
-                                <div class="confirm-content">
-                                    <p><span id="unfollow-message"></span>さんをフォロー解除しますか？</p>
-                                    <form method="POST" action="" id="unfollow-form">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="btn btn-danger">フォロー解除</button>
-                                        <button type="button" class="btn btn-secondary" id="cancel-unfollow">キャンセル</button>
-                                    </form>
-                                </div>
-                            </div>
-                            {{-- グレーアウト用の背景 --}}
-                            <div id="overlay" style="display: none;"></div>
-                        @else
-                            {{-- フォローするボタン --}}
-                            <form method="POST" action="{{ route('follow', $following->id) }}" class="d-inline">
-                                @csrf
-                                <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
-                            </form>
-                        @endif
-                    @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
-                        <a href="{{ route('login') }}" class="btn btn-outline-primary rounded-pill">フォローする</a>
-                    @endif
+                    {{-- フォローボタン共通コンポーネント --}}
+                    @include('commons.follow_button', ['userId' => $following->id, 'userName' => $following->name])
                 </div>
                 <p class="mb-0 text-muted">{{ $following->email }}</p>
             </div>

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -2,7 +2,8 @@
 @foreach ($followings as $following)
     <div class="list-group-item">
         <li class="media mb-1">
-            <img class="mr-3 rounded-circle" src="{{ Gravatar::src($following->email, 55) }}" alt="{{ $following->name }}のアバター画像">
+            <img class="mr-3 rounded-circle" 
+                  src="{{ Gravatar::src($following->email, 55) }}" alt="{{ $following->name }}のアバター画像">
             <div class="media-body">
                 <div class="d-flex justify-content-between align-items-center">
                     <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $following->id) }}">{{ $following->name }}</a></h5>

--- a/resources/views/users/followings.blade.php
+++ b/resources/views/users/followings.blade.php
@@ -1,35 +1,33 @@
-<div class="container">
-    <h5 class="mt-5 mb-4">フォローしているユーザー</h5>
-    <ul class="list-unstyled">
-        @foreach ($followings as $following)
-            <li class="media mb-4">
-                <img class="mr-3 rounded-circle" src="{{ Gravatar::src($following->email, 55) }}" alt="{{ $following->name }}のアバター画像">
-                <div class="media-body">
-                    <div class="d-flex justify-content-between align-items-center">
-                        <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $following->id) }}">{{ $following->name }}</a></h5>
-                        @if (Auth::check() && Auth::id() !== $following->id)  {{-- 自分自身でないかを確認 --}}
-                            @if (Auth::user()->isFollowing($following->id))
-                                <form method="POST" action="{{ route('unfollow', $following->id) }}" class="d-inline">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
-                                </form>
-                            @else
-                                <form method="POST" action="{{ route('follow', $following->id) }}" class="d-inline">
-                                    @csrf
-                                    <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
-                                </form>
-                            @endif
-                        @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
-                            <a href="{{-- route('login') --}}" class="btn btn-outline-primary rounded-pill">フォローする</a>
+<h5 class="mt-5 mb-4">フォローしているユーザー</h5>
+@foreach ($followings as $following)
+    <div class="list-group-item">
+        <li class="media mb-1">
+            <img class="mr-3 rounded-circle" src="{{ Gravatar::src($following->email, 55) }}" alt="{{ $following->name }}のアバター画像">
+            <div class="media-body">
+                <div class="d-flex justify-content-between align-items-center">
+                    <h5 class="mt-0 mb-1"><a href="{{ route('user.show', $following->id) }}">{{ $following->name }}</a></h5>
+                    @if (Auth::check() && Auth::id() !== $following->id)  {{-- 自分自身でないかを確認 --}}
+                        @if (Auth::user()->isFollowing($following->id))
+                            <form method="POST" action="{{ route('unfollow', $following->id) }}" class="d-inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-outline-secondary rounded-pill">フォロー中</button>
+                            </form>
+                        @else
+                            <form method="POST" action="{{ route('follow', $following->id) }}" class="d-inline">
+                                @csrf
+                                <button type="submit" class="btn btn-outline-primary rounded-pill">フォローする</button>
+                            </form>
                         @endif
-                    </div>
-                    <p class="mb-0 text-muted">{{ $following->email }}</p>
+                    @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
+                        <a href="{{ route('login') }}" class="btn btn-outline-primary rounded-pill">フォローする</a>
+                    @endif
                 </div>
-            </li>
-        @endforeach
-        <div class="mt-3">
-            {{ $followings->links('pagination::bootstrap-4') }}
-        </div>
-    </ul>
+                <p class="mb-0 text-muted">{{ $following->email }}</p>
+            </div>
+        </li>
+    </div>
+@endforeach
+<div class="mt-3">
+    {{ $followings->links('pagination::bootstrap-4') }}
 </div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,16 +19,34 @@
                 <h3 class="card-title text-light">{{ $user->name }}</h3>
                 @if (Auth::check() && Auth::id() !== $user->id)  {{-- 自分自身でないかを確認 --}}
                     @if (Auth::user()->isFollowing($user->id))
-                        <form method="POST" action="{{ route('unfollow', $user->id) }}" class="d-inline">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-secondary rounded-pill">フォロー中</button>
-                        </form>
+                        {{-- フォロー中ボタン --}}
+                        <button type="button" 
+                                class="btn btn-secondary rounded-pill follow-btn"
+                                data-follower-name="{{ $user->name }}" 
+                                data-follower-id="{{ $user->id }}">
+                            <span>フォロー解除</span>
+                            <span>フォロー中</span>
+                        </button>
+                        {{-- フォロー解除の確認ポップアップ --}}
+                        <div id="confirm-unfollow" class="floating-confirm" style="display: none;">
+                            <div class="confirm-content">
+                                <p><span id="unfollow-message"></span>さんをフォロー解除しますか？</p>
+                                <form method="POST" action="" id="unfollow-form">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-danger">フォロー解除</button>
+                                    <button type="button" class="btn btn-secondary" id="cancel-unfollow">キャンセル</button>
+                                </form>
+                            </div>
+                        </div>
+                        {{-- グレーアウト用の背景 --}}
+                        <div id="overlay" style="display: none;"></div>
                     @else
-                    <form method="POST" action="{{ route('follow', $user->id) }}" class="d-inline">
-                        @csrf
-                        <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
-                    </form>
+                        {{-- フォローするボタン --}}
+                        <form method="POST" action="{{ route('follow', $user->id) }}" class="d-inline">
+                            @csrf
+                            <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
+                        </form>
                     @endif
                 @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
                     <a href="{{ route('login') }}" class="btn btn-primary rounded-pill">フォローする</a>
@@ -44,7 +62,7 @@
                         <form method="POST" action="{{ route('user.delete', $user->id) }}">
                             @csrf
                             @method('DELETE')
-                            <button type="submit" class="btn btn-danger" data-user-name="{{ $user->name }}" data-user-email="{{ $user->email }}">退会する</button>
+                            <button type="submit" class="btn btn-danger delete-account" data-user-name="{{ $user->name }}" data-user-email="{{ $user->email }}">退会する</button>
                         </form>
                     </div>
                 @endif
@@ -100,4 +118,5 @@
     </div>
 </div>
 <script src="{{ asset('/js/confirmDelete.js') }}" defer></script>
+<script src="{{ asset('/js/confirmUnfollow.js') }}" defer></script>
 @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -18,36 +18,8 @@
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h3 class="card-title text-light">{{ $user->name }}</h3>
                 @if (Auth::check() && Auth::id() !== $user->id)  {{-- 自分自身でないかを確認 --}}
-                    @if (Auth::user()->isFollowing($user->id))
-                        {{-- フォロー中ボタン --}}
-                        <button type="button" 
-                                class="btn btn-secondary rounded-pill follow-btn"
-                                data-follower-name="{{ $user->name }}" 
-                                data-follower-id="{{ $user->id }}">
-                            <span>フォロー解除</span>
-                            <span>フォロー中</span>
-                        </button>
-                        {{-- フォロー解除の確認ポップアップ --}}
-                        <div id="confirm-unfollow" class="floating-confirm" style="display: none;">
-                            <div class="confirm-content">
-                                <p><span id="unfollow-message"></span>さんをフォロー解除しますか？</p>
-                                <form method="POST" action="" id="unfollow-form">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-danger">フォロー解除</button>
-                                    <button type="button" class="btn btn-secondary" id="cancel-unfollow">キャンセル</button>
-                                </form>
-                            </div>
-                        </div>
-                        {{-- グレーアウト用の背景 --}}
-                        <div id="overlay" style="display: none;"></div>
-                    @else
-                        {{-- フォローするボタン --}}
-                        <form method="POST" action="{{ route('follow', $user->id) }}" class="d-inline">
-                            @csrf
-                            <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
-                        </form>
-                    @endif
+                    {{-- フォローボタン共通コンポーネント --}}
+                    @include('commons.follow_button', ['userId' => $user->id, 'userName' => $user->name, 'buttonClass' => 'btn-secondary'])
                 @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
                     <a href="{{ route('login') }}" class="btn btn-primary rounded-pill">フォローする</a>
                 @endif
@@ -104,7 +76,6 @@
             @endif
         @endif
 
-
         {{-- フォロー中のユーザー一覧 --}}
         @if (Request::is('users/'.$user->id.'/followings'))
             @include('users.followings', ['user' => $user])
@@ -114,9 +85,9 @@
         @if (Request::is('users/'.$user->id.'/followers'))
             @include('users.followers', ['user' => $user, 'followers' => $followers])
         @endif
-        
     </div>
 </div>
+
 <script src="{{ asset('/js/confirmDelete.js') }}" defer></script>
 <script src="{{ asset('/js/confirmUnfollow.js') }}" defer></script>
 @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,6 +1,12 @@
 @extends('layouts.app')
 
 @section('content')
+@include('commons.error_messages')
+@if (session('status'))
+    <div class="alert alert-success mt-3">
+        {{ session('status') }}
+    </div>
+@endif
 <div class="row">
     <aside class="col-sm-4 mb-5">
         <div class="card bg-info">
@@ -9,12 +15,26 @@
                     {!! session('error') !!}
                 </div>
             @endif
-            <div class="card-header">
+            <div class="card-header d-flex justify-content-between align-items-center">
                 <h3 class="card-title text-light">{{ $user->name }}</h3>
+                @if (Auth::check() && Auth::id() !== $user->id)  {{-- 自分自身でないかを確認 --}}
+                    @if (Auth::user()->isFollowing($user->id))
+                        <form method="POST" action="{{ route('unfollow', $user->id) }}" class="d-inline">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-secondary rounded-pill">フォロー中</button>
+                        </form>
+                    @endif
+                @else
+                    <form method="POST" action="{{ route('follow', $user->id) }}" class="d-inline">
+                        @csrf
+                        <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
+                    </form>
+                @endif
             </div>
             <div class="card-body">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
-                @if (Auth::id() === $user->id)
+                @if (Auth::check() && Auth::id() === $user->id)
                     <div class="mt-3">
                         <a href="{{-- {{ route('user.edit') }} --}}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                     </div>
@@ -31,10 +51,27 @@
     </aside>
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">
-            <li class="nav-item"><a href="" class="nav-link {{ Request::is() ? 'active' : '' }}">タイムライン</a></li>
-            <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
-            <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
+            <li class="nav-item">
+                <a href="" class="nav-link {{ Request::is() ? 'active bg-primary text-white' : '' }}">タイムライン</a>
+            </li>
+            <li class="nav-item">
+                <a href="{{ route('user.followings', $user->id) }}" class="nav-link {{ Request::is('users/'.$user->id.'/followings') ? 'active bg-primary text-white' : '' }}">フォロー中</a>
+            </li>
+            <li class="nav-item">
+                <a href="{{ route('user.followers', $user->id) }}" class="nav-link {{ Request::is('users/'.$user->id.'/followers') ? 'active bg-primary text-white' : '' }}">フォロワー</a>
+            </li>
         </ul>
+
+        {{-- フォロー中のユーザー一覧 --}}
+        @if (Request::is('users/'.$user->id.'/followings'))
+            @include('users.followings', ['user' => $user])
+        @endif
+
+        {{-- フォロワーのユーザー一覧 --}}
+        @if (Request::is('users/'.$user->id.'/followers'))
+            @include('users.followers', ['user' => $user, 'followers' => $followers])
+        @endif
+        
     </div>
 </div>
 <script src="{{ asset('/js/confirmDelete.js') }}" defer></script>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -31,7 +31,7 @@
                     </form>
                     @endif
                 @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
-                    <a href="{{-- route('login') --}}" class="btn btn-primary rounded-pill">フォローする</a>
+                    <a href="{{ route('login') }}" class="btn btn-primary rounded-pill">フォローする</a>
                 @endif
             </div>
             <div class="card-body">
@@ -63,6 +63,26 @@
                 <a href="{{ route('user.followers', $user->id) }}" class="nav-link {{ Request::is('users/'.$user->id.'/followers') ? 'active bg-primary text-white' : '' }}">フォロワー</a>
             </li>
         </ul>
+
+        {{-- タイムラインの投稿一覧 --}}
+        @if (Request::is('users/'.$user->id))
+            <h5 class="mt-5 mb-4">最近の投稿</h5>
+            @if ($posts->count() > 0)
+                <div class="list-group">
+                    @foreach ($posts as $post)
+                        <div class="list-group-item">
+                            <h6>{{ $post->created_at->format('Y/m/d H:i') }}</h6>
+                            <p>{{ $post->post }}</p>
+                        </div>
+                    @endforeach
+                </div>
+                {{-- ページネーションリンク --}}
+                {{ $posts->links('pagination::bootstrap-4') }}
+            @else
+                <p>投稿がありません。</p>
+            @endif
+        @endif
+
 
         {{-- フォロー中のユーザー一覧 --}}
         @if (Request::is('users/'.$user->id.'/followings'))

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -54,7 +54,7 @@
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">
             <li class="nav-item">
-                <a href="" class="nav-link {{ Request::is() ? 'active bg-primary text-white' : '' }}">タイムライン</a>
+                <a href="{{ route('user.show', $user->id ) }}" class="nav-link {{ Request::is('users/'.$user->id) ? 'active bg-primary text-white' : '' }}">タイムライン</a>
             </li>
             <li class="nav-item">
                 <a href="{{ route('user.followings', $user->id) }}" class="nav-link {{ Request::is('users/'.$user->id.'/followings') ? 'active bg-primary text-white' : '' }}">フォロー中</a>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -54,13 +54,16 @@
     <div class="col-sm-8">
         <ul class="nav nav-tabs nav-justified mb-3">
             <li class="nav-item">
-                <a href="{{ route('user.show', $user->id ) }}" class="nav-link {{ Request::is('users/'.$user->id) ? 'active bg-primary text-white' : '' }}">タイムライン</a>
+                <a href="{{ route('user.show', $user->id ) }}" 
+                    class="nav-link {{ Request::is('users/'.$user->id) ? 'active bg-primary text-white' : '' }}">タイムライン</a>
             </li>
             <li class="nav-item">
-                <a href="{{ route('user.followings', $user->id) }}" class="nav-link {{ Request::is('users/'.$user->id.'/followings') ? 'active bg-primary text-white' : '' }}">フォロー中</a>
+                <a href="{{ route('user.followings', $user->id) }}" 
+                    class="nav-link {{ Request::is('users/'.$user->id.'/followings') ? 'active bg-primary text-white' : '' }}">フォロー中</a>
             </li>
             <li class="nav-item">
-                <a href="{{ route('user.followers', $user->id) }}" class="nav-link {{ Request::is('users/'.$user->id.'/followers') ? 'active bg-primary text-white' : '' }}">フォロワー</a>
+                <a href="{{ route('user.followers', $user->id) }}" 
+                    class="nav-link {{ Request::is('users/'.$user->id.'/followers') ? 'active bg-primary text-white' : '' }}">フォロワー</a>
             </li>
         </ul>
 

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -24,12 +24,14 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-secondary rounded-pill">フォロー中</button>
                         </form>
-                    @endif
-                @else
+                    @else
                     <form method="POST" action="{{ route('follow', $user->id) }}" class="d-inline">
                         @csrf
                         <button type="submit" class="btn btn-primary rounded-pill">フォローする</button>
                     </form>
+                    @endif
+                @elseif (!Auth::check())  {{-- ログインしていない場合 --}}
+                    <a href="{{-- route('login') --}}" class="btn btn-primary rounded-pill">フォローする</a>
                 @endif
             </div>
             <div class="card-body">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,7 +2,7 @@
 @section('content')
 <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
-            <h1><i class="pr-3"></i>Topic Posts</h1>
+            <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,24 +6,24 @@
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-        <div class="w-75 m-auto">
-            @include('commons.error_messages')
-            @if (session('status'))
-                <div class="alert alert-success mt-3">
-                    {{ session('status') }}
+    <div class="w-75 m-auto">
+        @include('commons.error_messages')
+        @if (session('status'))
+            <div class="alert alert-success mt-3">
+                {{ session('status') }}
+            </div>
+        @endif
+    </div>
+    <div class="text-center mb-3">
+        <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+            @csrf
+            <div class="form-group">
+                <textarea class="form-control" name="post" rows="3" value="{{ old('post') }}"></textarea>
+                <div class="text-left mt-3">
+                    <button type="submit" class="btn btn-primary">投稿する</button>
                 </div>
-            @endif
-        </div>
-        <div class="text-center mb-3">
-            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
-                @csrf
-                <div class="form-group">
-                    <textarea class="form-control" name="post" rows="3" value="{{ old('post') }}"></textarea>
-                    <div class="text-left mt-3">
-                        <button type="submit" class="btn btn-primary">投稿する</button>
-                    </div>
-                </div>
-            </form>
-            @include('posts.posts', ['posts' => $posts])
-        </div>
+            </div>
+        </form>
+        @include('posts.posts', ['posts' => $posts])
+    </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,11 +18,11 @@ Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('sign
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 // ユーザ
-Route::prefix('users')->group(function () {
-    Route::get('{id}', 'UsersController@show')->name('user.show');
-    Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
-    Route::get('{id}/followings', 'UsersController@followings')->name('user.followings');
-    Route::get('{id}/followers', 'UsersController@followers')->name('user.followers');
+Route::prefix('users/{id}')->group(function () {
+    Route::get('', 'UsersController@show')->name('user.show');
+    Route::delete('', 'UsersController@destroy')->name('user.delete');
+    Route::get('followings', 'UsersController@followings')->name('user.followings');
+    Route::get('followers', 'UsersController@followers')->name('user.followers');
 });
 
 // ログイン後
@@ -32,6 +32,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('', 'PostsController@store')->name('post.store');
     });
     // フォロー
-    Route::post('/users/{user}/follow', 'UsersController@follow')->name('follow');
-    Route::delete('/users/{user}/unfollow', 'UsersController@unfollow')->name('unfollow');
+    Route::prefix('users/{id}')->group(function () {
+        Route::post('follow', 'UsersController@follow')->name('follow');
+        Route::delete('unfollow', 'UsersController@unfollow')->name('unfollow');
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 Route::prefix('users')->group(function () {
     Route::get('{id}', 'UsersController@show')->name('user.show');
     Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
+    Route::get('{id}/followings', 'UsersController@followings')->name('user.followings');
+    Route::get('{id}/followers', 'UsersController@followers')->name('user.followers');
 });
 
 // ログイン後
@@ -29,4 +31,7 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
         Route::post('', 'PostsController@store')->name('post.store');
     });
+    // フォロー
+    Route::post('/users/{user}/follow', 'UsersController@follow')->name('follow');
+    Route::delete('/users/{user}/unfollow', 'UsersController@unfollow')->name('unfollow');
 });


### PR DESCRIPTION
## issue
- Closes #127 

## 概要
- フォロー機能

## 動作確認手順
> [!IMPORTANT]
> 未ログインでも「フォローする」ボタンが表示されるが
> 未ログインで「フォローする」ボタン押下時はログイン画面へ遷移させる ~~（ログイン画面未実装）~~
> ※ログイン画面実装をマージ済みです
- [ ] 下記URLにアクセスし、ユーザ名横に「フォローする」ボタンが表示されることを確認
http://localhost:8080/users/1
- [ ] 下記URLでユーザ１がフォローしているユーザ一覧が表示されることを確認
http://localhost:8080/users/1/followings
- [ ] 下記URLでユーザ１をフォローしているユーザ一覧が表示されることを確認
http://localhost:8080/users/1/followers
- ユーザログイン後 ~~（現時点では新規サインアップで対応）~~ 以下を確認
  - [ ] フォロー機能が動作すること
  - [ ] フォロー中のユーザには「フォロー中」ボタンが表示されること
  - [ ] 「フォロー中」ボタン ~~を押下するとフォローが解除されること~~ 
  にカーソルを合わせると「フォロー解除」ボタンに切り替わること
  - [ ] フォローを試行後、Adminerにて中間テーブルが更新されていることを確認
  http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=followers

### 参考イメージ
<img width="1440" alt="スクリーンショット 2024-09-14 18 22 05" src="https://github.com/user-attachments/assets/3cf922e4-349d-44d1-a7d4-dabd536c2cb9">

<img width="1440" alt="スクリーンショット 2024-09-14 17 56 28" src="https://github.com/user-attachments/assets/015e2c1f-c610-4b69-b393-b2dfab85b387">

<img width="1440" alt="スクリーンショット 2024-09-14 17 56 36" src="https://github.com/user-attachments/assets/27e70f48-1d12-4010-82a7-c4cee1386e85">



## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- 特になし