### PR TITLE
#123 投稿編集画面・更新 (おおつき)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -72,7 +72,7 @@ class PostsController extends Controller
             return back()すると、その2ページ目以降を再表示するため、
             1ページ目の先頭位置に表示される
             「今まさに投稿した分」確認できない
-            
+
             ユーザーからすると、「今まさに投稿した分」が表示されないので
             投稿できてないのではないかと、
             勘違いしてしまい、何度も投稿してしまうことになってしまう可能性があり
@@ -102,5 +102,32 @@ class PostsController extends Controller
 
         $this->showFlashSuccess("削除しました。");
         return back();
+    }
+
+    /**
+     * 編集
+     */
+    public function edit($id)
+    {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() !== $post->user_id) {
+            abort(403);
+        }
+
+        return view('posts.edit', [
+            'post' => $post,
+        ]);
+    }
+
+    /**
+     * 更新
+     */
+    public function update(PostRequest $request, $id)
+    {
+        $post = Post::findOrFail($id);
+        $post->content = $request->input('content');
+        $post->save();
+        $this->showFlashSuccess("更新しました。");
+        return redirect('/');
     }
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+@section('content')
+    <h2 class="mt-5">投稿を編集する</h2>
+        @include('commons.error_messages')
+        <form method="POST" action="{{ route('post.update', $post->id) }}">
+            @csrf
+            @method('PUT')
+            <div class="form-group">
+                <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </form>
+@endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -45,7 +45,7 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('post.edit', $post->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,17 +44,20 @@ Route::group(['middleware' => 'auth'], function() {
     Route::prefix('users')->group(function(){
         // 削除
         Route::delete('{id}', 'UsersController@destroy')->name('user.delete');
-        //編集・更新
+        // 編集・更新
         Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
         Route::put('{id}', 'UsersController@update')->name('user.update');
     });
-    
+
     // 「投稿」
     Route::prefix('posts')->group(function(){
         // 登録
         Route::post('', 'PostsController@store')->name('post.store');
-        //削除
+        // 削除
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
+        // 編集・更新
+        Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
+        Route::put('{id}', 'PostsController@update')->name('post.update');
     });
 
     // 「フォロー」
@@ -67,7 +70,7 @@ Route::group(['middleware' => 'auth'], function() {
 /* #region API */
 /*
     本来はapiなのでapi.phpに追加すべきだがweb.phpに追加しました。
-    
+
     ＜経緯＞
     api.phpでの「Route::middleware('auth:api')->」は、
     APIリクエストに対して、OAuthやJWT(JSON Web Token)などの仕組みを使って
@@ -87,7 +90,7 @@ Route::group(['middleware' => 'auth'], function() {
 
         // url=「/upload」のPOSTでアップロードで保存
         Route::post('', 'UploadController@store');
-        
+
         /*
             url=「/upload/{id}」のPUTで更新
 


### PR DESCRIPTION
## issue
- Closes #123 

## 概要
- 投稿編集画面・更新

## 動作確認手順
- ログイン後、トップページとユーザ詳細タイムラインにある
   自身の投稿「編集する」ボタン押下後、投稿編集ページに遷移を確認。
- 投稿編集ページで「更新する」ボタン押下後、
   トップページに遷移し投稿(content)の更新を確認。
- Adminerにて更新した投稿のcontent, updated_atが更新されていることを確認。

## 考慮して欲しいこと
- 以下ファイルのコメントアウト内の空行やスペースなどの記述の仕方が気になってしまい、
   可読性を上げるため、プロジェクト全体の記述と併せる方向で整え修正しています。
   実装とは関係ないものの考慮いただけますと幸いです。
   app/Http/Controllers/PostsController.php
   routes/web.php