### PR TITLE
#113 トップページの投稿表示 (おおつき)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -8,6 +8,18 @@ use App\Post;
 
 class PostsController extends Controller
 {
+    /**
+     * トップページの投稿表示
+     */
+    public function index()
+    {
+        $posts = Post::orderBy('id', 'desc')->paginate(10);
+
+        return view('welcome', [
+            'posts' => $posts,
+        ]);
+    }
+
     public function store(PostRequest $request)
     {
         $post = new Post;

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,16 +6,24 @@
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-    <div class="w-75 m-auto">@include('commons.error_messages')</div>
-    <div class="text-center mb-3">
-        <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
-            @csrf
-            <div class="form-group">
-                <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
-                <div class="text-left mt-3">
-                    <button type="submit" class="btn btn-primary">投稿する</button>
+    @auth
+        <div class="w-75 m-auto">@include('commons.error_messages')</div>
+        <div class="text-center mb-3">
+            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+                @csrf
+                <div class="form-group">
+                    <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
+                    <div class="text-left mt-3">
+                        <button type="submit" class="btn btn-primary">投稿する</button>
+                    </div>
                 </div>
-            </div>
-        </form>
+            </form>
+        </div>
+    @endauth
+    @foreach ($posts as $post)
+        @include('posts.show', ['user' => $post->user, 'post' => $post])
+    @endforeach
+    <div class="m-auto" style="width: fit-content">
+        {{ $posts->links('pagination::bootstrap-4') }}
     </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,13 +11,12 @@
 |
 */
 
-Route::get('/', function () {
-    return view('welcome');
-});
+// トップページの投稿表示
+Route::get('/', 'PostsController@index');
 
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
-Route::post('signup', 'Auth\RegisterController@register')->name('signup.post'); 
+Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 // ログイン
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');


### PR DESCRIPTION
## issue
- Closes #113 

## 概要
- トップページの投稿表示

## 動作確認手順
- トップページで全ての投稿（降順）がページネーションによって表示されていることを確認

## 考慮して欲しいこと
- トップページの投稿フォームはログイン時のみ表示に修正