### PR TITLE
#125 ユーザ退会（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -45,4 +45,11 @@ class UsersController extends Controller
         $user->save();
         return redirect()->route('user.show', $id);
     }
+
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        $user->delete();
+        return redirect()->route('user.index');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,13 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::deleted(function ($user) {
+            $user->posts()->delete();
+        });
+    }
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -40,7 +40,9 @@
                         <label>本当に退会しますか？</label>
                     </div>
                     <div class="modal-footer d-flex justify-content-between">
-                        <form action="" method="POST">
+                        <form action="{{ route('user.delete', $user->id) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
                             <button type="submit" class="btn btn-danger">退会する</button>
                         </form>
                         <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ユーザ
-Route::get('/', 'UsersController@index');
+Route::get('/', 'UsersController@index')->name('user.index');
 Route::prefix('users')->group(function() {
     Route::get('{id}', 'UsersController@show')->name('user.show');
 });
@@ -32,9 +32,10 @@ Route::group(['middleware' => 'auth'], function() {
     Route::prefix('posts')->group(function() {
         Route::post('', 'PostsController@store')->name('post.store');
     });
-    // ユーザ編集・更新
+    // ユーザ編集・更新・削除
     Route::prefix('users/{id}')->group(function() {
         Route::get('edit', 'UsersController@edit')->name('user.edit');
         Route::put('', 'UsersController@update')->name('user.update');
+        Route::delete('delete', 'UsersController@destroy')->name('user.delete');
     });
 });


### PR DESCRIPTION
## issue
- Closes #125 

## 概要
- ユーザ退会

## 動作確認手順
- 実際にローカルでユーザを退会させ、退会後にトップページまで遷移するかどうかを確認。
　ユーザ情報編集画面→「退会する」ボタン→モーダルウィンドウの「退会する」ボタン→トップページへ遷移（ユーザと投稿は削除されている）

## 考慮してほしいこと
- 今回は特にありません。