### PR TITLE
投稿編集画面へのアップロード適用(大川)

### DIFF
--- a/app/Helpers/ViewHelper.php
+++ b/app/Helpers/ViewHelper.php
@@ -304,4 +304,13 @@ class ViewHelper extends Helper
     }
 
     /* #endregion */ // 「avatar.blade.php」関連
+
+    /**
+     * previousUrlのパラメータ指定値を取得する。
+     */
+    public function getPreviousUrlParameter()
+    {
+        $ret = [ 'previousUrl' => urlencode(\Request::fullUrl()) ];
+        return $ret;
+    }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -53,7 +53,8 @@ class Controller extends BaseController
             その場合に開発作業上、不便にならないようには対処しておきたい。
         */
         $previousUrl = url("/");
-        return url("/");
+
+        return $previousUrl;
     }
 
     /* #region フラッシュメッセージ関連 */

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -26,6 +26,36 @@ class Controller extends BaseController
         }
     }
 
+    /**
+     * クエリパラメータに乗ってる遷移元のURLを取得する。
+     */
+    function getPreviousUrlByQueryParameter() {
+        $previousUrl = request()->query('previousUrl');
+        if ($previousUrl) {
+            $previousUrl = urldecode($previousUrl);
+            return $previousUrl;
+        }
+
+        /*
+            例として
+            http://localhost:8080/posts/65/edit
+            のようなURLで
+            アドレスバーを手編集でエンターキーで表示させたうえで
+            動作確認したいことは多々ありますので、その場合は、
+            「request()->query('previousUrl')」の値が無かったりします
+
+            一応、その状況でも動作はできるようにしときたいので
+            url("/")でトップ画面のurl固定になるが対応しておく
+
+            別に遷移元がどうであるかなど気にせず、それ以外の実装を
+            アドレスバーのURLを手編集で画面表示のうえ、
+            デバッグをしたいケースもあるでしょうから
+            その場合に開発作業上、不便にならないようには対処しておきたい。
+        */
+        $previousUrl = url("/");
+        return url("/");
+    }
+
     /* #region フラッシュメッセージ関連 */
 
     /*

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -2,12 +2,23 @@
 @section('content')
     <h2 class="mt-5">投稿を編集する</h2>
         @include('commons.error_messages')
-        <form method="POST" action="{{ route('post.update', $post->id) }}">
+        <form method="POST" action="{{ route('post.update', $post->id) }}" onsubmit="saveUploadUIInfo(event)">
             @csrf
             @method('PUT')
             <div class="form-group">
                 <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
             </div>
-            <button type="submit" class="btn btn-primary">更新する</button>
+            @include('commons.upload', [
+                'multiFlg' => 'ON',
+                'editFlg' => 'ON',
+                'imageType' => 'post',
+                'post' => $post,
+            ])
+            <div class="d-flex justify-content-between">
+                <button type="submit" class="btn btn-primary">更新する</button>
+                <a href="{{ $previousUrl }}" class="btn btn-info">戻る</a>
+            </div>
+            {{-- 非GETの処理で取得可能にする対応 --}}
+            <input type="hidden" name="previousUrl" value="{{ $previousUrl }}">
         </form>
 @endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,4 +1,7 @@
 @php
+    require_once app_path('Helpers/ViewHelper.php');
+    $viewHelper = \App\Helpers\ViewHelper::getInstance();
+
     if (!isset($followsParam)) {
         // 「$followsParam」が未定義の場合(呼び元で指定がない場合)は、デフォルト値を指定
         $followsParam = \App\User::createDefaultFollowsParam();
@@ -50,7 +53,10 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="{{ route('post.edit', $post->id) }}" class="btn btn-primary">編集する</a>
+                        @php
+                            $previousUrlParameter = $viewHelper->getPreviousUrlParameter();
+                        @endphp
+                        <a href="{{ route('post.edit', ['id' => $post->id] + $previousUrlParameter) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>


### PR DESCRIPTION
## issue
- Closes Draft 投稿編集画面へのアップロード適用

投稿編集画面でアップロードの部品を組み込んだ

投稿編集画面に戻るボタンを追加し遷移先に戻れるようにした
更新ボタンで更新成功時に戻れるようにした

間にバリデーションエラーが何回か、あっても、戻るボタンで戻れるし、更新成功時、遷移元に戻れます
デバッグの中心がそこだった。
paginateのページ数も含めて、遷移元に戻れます。
今、編集した投稿がそこに見えてる確率が高いです

トップの投稿一覧など他のユーザが投稿してくるなどして、今編集した投稿が別ページにずれることはあるので、
必ず、そうとは言えませんが、「今、編集した投稿がそこに見えてる確率が高い」です。

## 動作手順
まえのプルリクの
複数画像のアップロードと表示のコンポーネントの実装、および、新規投稿時に適用(大川)
の時の
動作手順での環境ができていれば、
動くはず。

## 考慮してほしいこと（その１）
アップロードの部品の組み込みは、
onsubmit="saveUploadUIInfo(event)"
と
```
            @include('commons.upload', [
                'multiFlg' => 'ON',
                'editFlg' => 'ON',
                'imageType' => 'post',
                'post' => $post,
            ])
```
の追加だけで完了しました。

## 考慮してほしいこと（その２）
GET時はリクエストパラメータに乗せてます
指定値を作るのは、ViewHelper.phpでしました。
取得側は、Controller.php
非GETの取得は、hiddenタグと、継承元のFormRequestの機能で取得してます。

## 今後
スケジューラなどで削除できるか、お掃除のほうから先にやるかもしれません。
というのは、
今、親や、おじいちゃん　を消した時に
deletingを通じた時に、
post_images、user_imagesでDB削除時にstorageも削除している
お掃除と、その削除が同時に動いた時の干渉が気になるです
干渉したとき、なぜ、エラーになったのか、再現性がなく
めんどいので避けたい
常に、該当ファイルを消すのが、１度に１プロセスとなれば干渉しない
そのため、storageを消すプロセスが、お掃除　のみ
となれば、deletingの時に、sotrageを削除する処理を消せる
しかし、その処理を消すのであれば
先に、
スケジューラなどで動いた お掃除 での削除処理が問題ない事が裏どりされてなければ
せっかく実装したものを消せない
したがって、先に
スケジューラなどで動いた お掃除
をしたい
それがうまくいったら、deletingでのsotrage削除が消せる
お掃除が動く前提で、ものが考えられる状況のほうが

削除を放置して、更新ボタンでのDB反映の構造に
コンポーネントの実装を変える作業もしやすいと考えたから。