### PR TITLE
#113 トップページの投稿表示（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -4,12 +4,16 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\User;
+use App\Post;
 
 class UsersController extends Controller
 {
     public function index()
     {
-        return view('welcome');
+        $posts = Post::orderBy('id', 'desc')->paginate(10);
+        return view('welcome', [
+            'posts' => $posts
+        ]);
     }
 
     public function show($id)

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -20,3 +20,4 @@
         </form>
     </div>
     @endif
+@include('posts.posts', ['posts => $posts'])


### PR DESCRIPTION
## issue
- Closes #113

## 概要
- トップページの投稿表示

## 動作確認手順
- ローカルにて、トップページに最新の投稿から10個が表示されることを確認。
　　http://localhost:8080/

- ブートストラップのページ送り機能で、11個めの投稿からは2ページ目に表示されることを確認。
　　http://localhost:8080/?page=2
