### PR TITLE
#117 ユーザ編集画面・更新(ゆうじ)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use App\Http\Requests\UserRequest;
 use App\User;
 
 class UsersController extends Controller
@@ -28,5 +30,25 @@ class UsersController extends Controller
             return redirect()->route('welcome')->with('status', 'ユーザの退会処理が完了しました。');
         }
         return back()->with('error', 'ユーザの退会処理に失敗しました。<br>再度ログインしてからやり直してください。');
+    }
+
+    public function edit($id)
+    {
+        $user = User::findOrFail($id);
+        if ($id == \Auth::id()) {
+            $user = \Auth::user();
+            return view('users.edit', ['user' => $user]);
+        }
+        abort(404);
+    }
+
+    public function update(UserRequest $request, $id)
+    {
+        $user = User::findOrFail($id);
+        $user->name = $request-> name ;
+        $user->email = $request-> email ;
+        $user->password = Hash::make($request->password);
+        $user->save();
+        return redirect()->route('user.show', ['id' => $user->id]);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -36,7 +36,6 @@ class UsersController extends Controller
     {
         $user = User::findOrFail($id);
         if ($id == \Auth::id()) {
-            $user = \Auth::user();
             return view('users.edit', ['user' => $user]);
         }
         abort(404);

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+}

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UserRequest extends FormRequest
 {
@@ -25,7 +26,7 @@ class UserRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($this->id)],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ];
     }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -5,7 +5,6 @@
     <form method="POST" action="{{ route('user.update', $user->id)}}">
         @csrf
         @method('PUT')
-        <input type="hidden" name="id" value="" />
         <div class="form-group">
             <label for="name">ユーザ名</label>
             <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
@@ -42,7 +41,9 @@
                     <label>本当に退会しますか？</label>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
-                    <form action="" method="POST">
+                    <form action="{{ route('user.delete', $user->id)}}" method="POST">
+                        @csrf
+                        @method('DELETE')
                         <button type="submit" class="btn btn-danger">退会する</button>
                     </form>
                     <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.app')
+@section('content')
+    <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+    @include('commons.error_messages')
+    <form method="POST" action="{{ route('user.update', $user->id)}}">
+        @csrf
+        @method('PUT')
+        <input type="hidden" name="id" value="" />
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
+        </div>
+
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
+        </div>
+
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password_confirmation" />
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+    </form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="" method="POST">
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -16,7 +16,8 @@
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
                 @if (Auth::id() === $user->id)
                     <div class="mt-3">
-                        <a href="{{-- {{ route('user.edit') }} --}}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+
+                        <a href="{{ route('user.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                     </div>
                     <div class="mt-3">
                         <form method="POST" action="{{ route('user.delete', $user->id) }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,12 +40,6 @@ Route::group(['middleware' => 'auth'], function () {
         //削除
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
-
-    // ユーザー編集・更新
-    Route::prefix('users/{id}')->group(function () {
-        Route::get('edit', 'UsersController@edit')->name('user.edit');
-        Route::put('', 'UsersController@update')->name('user.update');
-    });
     
     // フォロー
     Route::prefix('users/{id}')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,4 +36,10 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
         Route::post('', 'PostsController@store')->name('post.store');
     });
+
+    // ユーザー編集・更新
+    Route::prefix('users')->group(function () {
+        Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
+        Route::put('{id}', 'UsersController@update')->name('user.update');
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,8 +38,8 @@ Route::group(['middleware' => 'auth'], function () {
     });
 
     // ユーザー編集・更新
-    Route::prefix('users')->group(function () {
-        Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
-        Route::put('{id}', 'UsersController@update')->name('user.update');
+    Route::prefix('users/{id}')->group(function () {
+        Route::get('edit', 'UsersController@edit')->name('user.edit');
+        Route::put('', 'UsersController@update')->name('user.update');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,12 +41,12 @@ Route::group(['middleware' => 'auth'], function () {
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
     });
     
-    // フォロー
     Route::prefix('users/{id}')->group(function () {
+        // フォロー
         Route::post('follow', 'UsersController@follow')->name('follow');
         Route::delete('unfollow', 'UsersController@unfollow')->name('unfollow');
-
-    // ユーザー編集・更新
+        
+        // ユーザー編集・更新
         Route::get('edit', 'UsersController@edit')->name('user.edit');
         Route::put('', 'UsersController@update')->name('user.update');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,5 +51,9 @@ Route::group(['middleware' => 'auth'], function () {
     Route::prefix('users/{id}')->group(function () {
         Route::post('follow', 'UsersController@follow')->name('follow');
         Route::delete('unfollow', 'UsersController@unfollow')->name('unfollow');
+
+    // ユーザー編集・更新
+        Route::get('edit', 'UsersController@edit')->name('user.edit');
+        Route::put('', 'UsersController@update')->name('user.update');
     });
 });


### PR DESCRIPTION
## issue
- Closes #117

## 概要
- ユーザ編集画面・更新

## 動作確認手順
- 下記の手順でユーザ編集画面とユーザ情報の更新動作を確認
① http://localhost:8080/signup にてユーザを新規作成し、ログイン状態でユーザ詳細画面にある「ユーザ情報の編集」ボタンを押下する。
②「 ユーザ名、メールアドレス、パスワード、パスワードの確認」を変更入力し、「更新する」ボタンを押下してユーザ詳細画面に遷移することを確認する。
③Adminerにて`users`テーブルの該当するレコードが更新されていることを確認。

- 追加で、ユーザ編集画面の「退会する」ボタンから退会できるように更新
①ユーザ編集画面の「退会する」ボタンを押下する。
②「本当に退会しますか？」の文言が表示されるので「退会する」ボタンを押下する。
③トップページに自動で遷移し「ユーザの退会処理が完了しました。」の表示を確認。Adminerにて該当ユーザが論理削除されていることを確認。

### 考慮して欲しいこと
前回のpushのあと、フォロー機能がマージされてから今回の再プッシュとなります。コンフリクトを解消して再プッシュしておりますので、よろしくお願いいたします。