### PR TITLE
全体の細かな修正タスク（9/17時点　西山しょうこ）

### DIFF
--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,7 +8,7 @@
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
               @if (Auth::check())
-                  <li class="nav-item"><a href="" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
+                  <li class="nav-item"><a href="{{ route('user.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                   <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
               @else
                   <li class="nav-item"><a href="{{ route('login') }}" class="nav-link text-light">ログイン</a></li>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,13 +1,6 @@
- {{-- @extends('layouts.app') --}}
- {{-- @section --}}
+ @extends('layouts.app')
+ @section('content')
     <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
-    @if (count($errors) > 0)
-    <ul class="alert alert-danger" role="alert">
-        @foreach ($errors->all() as $error)
-            <li class="ml-4">{{ $error }}</li>
-        @endforeach
-    </ul>
-    @endif
         <form method="POST" action="{{ route('user.update', $user->id) }}">
             @csrf
             @method('PUT')    
@@ -55,4 +48,4 @@
                 </div>
             </div>    
         </div>
-{{-- @endsection --}}
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,5 +1,5 @@
-{{-- @extends('layouts.app') --}}
-{{-- @section('content') --}}
+@extends('layouts.app')
+@section('content')
     <div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">
@@ -8,9 +8,11 @@
                 </div>
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 350) }}" alt="ユーザのアバター画像">
+                        @if (Auth::check())
                         <div class="mt-3">
                             <a href="{{ route('user.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                         </div>
+                        @endif
                 </div>
             </div>
         </aside>
@@ -23,4 +25,4 @@
             @include('posts.posts', ['posts' => $posts])
         </div>
     </div>
-{{-- @endsection --}}
+@endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,7 +2,7 @@
 @section('content')
 <div class="center jumbotron bg-info">
     <div class="text-center text-white mt-2 pt-1">
-        <h1><i class="pr-3"></i>Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
 </div>
 <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
@@ -12,7 +12,7 @@
         <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
             @csrf
             <div class="form-group">
-                <textarea class="form-control" name="content" rows=""></textarea>
+                <textarea class="form-control" name="content" rows="4"></textarea>
                 <div class="text-left mt-3">
                     <button type="submit" class="btn btn-primary">投稿する</button>
                 </div>


### PR DESCRIPTION
## issue
- 現時点で気が付いた箇所を、いくつか調整しました。

## 概要
- トップページタイトル横のアイコン追加
- 新規投稿作成枠の縦幅（row）を調整
- ユーザ詳細画面で、そのユーザのログイン時のみ、アバターの下に「ユーザ情報の編集」が表示されるように変更
- ログイン時に、ヘッダー内のユーザ名をクリックするとユーザ詳細画面に飛ぶようにする
- 各bladeファイルの @extends, @section, @endsection のコメントアウトをはずす

## 動作確認手順
- それぞれ、お手本のページとローカルのページを見比べて確認。