### PR TITLE
#117 ユーザ編集画面・更新（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\User;
 use App\Post;
+use App\Http\Requests\UserRequest;
 
 class UsersController extends Controller
 {
@@ -25,5 +26,21 @@ class UsersController extends Controller
             'posts' => $posts
         ];
         return view('users.show', $data); 
+    }
+
+    public function edit($id)
+    {
+        $user = User::findOrFail($id);
+        return view('users.edit', ['user' => $user]);
+    }
+
+    public function update(UserRequest $request, $id)
+    {
+        $user =User::findOrFail($id);
+        $user->name = $request->name;
+        $user->email = $request->email;
+        $user->password = $request->password;
+        $user->save();
+        return back();
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\User;
 use App\Post;
 use App\Http\Requests\UserRequest;
+use Illuminate\Support\Facades\Hash;
 
 class UsersController extends Controller
 {
@@ -30,7 +31,8 @@ class UsersController extends Controller
 
     public function edit($id)
     {
-        $user = User::findOrFail($id);
+        $user = User::findOrFail($id);  
+        abort_unless($user->id === \Auth::id(), 403);
         return view('users.edit', ['user' => $user]);
     }
 
@@ -39,8 +41,8 @@ class UsersController extends Controller
         $user =User::findOrFail($id);
         $user->name = $request->name;
         $user->email = $request->email;
-        $user->password = $request->password;
+        $user->password = Hash::make($request->password);
         $user->save();
-        return back();
+        return redirect()->route('user.show', $id);
     }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UserRequest extends FormRequest
 {
@@ -25,7 +26,7 @@ class UserRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($this->id)],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ];
     }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'name' => 'ユーザ名',
+            'email' => 'メールアドレス',
+            'password' => 'パスワード',
+        ];
+    }
+}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,52 @@
+ {{-- @extends('layouts.app') --}}
+ {{-- @section --}}
+    <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+        <form method="POST" action="{{ route('user.update', $user->id) }}">
+            @csrf
+            @method('PUT')    
+            <input type="hidden" name="id" value="#" />
+            <div class="form-group">
+                <label for="name">ユーザ名</label>
+                <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
+            </div>
+
+            <div class="form-group">
+                <label for="email">メールアドレス</label>
+                <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
+            </div>
+
+            <div class="form-group">
+                <label for="password">パスワード</label>
+                <input class="form-control" type="password" name="password" />
+            </div>
+
+            <div class="form-group">
+                <label for="password_confirmation">パスワードの確認</label>
+                <input class="form-control" type="password" name="password" />
+            </div>
+
+            <div class="d-flex justify-content-between">
+                <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+                <button type="submit" class="btn btn-primary">更新する</button>
+            </div>
+        </form>
+
+        <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h4>確認</h4>
+                    </div>
+                    <div class="modal-body">
+                        <label>本当に退会しますか？</label>
+                    </div>
+                    <div class="modal-footer d-flex justify-content-between">
+                        <form action="" method="POST">
+                            <button type="submit" class="btn btn-danger">退会する</button>
+                        </form>
+                        <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                    </div>
+                </div>
+            </div>    
+        </div>
+{{-- @endsection --}}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,10 +1,16 @@
  {{-- @extends('layouts.app') --}}
  {{-- @section --}}
     <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+    @if (count($errors) > 0)
+    <ul class="alert alert-danger" role="alert">
+        @foreach ($errors->all() as $error)
+            <li class="ml-4">{{ $error }}</li>
+        @endforeach
+    </ul>
+    @endif
         <form method="POST" action="{{ route('user.update', $user->id) }}">
             @csrf
             @method('PUT')    
-            <input type="hidden" name="id" value="#" />
             <div class="form-group">
                 <label for="name">ユーザ名</label>
                 <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
@@ -22,7 +28,7 @@
 
             <div class="form-group">
                 <label for="password_confirmation">パスワードの確認</label>
-                <input class="form-control" type="password" name="password" />
+                <input class="form-control" type="password" name="password_confirmation" />
             </div>
 
             <div class="d-flex justify-content-between">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -9,7 +9,7 @@
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 350) }}" alt="ユーザのアバター画像">
                         <div class="mt-3">
-                            <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                            <a href="{{ route('user.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                         </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,8 +28,8 @@ Route::group(['middleware' => 'auth'], function() {
         Route::post('', 'PostsController@store')->name('post.store');
     });
     // ユーザ編集・更新
-    Route::prefix('users')->group(function() {
-        Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
-        Route::put('{id}', 'UsersController@update')->name('user.update');
+    Route::prefix('users/{id}')->group(function() {
+        Route::get('edit', 'UsersController@edit')->name('user.edit');
+        Route::put('', 'UsersController@update')->name('user.update');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,4 +27,9 @@ Route::group(['middleware' => 'auth'], function() {
     Route::prefix('posts')->group(function() {
         Route::post('', 'PostsController@store')->name('post.store');
     });
+    // ユーザ編集・更新
+    Route::prefix('users')->group(function() {
+        Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
+        Route::put('{id}', 'UsersController@update')->name('user.update');
+    });
 });


### PR DESCRIPTION
## issue
- Closes #117

## 概要
- ユーザ編集画面・更新

## 動作確認手順
- ローカルにて、以下の手順で、ユーザ編集画面とユーザ情報の更新確認を行った。
① http://localhost:8080/signup  から、ユーザを1人新規作成( id:9 )し、ログインしている状態のトップページへ遷移。
② 投稿を1つ新規作成して、トップページにid:9 のユーザ名と投稿を表示させた。そのURL付きのユーザ名（id:9）をクリックし、ユーザ詳細画面へ移動。
③「ユーザ情報の編集」をクリックし、 http://localhost:8080/users/9/edit が表示されることを確認。
④実際にユーザ名を変更&更新してみて、元の編集画面に戻ることを確認。

## 確認したいこと。
- validationの書き方や場所がこれでよいのか、少し不安です。
- 動作確認手順がこれで良かったのか気になります。もし、より良い方法があれば教えていただきたいです。
