### PR TITLE
アバター画像のアップロードとその表示対応(大川)

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -2,6 +2,7 @@
 
 namespace App\Helpers;
 
+use App\UserImage;
 use App\PostImage;
 
 /**
@@ -32,21 +33,89 @@ class Helper
         return self::$instance;
     }
 
+    /* #region userImage関連 */
+
+    /**
+     * 「user_images」の再構成を行う。
+     */
+    public function reconstructionUserImage($user, $fileUuids, $fileNames)
+    {
+        $userImage = $user->userImage()->first();
+
+        // 「user_images」のDELETE/INSERT処理を行う。
+
+        /*
+            DELETEの処理
+
+            「users」と「user_images」は「1対1」または「1対0」の関係
+            既にavatar画像がありの時を
+            if ($userImage) {
+            で判定し、そのときだけDELETEする。
+        */
+        if ($userImage) {
+            $userImage->delete();
+        }
+
+        // $requestFileInfoCount関連
+
+        $requestFileInfoCount = static::getRequestFileInfoCountWithValidation($fileUuids, $fileNames);
+        if($requestFileInfoCount <= 0) {
+            return;
+        }
+
+        if($requestFileInfoCount !== 1) {
+            /*
+                アップロードUIコンポーネントは、「'multiFlg' => 'OFF'：単一画像モード」の時で、
+                既に画像が1つ登録済状態の時は、「未指定のアップロードUI」はありえない。
+                (  'imageType' => 'avatar' の時は、その想定。)
+
+                よって、前処理で 0件時をケアしている状況では、
+                ここは、必ず、1でなければならない。
+
+                アップロードUIコンポーネント側のバグ検知や、仕様変更時の対応漏れの発見
+                の意味として、例外を投げる。
+            */
+            throw new \Exception(
+                "requestFileInfoCount : " . strval($requestFileInfoCount) . " should be 1 . ");
+            return;
+        }
+
+        // INSERTの処理
+
+        $uuid = $fileUuids[0];
+        $fileName = $fileNames[0];
+
+        $userImage = new UserImage;
+        $userImage->user_id = $user->id;
+
+        $userImage->uuid = $uuid;
+        $userImage->file_name = $fileName;
+
+        $userImage->save();
+    }
+    
+    /* #endregion */ // userImage関連
+
+
     /* #region postImages関連 */
 
     /**
      * $postImagesの「storage」と「DB値」を削除する
      */
-    public function deletePostImages($postImages)
+    public function deletePostImages($postImages, $isNeedDeleteStorage = true)
     {
         if(is_null($postImages)) {
             return;
         }
 
         foreach($postImages as $postImage) {
-            $uuid = $postImage->uuid;
-            // $imageType、$uuidを指定してstorageから削除
-            static::deleteImageOnStorage('post', $uuid);
+
+            if ($isNeedDeleteStorage) {
+
+                $uuid = $postImage->uuid;
+                // $imageType、$uuidを指定してstorageから削除
+                static::deleteImageOnStorage('post', $uuid);   
+            }
 
             $postImage->delete();
         }
@@ -57,23 +126,17 @@ class Helper
      */
     public function insertPostImages($postId, $fileUuids, $fileNames)
     {
-        if(empty($fileUuids) || empty($fileNames)) {
-            return;
-        }
+        $requestFileInfoCount = static::getRequestFileInfoCountWithValidation($fileUuids, $fileNames);
 
-        $fileUuidsLength = count($fileUuids);
-        $fileNamesLength = count($fileNames);
-
-        if($fileUuidsLength !== $fileNamesLength) {
-            throw new \Exception(
-                "fileUuidsLength : " . strval($fileUuidsLength) . 
-                ", fileNamesLength : " . strval($fileNamesLength) .
-                " not match.");
-        }
+        /*
+            $requestFileInfoCountの値は、
+            「if(is_null($uuid) || is_null($fileName)) {」
+            が成立するケースも含んだ件数なので、後続処理を続行する。 
+        */
 
         $order = 0;
 
-        for($index = 0 ; $index < $fileUuidsLength ; ++$index) {
+        for($index = 0 ; $index < $requestFileInfoCount ; ++$index) {
 
             $uuid = $fileUuids[$index];
             $fileName = $fileNames[$index];
@@ -118,4 +181,48 @@ class Helper
     }
 
     /* #endregion */ // postImages関連
+
+
+    /* #region 「$fileUuids、$fileNames」関係のヘルパー処理 */
+
+    /**
+     * リクエストのファイル情報「$fileUuids、$fileNamesの件数取得」を行う。
+     * その際、件数一致のアサーションもする。
+     */
+    public function getRequestFileInfoCountWithValidation($fileUuids, $fileNames)
+    {
+        if(empty($fileUuids) || empty($fileNames)) {
+            return 0;
+        }
+
+        $fileUuidsLength = count($fileUuids);
+        $fileNamesLength = count($fileNames);
+
+        if($fileUuidsLength !== $fileNamesLength) {
+            throw new \Exception(
+                "fileUuidsLength : " . strval($fileUuidsLength) . 
+                ", fileNamesLength : " . strval($fileNamesLength) .
+                " not match.");
+        }
+
+        return $fileUuidsLength;
+    }
+
+    /**
+     * 「編集モードの初期表示時のアップロードUIの復元情報」を作成する。
+     */
+    public function createUploadUiLoadInfo($fileUuids, $fileNames)
+    {
+        // 編集の初期表示時のアップロードUIの復元情報
+        $loadInfo = new \ArrayObject([
+            // uuid
+            "fileUuids" => json_encode($fileUuids),
+            // ファイル名
+            "fileNames" => json_encode($fileNames),
+        ], \ArrayObject::ARRAY_AS_PROPS);
+
+        return $loadInfo;
+    }
+
+    /* #endregion */ // 「$fileUuids、$fileNamesの検証と件数取得」
 }

--- a/app/Helpers/ViewHelper.php
+++ b/app/Helpers/ViewHelper.php
@@ -2,6 +2,8 @@
 
 namespace App\Helpers;
 
+use Thomaswelton\LaravelGravatar\Facades\Gravatar;
+
 /**
  * viewの処理のヘルパークラス
  */
@@ -133,4 +135,173 @@ class ViewHelper extends Helper
 
         return $config;
     }
+
+    /* #region 「avatar.blade.php」関連 */
+
+    /**
+     * アバター画像のimgタグのstyle属性(まるごと)を取得する。
+     */
+    private function getAvatarImageStyle($isEdit, $imageSize)
+    {
+        /*
+            resources/views/commons/avatar.blade.php
+            でのアバター画像のimgのstyleについては、
+            編集モードかどうかの違いは、" display:none;"の有無の違い
+            でしかないため、一旦、変数に落として文字列連結に備える
+        */
+        $display = "";
+        if($isEdit) {
+            $display = " display:none;";
+        }
+
+        // アップロード済画像のimgタグ用のstyle値
+        $imgUploadedAvatarStyle = trim("width:{$imageSize}px; height: {$imageSize}px;{$display}");
+        $imgUploadedAvatarStyle = "style=\"{$imgUploadedAvatarStyle}\"";
+
+        // Gravatar用の画像のimgタグ用のstyle値
+        $imgGravatarStyle = trim($display);
+        if( $imgGravatarStyle) {
+            $imgGravatarStyle = "style=\"{$imgGravatarStyle}\"";
+        } else {
+            $imgGravatarStyle = "";
+        }
+
+        $avatarImageStyle = new \ArrayObject([
+            "imgUploadedAvatarStyle" => $imgUploadedAvatarStyle,
+            "imgGravatarStyle" => $imgGravatarStyle,
+        ], \ArrayObject::ARRAY_AS_PROPS);
+
+        return $avatarImageStyle;
+    }
+
+    /**
+     * アバター画像のimgタグのid属性(まるごと)を取得する。
+     *
+     */
+    private function getAvatarImageId($isEdit)
+    {
+        /*
+            id属性が必要なのは、編集モードの時だけである。
+            そうでない場合は、空文字列を指定しておく
+        */
+        $imgUploadedAvatarId = '';
+        $imgGravatarId = '';
+        if($isEdit) {
+            $imgUploadedAvatarId = "id=\"imgUploadedAvatar\"";
+            $imgGravatarId = "id=\"imgGravatar\"";
+        }
+
+        $avatarImageId = new \ArrayObject([
+            "imgUploadedAvatarId" => $imgUploadedAvatarId,
+            "imgGravatarId" => $imgGravatarId,
+        ], \ArrayObject::ARRAY_AS_PROPS);
+        
+        return $avatarImageId;
+    }
+
+    /**
+     * アバター画像のimgタグを作成する。
+     */
+    public function createAvatarImgTag($isEdit, $user, $imgSrcParam, $class, $imageSize)
+    {
+        /**
+         * アバター画像のimgタグのstyle属性(まるごと)を取得する。
+         * 
+         * 「->」演算子でメンバーアクセス箇所での赤ニョロ回避の「PHPDoc」
+         * @var object $avatarImageStyle
+         * @property string $imgUploadedAvatarStyle
+         * @property string $imgGravatarStyle
+         */
+        $avatarImageStyle = $this->getAvatarImageStyle($isEdit, $imageSize);
+    
+        /**
+         * アバター画像のimgタグのid属性(まるごと)を取得する。
+         * 
+         * 「->」演算子でメンバーアクセス箇所での赤ニョロ回避の「PHPDoc」
+         * @var object $avatarImageId
+         * @property string $imgUploadedAvatarId
+         * @property string $imgGravatarId
+         */
+        $avatarImageId = $this->getAvatarImageId($isEdit);
+    
+        /*
+            (a) アップロードしたアバター画像がある場合 (言い換えると、テーブル「users」に1対1対応で紐づく「user_images」がある場合)
+                「user_images」に基づいた画像を表示する。
+
+            (b) アップロードしたアバター画像がない場合 (言い換えると、テーブル「users」に1対1対応で紐づく「user_images」がない場合)
+                「Gravatar::src()」を用いた表示をする
+
+            とした場合
+
+            編集モードである時は、問答無用で(a)、(b)のimgタグを作っておいて、
+                いずれも、style="display:none;" を指定して、一旦、消しておいて、
+                javascript側で、いずれかをshow()する考え方とする。
+                表示／非表示にかかわらず、(a)、(b)ともに、imgタグがDOMツリーにあったほうが
+                javascript側の制御が楽である。
+                編集モードの時は、１画面に１つしか当コンポーネントを配置しない想定なので
+                1個に決め打ったid属性値を指定し、javascript側の制御しやすい形にしておく
+
+            編集モードでない時は、
+                style="display:none;" を指定する必要はなく
+                条件に応じて、(a)のimgタグ、(b)のimgタグ のいずれか、一方を
+                DOMツリーに置いておけばよい
+    
+                $imgSrcParamの値がある場合、
+                    言い換えると
+                    $imgSrcParamは、アップロード済の画像を表示するためのURLであり
+                    その値がある場合とは、「「users」に1対1対応で紐づく「user_images」がある場合
+                    なのであるが、
+                    この場合は、
+                    (a)のimgタグをDOMツリーに置く
+                    (b)のimgタグはDOMツリーに置かない
+                $imgSrcParamの値がない場合、
+                    (a)のimgタグをDOMツリーに置かない
+                    (b)のimgタグはDOMツリーに置く
+    
+                なぜなら、編集モードでない時は、
+                表示専用のため画面表示時に一回、決まればよく、その後、javascript処理による表示変更は不要であるから。
+                (a)のimgタグ、(b)のimgタグのうち、必要なものだけを一回、DOMツリーに置けばよいだけである。
+        */
+
+        // (a)のimgタグ imgUploadedAvatar をDOMツリーに置くかどうか
+        $isDomImgUploadedAvatar = ( $isEdit || $imgSrcParam );
+
+        // (b)のimgタグ imgUploadedAvatar をDOMツリーに置くかどうか
+        $isDomImgGravatar = ( $isEdit || !$imgSrcParam );
+
+        $imgUploadedAvatar = '';
+        if ($isDomImgUploadedAvatar) {
+            // (a)のimgタグ
+            $imgUploadedAvatar =
+                "<img {$avatarImageId->imgUploadedAvatarId} " .
+                    "class=\"{$class}\" " .
+                    "src=\"{$imgSrcParam}\" " .
+                    "alt=\"{$user->name}\" " .
+                    "{$avatarImageStyle->imgUploadedAvatarStyle}>"
+            ;
+        }
+
+        $imgGravatar = '';
+        if ($isDomImgGravatar) {
+            $gravatarSrc = Gravatar::src($user->email, $imageSize);
+
+            // (b)のimgタグ
+            $imgGravatar =
+                "<img {$avatarImageId->imgGravatarId} " .
+                    "class=\"{$class}\" " .
+                    "src=\"{$gravatarSrc}\" " .
+                    "alt=\"{$user->name}\" " .
+                    "{$avatarImageStyle->imgGravatarStyle}>"
+            ;
+        }
+
+        $avatarImgTag = new \ArrayObject([
+            "imgUploadedAvatar" => $imgUploadedAvatar,
+            "imgGravatar" => $imgGravatar,
+        ], \ArrayObject::ARRAY_AS_PROPS);
+        
+        return $avatarImgTag;
+    }
+
+    /* #endregion */ // 「avatar.blade.php」関連
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -11,6 +11,21 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
+    /**
+     * データがログインユーザに紐づいているかを検証する。
+     * ( NGの場合は403エラーにする。)
+     */
+    function validateOwnership($targetUserId) {
+
+        if(!\Auth::check()) {
+            abort(403);
+        }
+
+        if (\Auth::id() !== $targetUserId) {
+            abort(403);
+        }
+    }
+
     /* #region フラッシュメッセージ関連 */
 
     /*

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -128,6 +128,8 @@ class UsersController extends Controller
     {
         $user = User::findOrFail($id);
 
+        $this->validateOwnership($user->id);
+
         \DB::transaction(function () use ($user) {
             $user->delete();
         });
@@ -156,6 +158,9 @@ class UsersController extends Controller
             $user->password = Hash::make($request->input('password'));
         }
         $user->save();
-        return back();
+        $this->showFlashSuccess("更新しました。");
+        return back()->with([
+            'toggleOnOff' => $request->toggleOnOff,
+        ]);
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -57,6 +57,9 @@ class Post extends Model
      * 編集の初期表示時のアップロードUIの復元情報を返す
      */
     public function getLoadInfoForEditPostInitial() {
+
+        $helper = Helper::getInstance();
+
         // $thisに紐づく「post_images」をorder順に取得
         $postImages = $this->postOrderImages()->get();
         if ($postImages->isEmpty()) {
@@ -71,13 +74,8 @@ class Post extends Model
             $fileNames[] = $postImage->file_name;
         }
 
-        // 編集の初期表示時のアップロードUIの復元情報
-        $loadInfo = new \ArrayObject([
-            // uuid
-            "fileUuids" => json_encode($fileUuids),
-            // ログインユーザ以外のuserId
-            "fileNames" => json_encode($fileNames),
-        ], \ArrayObject::ARRAY_AS_PROPS);
+        //「編集モードの初期表示時のアップロードUIの復元情報」を作成する。
+        $loadInfo = $helper->createUploadUiLoadInfo($fileUuids, $fileNames);
 
         return $loadInfo;
     }

--- a/app/UserImage.php
+++ b/app/UserImage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserImage extends Model
+{
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2024_09_14_180739_create_user_images_table.php
+++ b/database/migrations/2024_09_14_180739_create_user_images_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUserImagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        /*
+            当「user_images」テーブルについて、
+            「users」と「user_images」の関係が1対1または、1対0
+
+            「post_images」と同様、「uuid/file_name」のパスで画像ファイルをアップロードした情報の管理だが
+            uuidと、file_nameの組み合わせにを最大1個まで保持できればよいため、order項目はない。
+
+            アップロードしたアバター画像のuuidと、file_nameの組み合わせの管理に用いる。
+
+            当テーブルを削除時は、物理削除とします。
+        */
+        Schema::create('user_images', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+
+            $table->string('uuid');
+            $table->string('file_name');
+
+            $table->timestamps();
+
+            //外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('user_images');
+    }
+}

--- a/public/js/avatar.js
+++ b/public/js/avatar.js
@@ -1,0 +1,50 @@
+/*
+    アップロード／削除のコンポーネントから
+    「画像関係のDBの再構成」した後のコールバックで実行される関数
+
+    引数は、imgタグのsrc属性にそのまま指定可能なurlの配列
+
+    その値を使ってアバター画像の表示更新をする。
+*/
+function reconstructionImageDBCallBack(filePaths)
+{
+    let imgSrcParam = '';
+    if(filePaths) {
+        if(filePaths.length > 0) {
+            imgSrcParam = filePaths[0];
+        }
+    }
+
+    $('#avatarImgSrcParam').val(imgSrcParam);
+
+    switchImage();
+}
+
+/*
+    アップロード済アバター画像表示用のimgタグと
+    Gravatarの画像表示用のimgタグとで
+    show()とhide()を入れ替える
+*/
+function switchImage()
+{
+    let imgSrcParam = $('#avatarImgSrcParam').val();
+
+    if (imgSrcParam) {
+        $('#imgUploadedAvatar').attr('src', imgSrcParam);
+        $('#imgUploadedAvatar').show();
+        $('#imgGravatar').hide();
+    } else {
+        $('#imgUploadedAvatar').attr('src', '');
+        $('#imgUploadedAvatar').hide();
+        $('#imgGravatar').show();
+    }
+}
+/*
+    初期状態のavatarImgSrcParamの値に応じて、
+    アップロード済アバター画像表示用のimgタグと
+    Gravatarの画像表示用のimgタグとで
+    show()とhide()を入れ替える
+*/
+$(document).ready(function() {
+    switchImage();
+});

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -21,8 +21,9 @@ function stopSubmit(event) {
     event.stopPropagation();
 }
 
-// クライアントのフラッシュメッセージを非表示にする。
-function hideFlashClientMessage() {
+// フラッシュメッセージを消す。
+function hideFlashMessages() {
+    $('.myserver-flash-marking').remove();
     $('#flashClientMessage').hide();
 }
 

--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -53,6 +53,28 @@ function changeCompleteFileWrapper(param) {
     */
     param.fileWrapper.find('.fileInputDiv').hide();
 
+    /*
+        「 <input type="file" 」の要素について、ただ表示を消しても
+        disabledがfalseであれば、親要素のformがsubmitされるときに
+        選択しているファイルの中身をリクエストにのせて送信してしまう。
+
+        アップロード自体は、ajax通信で完了させる実装で、
+        当「 <input type="file" 」はファイルの選択や、選択イベント発火、
+        選択したファイルの中身のjavascriptコードでの取得(ajaxの送信データとして指定のため)
+        に使っているだけである。
+
+        submit通信時にファイルの中身をリクエストにのせる用途では、当実装では使いたくない。
+
+        それは、submit時の無駄な通信であり、パフォーマンス低下を招くから避けたい。
+        また、それだけではなく、
+        通信サイズの最大値などの環境設定の調査や、動作確認時での
+        起きた事象に対する原因調査や、特定の「やりやすさ／やりにくさ」にも
+        影響がでると予想される。
+        
+        そのため、disabledをtrueにしておく。
+    */
+    param.fileWrapper.find('.file-input').prop('disabled', true);
+
     let fileNameLabel = param.fileWrapper.find('.file-name-label');
     fileNameLabel.text(param.fileName);
     fileNameLabel.show();
@@ -346,8 +368,8 @@ $(document).ready(function() {
     // ファイル選択時
     $(document).on('change', '.file-input', function() {
 
-        // クライアントのフラッシュメッセージを非表示にする。
-        hideFlashClientMessage();
+        // フラッシュメッセージを消す。
+        hideFlashMessages();
 
         const fileInput = $(this)[0];
         const fileWrapper = $(this).closest('.file-upload-wrapper');
@@ -435,8 +457,8 @@ $(document).ready(function() {
         // sumitを抑制(form内に配置したbuttonタグだとsubmit反応してしまうため抑制)
         stopSubmit(event);
 
-        // クライアントのフラッシュメッセージを非表示にする。
-        hideFlashClientMessage();
+        // フラッシュメッセージを消す。
+        hideFlashMessages();
 
         const fileWrapper = $(this).closest('.file-upload-wrapper');
         let uuid = fileWrapper.find('.file-uuid').val();

--- a/public/js/views/users/edit.js
+++ b/public/js/views/users/edit.js
@@ -1,0 +1,42 @@
+/**
+ * トグル結果に関する調整処理
+ */
+function adjustToggleUi(divAvatar, avatarToggleLink)
+{
+    // リンクのテキストを表示状態に応じて変更
+    if (divAvatar.is(':visible')) {
+        avatarToggleLink.text('アバター画像の表示／追加／削除をしない');
+        $('#toggleOnOff').val('ON');
+    } else {
+        avatarToggleLink.text('アバター画像の表示／追加／削除をする');
+        $('#toggleOnOff').val('OFF');
+    }
+}
+/**
+ * resources/views/users/edit.blade.php
+ * 「ユーザ編集」画面専用のjavascript定義
+ */
+$('#avatarToggleLink').on('click', function(event) {
+    // リンクのデフォルトの動作を無効化
+    event.preventDefault();
+
+    var divAvatar = $('#divAvatar');
+    var avatarToggleLink = $('#avatarToggleLink');
+
+    // divAvatarの表示/非表示をトグル
+    divAvatar.toggle();
+
+    // トグル結果に関する調整処理
+    adjustToggleUi(divAvatar, avatarToggleLink);
+});
+$(document).ready(function() {
+    var divAvatar = $('#divAvatar');
+    var avatarToggleLink = $('#avatarToggleLink');
+
+    if($('#toggleOnOff').val() === 'ON') {
+        divAvatar.toggle();
+    }
+
+    // トグル結果に関する調整処理
+    adjustToggleUi(divAvatar, avatarToggleLink);
+});

--- a/resources/views/commons/avatar.blade.php
+++ b/resources/views/commons/avatar.blade.php
@@ -1,0 +1,107 @@
+{{-- 
+    当初avatar画像の表示部分は、
+    例として、
+    img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像"
+    のようなimgタグとなっていた。
+    (
+        コメント表記の都合上、上記の例では「 両端の< >の記号 」は消してる。
+        「 両端の< >の記号 」をつけるとVSコード上、実コードと認識されるので、それを回避してコメント記述している。
+        以後、同じ。要領で両端の< >の記号は消してます。
+    )
+
+    当「avatar.blade.php」を実装直前の周辺での
+    「Gravatar::src()」を用いたアバター画像表示部分は、
+    (1) ユーザ詳細画面
+        resources/views/posts/show.blade.php にあった
+        img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像"
+
+    (2) ユーザ編集画面
+        resources/views/users/edit.blade.php にあった
+        img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt=""
+
+    (3) トップ画面または、ユーザ詳細画面での「ユーザと投稿の組み合わせ表示部品」
+        resources/views/users/show.blade.php にあった
+        img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt=""
+
+    上記の(1)、(2)、(3)の状態だった。
+    上記の(1)、(2)、(3)を見比べた時、
+        $editFlg : 編集モードかどうかのフラグ ( これは、後述で説明している )
+        $imageSize : 上記の55や、400に相当する値
+        $user : Userモデル。Gravatar::src()の引数のemailの値や、後述の「user_images」を求めるのにも必要。
+        $class : class属性値
+    の引数が当コンポーネントに指定されればよいことが判断できた。
+
+    この時点での仕様と、avatar画像のアップロード対応後の仕様を総合すると
+    下記のように考えるのが適切であろう。
+
+    (a) アップロードしたアバター画像がある場合 (言い換えると、テーブル「users」に1対1対応で紐づく「user_images」がある場合)
+        「user_images」に基づいた画像を表示する。
+
+    (b) アップロードしたアバター画像がない場合 (言い換えると、テーブル「users」に1対1対応で紐づく「user_images」がない場合)
+        「Gravatar::src()」を用いた表示をする
+
+    上記の(a)ではユーザがアップロードした画像の実寸が様々であることから
+    例として
+    img class="rounded-circle img-fluid" style="width: 400px; height: 400px;" src="http://localhost:8080/storage/images/avatar/26c236d6-285d-41e4-97c9-8f174f3a833a/image1.png" alt="ユーザ名１"
+    のように、「  style="width: 400px; height: 400px;"  」を補った形で ( $imageSizeが、400の例です。 )
+    サイズ調整した形でimgタグを作る必要がある。
+    width、heightを同じ値にして拡大／縮小し正方形にしておけば、
+    $classにrounded-circleが含まれた値があれば、円形になるだろう。
+
+    上記の(b)では、「Gravatar::src()」は、55や、400つまり、$imageSizeを指定していれば
+    その大きさの画像のURLがGravatarが返してくれる
+    実行時は、例として
+    img class="rounded-circle img-fluid" src="https://secure.gravatar.com/avatar/33ead0fffce3518ee97d59348a3708af?s=400&amp;r=g&amp;d=identicon" alt="ユーザ名１"
+    であり、特に、width, heightの指定は、imgタグには不要である。
+
+    (1)、(3)については、表示専用である。
+    (2)については、avatar画像の「アップロード／削除」を行うコンポーネント自体が
+       'editFlg' => 'ON'の編集モードであるため、「reconstructionImageDBCallBack」を通じた
+       javascript側で表示更新に対応すべく、
+       もし、「reconstructionImageDBCallBack」のコールバックの引数が空であった時、
+       「画像削除」の操作の結果、今、アップロード済のアバター画像がないということですから
+       (b)方式でのimgとなる表示更新をjavascriptでする必要がある。
+       ( ajax通信の後処理で画面全体リロードをしないからである )
+    
+    (2)は、当「avatar.blade.php」でも、'editFlg' => 'ON'の編集モードでの引数指定を
+    受けてその制御をする形とすればよいだろう。
+    ただし、(2)の場合は、ユーザー編集画面を見れば１画面に１つしか
+    当コンポーネントを配置しないであろう。
+    ですから、carousel.blade.php、carousel.jsに見られるような
+    「id属性に親レコードのid値を前ゼロ補充した数字文字列を付与して複数インクルードにそなえるような対応」は不要だと言える
+    (1)、(3)はたしかに、1画面に複数インクルードされるが、表示専用のため画面表示時に一回、
+    決まればよく、その後、javascript処理による表示変更は不要であるため、これまた、
+    「id属性に親レコードのid値を前ゼロ補充した数字文字列を付与して複数インクルードにそなえるような対応」は不要だと言える
+
+    これまで上記で記載してきた考え方の実装は、ある程度、複雑なので、それを各個別画面で同じ実装を
+    一個一個していくようなアプリの実装は避けたほうがよい。 (保守性、拡張性の問題)
+
+    必要性が生じたタイミングの初期段階でコンポーネント化を検討すべきである。
+    
+    当「avatar.blade.php」にてコンポーネント化をして、将来的にavatar画像の表示すべき画面が増えた時
+    また、avatar画像の表示仕様変更時の実装対応がしやすい構造としたい。
+--}}
+@php
+    require_once app_path('Helpers/ViewHelper.php');
+    $viewHelper = \App\Helpers\ViewHelper::getInstance();
+
+    $isEdit = ($editFlg === 'ON');
+
+    // アップロード済のアバター画像の表示時にimgタグのsrcに指定値を取得する。
+    $imgSrcParam = $user->getUploadedAvatarImgSrcParam();
+
+    // アバター画像のimgタグを作成する。
+    $avatarImgTag = $viewHelper->createAvatarImgTag($isEdit, $user, $imgSrcParam, $class, $imageSize);
+@endphp
+{{-- アバター画像に関するimgタグを出力 --}}
+{!! $avatarImgTag->imgUploadedAvatar !!}
+{!! $avatarImgTag->imgGravatar !!}
+@if ($isEdit)
+    {{-- 編集モードの場合 --}}
+
+    {{-- アップロード済のアバター画像の表示時にimgタグのsrcに指定値 --}}
+    <input id="avatarImgSrcParam" type="hidden" value="{{ $imgSrcParam }}" />
+
+    {{-- avatar.jsの読み込みをする。 --}}
+    <script src="{{ asset('js/avatar.js') }}"></script>
+@endif

--- a/resources/views/commons/flash_messages.blade.php
+++ b/resources/views/commons/flash_messages.blade.php
@@ -26,7 +26,7 @@
     {{-- にて定義した表示メソッドで指定した内容を表示する領域 --}}
     {{-- ********************************************** --}}
 
-    <div class="alert alert-{{ $info->alertClass }} alert-dismissible fade show" role="alert" style="margin-bottom: 2px;">
+    <div class="alert alert-{{ $info->alertClass }} alert-dismissible fade show myserver-flash-marking" role="alert" style="margin-bottom: 2px;">
         {{--  「Bootstrap 4」の右端の「×」ボタン --}}
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
@@ -35,3 +35,24 @@
         {!! nl2br(e($info->message)) !!}
     </div>
 @endforeach
+@php
+    /*
+        javascript関数として定義したhideFlashMessages()のテストを実施時に、
+        テストのためトップ画面の初期表示時、いくつかメッセージ出力させて、動作確認中のことだが、
+
+        トップ画面表示中に、ヘッダー部のユーザ名をクリックし、ユーザ詳細画面へ遷移したところ
+        ユーザ詳細画面の初期表示時に、同じメッセージが出力される不具合を発見した。
+        ( 他の操作では、そんなことはなく、なぜ、それだけ、そうなるのかまでは不明 )
+
+        調べていくと
+        withと異なり、session()->flash(キー、バリュー)で作った値は、次リクエストに残ることがあるとのこと
+
+        そこで、表示が終わったこのタイミングで明示的な削除処理を実行することにした。
+
+        上記、不具合はなくなった。
+
+        ほとんどのケースはwithを用いるが、session()->flash(キー、バリュー)を使う必要がある場合は
+        今回のケースのように消す処理も視野に入れたほうがよいだろう
+    */
+    session()->forget('flashMessageInfos');
+@endphp

--- a/resources/views/commons/upload.blade.php
+++ b/resources/views/commons/upload.blade.php
@@ -1,4 +1,9 @@
-<div class="container">
+@php
+    if (!isset($divContainerStyle)) {
+        $divContainerStyle = '';
+    }
+@endphp
+<div class="container" {!! $divContainerStyle !!}>
     <div id="file-upload-container" style="margin: 20px;"></div>
 
     {{-- アップロード済の画像をクライアントサイドでサムネイル表示のためhrefに指定するURLのベース部分 --}}
@@ -13,6 +18,8 @@
         @php
             if (isset($post)) {
                 $baseId = $post->id;
+            } else if (isset($user)) {
+                $baseId = $user->id;
             } else {
                 throw new \Exception("編集時の基礎情報がありません");
             }
@@ -24,7 +31,7 @@
     <input id="file-upload-imageType" type="hidden" value="{{ $imageType }}" />
 
     {{-- バリデーションエラー時に動的作成UI部の復元すべきかの判定のため前回値の有無の判定用 --}}
-    {{-- サーバーに一回送って、それが返ってくるかで前回対の有無を判定するためname属性を指定している。 --}}
+    {{-- サーバーに一回送って、それが返ってくるかで前回値の有無を判定するためname属性を指定している。 --}}
     <input name="fileUploadSubmitFlg" type="hidden" value="ON" />
 
     {{-- アップロードUIの復元モードであるかどうかのフラグ --}}
@@ -44,6 +51,8 @@
         @php
             if (isset($post)) {
                 $loadInfo = $post->getLoadInfoForEditPostInitial();
+            } else if (isset($user)) {
+                $loadInfo = $user->getLoadInfoForEditUserInitial();
             } else {
                 throw new \Exception("編集時の初期表示のロードに必要な情報の引数指定がありません");
             }

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -15,7 +15,12 @@
         @endif
 
         <div class="text-left d-inline-block w-75 mb-2">
-            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像">
+            @include('commons.avatar', [
+                'editFlg' => 'OFF',
+                'imageSize' => '55',
+                'user' => $user,
+                'class' => 'mr-2 rounded-circle',
+            ])
             <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $user->id) }}" title="{{ $user->name }}">{{ $user->truncateName() }}</a></p>
 
             @if ($followsParam->isFollowsBaseOk)

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,8 +1,72 @@
 @extends('layouts.app')
 @section('content')
+    @php
+        /*
+            更新成功時もトグル状態の復元したい
+            (1) 更新成功時で、バリデーションエラーではない時
+                sessionのほうは値あり ( 更新成功時にwithのflashで指定している )
+                oldのほうは値がなし
+            (2) バリデーションエラーの時
+                sessionのほうは値なし
+                oldのほうは値があり
+            (3) 初期表示時は、どちらも値なしのためold()の第2引数のデフォルト値となる。
+        */
+        if (session('toggleOnOff')) {
+            $toggleOnOff = session('toggleOnOff');
+        } else {
+            $toggleOnOff = old('toggleOnOff', 'OFF');
+        }
+    @endphp
+    <a href="#" id="avatarToggleLink">アバター画像の表示／追加／削除をする</a>
+
+    {{-- スペーサーとしてのdivタグ--}}
+    <div style="margin: 15px;"></div>
+
+    <script src="{{ asset('js/views/users/edit.js') }}"></script>
+
+    <div id="divAvatar" class="row" style="margin-left: 50px; display: none;">
+
+        <aside class="col-sm-4 mb-5">
+            <div class="card bg-info">
+                <div class="card-header">
+                    <h3 class="card-title text-light" title="{{ $user->name }}">
+                        {{ $user->truncateName(9) }}
+                    </h3>
+                </div>
+                <div class="card-body">
+                    @include('commons.avatar', [
+                        'editFlg' => 'ON',
+                        'imageSize' => '280',
+                        'user' => $user,
+                        'class' => 'rounded-circle img-fluid',
+                    ])
+                </div>
+            </div>
+        </aside>
+
+        <div class="col-sm-8">
+            <p style="margin-left: 20px; margin-top: 20px; margin-bottom: 20px;">
+                <div style="color:red;">
+                    アバター画像の画像追加／削除は「更新する」を押さなくても即時適用のため、
+                </div>
+                <div style="color:red;">
+                    ご注意のうえ操作してください。
+                </div>
+            </p>
+            @include('commons.upload', [
+                'multiFlg' => 'OFF',
+                'editFlg' => 'ON',
+                'imageType' => 'avatar',
+                'user' => $user,
+                'divContainerStyle' => "style='margin-top: 80px;'"
+            ])
+        </div>
+    </div>
+
     <h2 class="mt-5">ユーザ情報を編集する</h2>
+
     @include('commons.error_messages')
-    <form method="POST" action="{{ route('user.update', $user->id) }}">
+    <form method="POST" action="{{ route('user.update', $user->id) }}" onsubmit="saveUploadUIInfo(event)">
         @csrf
         @method('PUT')
         <div class="form-group">
@@ -26,6 +90,8 @@
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
 
+        {{-- トグル状態の復元のため、このform内のリクエストに前回値を乗せるためのhidden項目 --}}
+        <input id="toggleOnOff" name="toggleOnOff" type="hidden" value="{{ $toggleOnOff }}">
     </form>
 
     <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -23,16 +23,23 @@
                         </div>
                     @endif
                     <h3 class="card-title text-light" title="{{ $user->name }}">
-                        {{ $user->truncateName(5) }}
-
                         {{-- 「右寄せ」のために同じH3タグ内に置く必要あり--}}
                         @if ($followsParam->isFollowsBaseOk)
+                            {{ $user->truncateName(5) }}
+
                             @include('follows.button', ['followsParam' => $followsParam])
+                        @else
+                            {{ $user->truncateName(9) }}
                         @endif
                     </h3>
                 </div>
                 <div class="card-body">
-                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="">
+                    @include('commons.avatar', [
+                        'editFlg' => 'OFF',
+                        'imageSize' => '310',
+                        'user' => $user,
+                        'class' => 'rounded-circle img-fluid',
+                    ])
                     @if (Auth::id() === $user->id)
                         <div class="mt-3">
                             <a href="{{ route('user.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>


### PR DESCRIPTION
## issue
- Closes Draft アバター画像のアップロードとその表示対応

ユーザー編集画面にアバター画像のアップロード／削除
即時にアバター大画像に反映

ユーザ詳細でのアップロードしたアバター画像表示
および、
postsのshow.blade.phpでの利用箇所
・トップの投稿一覧
・ユーザ詳細でのタイムライン、フォロー中および、フォロワーのユーザごとの最新投稿
でのアバター画像表示

いずれも、
アップロードした画像が無い場合は、
Gravator表示

## 動作手順
まえのプルリクの
複数画像のアップロードと表示のコンポーネントの実装、および、新規投稿時に適用(大川)
の時の
動作手順での環境ができていれば、
動くはず。

## 考慮してほしいこと（その１）

ユーザー編集画面のアバター大画像
ユーザ詳細でのアップロードしたアバター大画像
および、
postsのshow.blade.phpでの利用箇所
・トップの投稿一覧
・ユーザ詳細でのタイムライン、フォロー中および、フォロワーのユーザごとの最新投稿
でのアバターの小画像

いずれも、アップロードしたアバター画像があれば、それ
なければ、Gravatorの画像。

この制御を複数個所にしたくないため

avatar.blade.php ( imgタグの作成の大半はViewHelper.php側にもっていってる )
avatar.blade.js
をインクルードして行っている

なぜ、そうしたかの考え方については、
avatar.blade.phpの先頭位置のコメントで詳細に説明している
その詳細説明コメントで、
利用しているインクルードの実装は下記のとおり、
**********************************************************************
ユーザー編集画面 : resources/views/users/edit.blade.php
で、'editFlg' => 'ON',
での利用時
```
@include('commons.avatar', [
    'editFlg' => 'ON',
    'imageSize' => '280',
    'user' => $user,
    'class' => 'rounded-circle img-fluid',
])
```
'imageSize' => '280',
元は、400だったが、
アップロードした画像の実寸は、縦横比が異なるなどして
img-fluidがあると、外側枠にフィットさせようとして
楕円になってしまった
小さめの280にしたら、円形になった。
円形を維持してできるだけ大きくを微調整したら280ぐらいだった

**********************************************************************

ユーザ詳細画面：resources/views/users/show.blade.php
で、'editFlg' => 'OFF',
での利用時
```
@include('commons.avatar', [
    'editFlg' => 'OFF',
    'imageSize' => '310',
    'user' => $user,
    'class' => 'rounded-circle img-fluid',
])
```
元は、400だったが、
同様の理由で310、ユーザ編集より枠の大きさが少し大き目で
円形を維持してできるだけ大きくを微調整したら310ぐらいだった

**********************************************************************

各種「１つのユーザ、１つの投稿に、複数画像のサムネイル、カルーセル、フォロー状態の表示、操作」
に関するコンポーネント
resources/views/posts/show.blade.php
で、'editFlg' => 'OFF',
での利用時
```
@include('commons.avatar', [
    'editFlg' => 'OFF',
    'imageSize' => '55',
    'user' => $user,
    'class' => 'mr-2 rounded-circle',
])
```
これは、元から、img-fluidもなく
55のままで円形となった
**********************************************************************

## 考慮してほしいこと（その２）
public/js/views/users/edit.js
について、
今まで、実装したjsは、
全体のjsか、あるテーマのコンポーネント用のjsしかなかったが
今回は、画面に1対1対応のjsを作った
resources/views/users/edit.blade.php
専用のjsなので
public/js/views/users/edit.js
のパスで作成した
理由は、ファイル名だけ「edit.blade.php」だけで
別の画面が、ありうるので
画面のパス構成にあわせて、
public/js/views/users/edit.js
で、画面に1対1対応のjsで作った

## 考慮してほしいこと（その３）
app/Http/Controllers/Controller.php
に
```
    /**
     * データがログインユーザに紐づいているかを検証する。
     * ( NGの場合は403エラーにする。)
     */
    function validateOwnership($targetUserId) {

        if(!\Auth::check()) {
            abort(403);
        }

        if (\Auth::id() !== $targetUserId) {
            abort(403);
        }
    }
```
を作った
403の考慮漏れが、ユーザ退会処理であったため
上記のメソッドを作った

どっかのタイミングで余裕があるとき、
403の他のものも、これに置き換えていったり
flashメッセージが漏れてるものもも、余裕があるときに
対応しようとは思う

## 考慮してほしいこと（その４）
ユーザ退会時、Userのdeletingに新設テーブルの
user_imagesの削除処理とstorageの削除を追加している
post_imagesのときも、そうしてた。（　親、子、孫 )

## 考慮してほしいこと（その５）
画像追加、画像削除はajax通信で画面リロードしないので、
flashメッセージを消されないで残ってしまっていた
これを消すようにした

## 考慮してほしいこと（その６）
resources/views/commons/flash_messages.blade.php
の最後のコメントに書いてるとおり
withと異なり、session()->flash(キー、バリュー)で作った値は、次リクエストに残ることがあるとのこと
なので、
session()->forget('flashMessageInfos');
対応した。

## 考慮してほしいこと（その７）
public/js/upload.js
にて、
```
    /*
        「 <input type="file" 」の要素について、ただ表示を消しても
        disabledがfalseであれば、親要素のformがsubmitされるときに
        選択しているファイルの中身をリクエストにのせて送信してしまう。

        アップロード自体は、ajax通信で完了させる実装で、
        当「 <input type="file" 」はファイルの選択や、選択イベント発火、
        選択したファイルの中身のjavascriptコードでの取得(ajaxの送信データとして指定のため)
        に使っているだけである。

        submit通信時にファイルの中身をリクエストにのせる用途では、当実装では使いたくない。

        それは、submit時の無駄な通信であり、パフォーマンス低下を招くから避けたい。
        また、それだけではなく、
        通信サイズの最大値などの環境設定の調査や、動作確認時での
        起きた事象に対する原因調査や、特定の「やりやすさ／やりにくさ」にも
        影響がでると予想される。
        
        そのため、disabledをtrueにしておく。
    */
    param.fileWrapper.find('.file-input').prop('disabled', true);
```
を追加してる、理由は、コメント記載のとおり


## 今後の課題 (その１）
前、プルリクに引き続き
アップロードのバリデーション時の最大サイズの調査などは残ってるが
最後の「考慮してほしいこと（その７）」の対応にて
調査しやすくなってるといいなぁっておもってる
これは、引き続き、保留

## 今後の課題 (その２）
今、アップロードのコンポーネントは、編集モードのとき
アップロード／削除　ともに、即時にstorageに保存、削除し
DBのDELETE/INSERTによる　更新処理までしてる
これは、編集系の画面で、画像削除し、更新系のボタンを「おさずに」
別画面遷移してしまったときに、
その後の画像表示ができない問題を回避するためだったが
アップロード／削除　について、
削除については、storageからの削除については、やらないで放置しておけば
編集系の画面で、更新系のボタンを押したときの
DB更新の方式でも、問題が無いのではないかと、MTGでの議題があった
これは、アップロードコンポーネント側の実装対応となる
（　といっても、実装を追加でなく、削っていくような対応だと思うですが
代わりに、利用側の更新系のボタン側へ、削った実装が移動するイメージに思える）

いずれにせよ。
この対応は後回しにして
一旦、当プルリクをだして

おおつきさんが、やった、投稿編集に、アップロード機能を組み込むのを先に
やろうと思うです

その後、
アバターと、投稿編集のところにある、
アップロード機能での、アップロード、削除については、
即時反映でなく、編集画面の更新系のボタンでのDB反映に
アバターと、投稿編集の両画面を右へ倣えで対応しようかと思ってます

## 今後の課題 (その３）・・・（質問）
「今後の課題 (その２）」で削除時は放置の方向性に倒していった、
最終計で、
「post_images」や、「user_image」に存在しない
uuidと、file_nameの組み合わせについて、
storageから削除する、お掃除を実装するにあたって、
今まさに、新規投稿のため、画像追加し、
「post_images」にない、storageであるが、
もうちょっとしたら、postsに紐づく形で、
「post_images」にDB登録されるよ
というような、画像が、削除されても困るので
sotrage上の、ファイルや、ディレクトリの作成日時も見て、
直近を避けることも条件に
お掃除することが予想されますが
そんなお掃除は、何で走らせる？　Laravelに定期実行や、
常駐サービスみたいなものがあるのでしょか？・・・（質問）
https://www.rail-c.com/laravel%E3%81%AE%E3%82%BF%E3%82%B9%E3%82%AF%E3%82%B9%E3%82%B1%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%A7%E5%AE%9A%E6%9C%9F%E5%87%A6%E7%90%86%E3%82%92%E8%87%AA%E5%8B%95%E5%AE%9F%E8%A1%8C/

に書いてるようなスケジューラを定義するなど？