### PR TITLE
共通ファイル＆ヘッダー・フッター＆トップページのタイトルのみ表示「Topic Posts」(大畑)

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,5 +1,5 @@
-{{-- @extends('layouts.app') --}}
-{{-- @section('content') --}}
+@extends('layouts.app')
+@section('content')
 <div class="text-center">
         <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
@@ -26,4 +26,4 @@
             <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
         </div>
     </div>
-   {{-- @endsection --}}
+@endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,5 +1,5 @@
-{{-- @extends('layouts.app') --}}
-{{-- @section('content') --}}    
+@extends('layouts.app')
+@section('content')  
     <div class="text-center">
         <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
@@ -33,4 +33,4 @@
             </form>
         </div>
     </div>
-{{-- @endsection --}}
+@endsection

--- a/resources/views/commons/error_messages.blade.php
+++ b/resources/views/commons/error_messages.blade.php
@@ -1,0 +1,7 @@
+@if (count($errors) > 0)
+    <ul class="alert alert-danger" role="alert">
+      @foreach ($errors->all() as $error)
+          <li class="ml-4">{{ $error }}</li>
+      @endforeach        
+    </ul>
+@endif

--- a/resources/views/commons/footer.blade.php
+++ b/resources/views/commons/footer.blade.php
@@ -1,0 +1,5 @@
+<footer class="mt-5">
+    <nav class="navbar navbar-dark bg-info justify-content-center">
+        <span class="navbar-brand">©Gut Familie, All rights reserved.</span>
+    </nav>
+</footer>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,0 +1,20 @@
+<header class="mb-5">
+    <nav class="navbar navbar-expand-sm navbar-dark bg-info">
+        <a class="navbar-brand" href="/">Topic Posts</a>
+        <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="nav-bar">
+            <ul class="navbar-nav mr-auto"></ul>
+            <ul class="navbar-nav">
+              @if (Auth::check())
+                  <li class="nav-item"><a href="" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
+                  <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
+              @else
+                  <li class="nav-item"><a href="{{ route('login') }}" class="nav-link text-light">ログイン</a></li>
+                  <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>
+              @endif
+            </ul>
+        </div>
+    </nav>
+</header>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="utf-8">
+        <title>Topic Posts</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    </head>
+    <body>
+      @include('commons.header')
+        <div class="container">
+          @include('commons.error_messages')
+          @yield('content')
+        </div>
+        @include('commons.footer')
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script defer src="https://use.fontawesome.com/releases/v5.7.2/js/all.js"></script>
+    </body>
+</html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,7 +12,7 @@
           @include('commons.error_messages')
           @yield('content')
         </div>
-        @include('commons.footer')
+      @include('commons.footer')
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,7 +6,7 @@
     </div>
 </div>
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-    <div class="w-75 m-auto">@extends('commons.error_messages')</div>
+    <div class="w-75 m-auto">@include('commons.error_messages')</div>
     @if (Auth::check())
     <div class="text-center mb-3">
         <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,12 +1,12 @@
-{{-- トップページで動作確認（ログイン時に投稿枠&ボタン表示）したかったので作りました --}}
-
+@extends('layouts.app')
+@section('content')
 <div class="center jumbotron bg-info">
     <div class="text-center text-white mt-2 pt-1">
         <h1><i class="pr-3"></i>Topic Posts</h1>
     </div>
 </div>
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-    <div class="w-75 m-auto">エラーメッセージが入る場所</div>
+    <div class="w-75 m-auto">@extends('commons.error_messages')</div>
     @if (Auth::check())
     <div class="text-center mb-3">
         <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
@@ -21,4 +21,4 @@
     </div>
     @endif    
 @include('posts.posts', ['posts => $posts'])
-
+@endsection


### PR DESCRIPTION
## issue
- Closes #97
## 概要
- 共通ファイル＆ヘッダー・フッター＆トップページのタイトルのみ表示「Topic Posts」
## 動作確認手順
- トップ画面でのタイトルとヘッダー、フッターの表示、ログイン後のヘッダーフッターの表示の確認。
- 新規登録画面でのエラーメッセージの表示を確認。
## 考慮してほしいこと
- welcome.blade.phpの9行目をextends、include、yieldのどれを使用するか迷いました。
