### PR TITLE
不要ファイルのクリーンナップコマンドおよび、ロックファイル作成コマンドなど(大川)

### DIFF
--- a/app/Console/Commands/CleanupUnusedFiles.php
+++ b/app/Console/Commands/CleanupUnusedFiles.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Helpers\Helper;
+
+use Carbon\Carbon;
+use App\UnusedFileChecker;
+use App\UserImage;
+use App\PostImage;
+
+class CleanupUnusedFiles extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'cleanup:unused-files';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'データベース内で参照されていないファイルをストレージから削除する';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    private function outputInfo($msg)
+    {
+        // コンソール
+        $this->info($msg . "\n");
+        // ログ
+        \Log::Info($msg . "\n");
+    }
+
+    private function outputError($msg)
+    {
+        // コンソール
+        $this->error($msg . "\n");
+        // ログ
+        \Log::error($msg . "\n");
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        try {
+            $helper = Helper::getInstance();
+
+            $exclusionDays = config('app.exclusionDays');
+            $exclusionHours = config('app.exclusionHours');
+            $exclusionMinutes = config('app.exclusionMinutes');
+            $exclusionSeconds = config('app.exclusionSeconds');
+            $cleanupUnusedFilesTakeCount = config('app.cleanupUnusedFilesTakeCount');
+
+            $types = [
+                'avatar',
+                'post',
+            ];
+
+            foreach ($types as $type) {
+                /*
+                    アプリ側で「user_images」、「post_images」のDELETE/INSERT処理をしている
+                    当クリーンナップ処理では、「user_images」、「post_images」に存在するかで
+                    削除対象とすべきかを判定している。
+                    そのため、タイミングによっては、意図しないものまで、削除対象となってしまう
+    
+                    これを防ぐためには、$helper->doWithLock()からの
+                    コールバック処理とする形で、排他ロックするしかない。
+                */
+                $helper->doWithLock($type, function () use (
+                    $helper,
+                    $type,
+                    $exclusionDays,
+                    $exclusionHours,
+                    $exclusionMinutes,
+                    $exclusionSeconds,
+                    $cleanupUnusedFilesTakeCount
+                ) {
+                    $this->doProcess(
+                        $helper,
+                        $type,
+                        $exclusionDays,
+                        $exclusionHours,
+                        $exclusionMinutes,
+                        $exclusionSeconds,
+                        $cleanupUnusedFilesTakeCount
+                    );
+                });
+            }
+
+            return 0;
+        } catch (\Exception $e) {
+            $this->outputError('******************************************');
+            $this->outputError('Exception Message: ' . $e->getMessage());
+            $this->outputError('Stack Trace: ' . $e->getTraceAsString());
+            $this->outputError('******************************************');
+            throw $e;
+        }
+    }
+
+    /**
+     * $typeごとのクリーンナップ処理を行う。
+     */
+    private function doProcess(
+        $helper,
+        $type,
+        $exclusionDays,
+        $exclusionHours,
+        $exclusionMinutes,
+        $exclusionSeconds,
+        $cleanupUnusedFilesTakeCount
+    ) {
+        $isAvatar = ($type === 'avatar');
+        $isPost = ($type === 'post');
+        if(!$isAvatar && !$isPost) {
+            throw new \Exception("invalid type value : '{$type}'");
+        }
+
+        /*
+            処理対象の抽出のクエリに関する説明
+
+            ・typeで絞る
+
+            ・created_atが除外すべき現在時刻からの期間よりも古い 
+                まさに、今、画面操作で画像追加してて、あと少しで登録／更新系のボタンを押して
+                DB反映されそうなものまで、未だDB反映されてないということで削除対象になってしまうのを防ぐため
+            
+            ・check_countの昇順
+                当クリーンナップ処理による判定をあまりやってないものを優先的に処理したい
+            
+            ・idの昇順
+                check_countが同じ値ならば、純粋に古いものを優先的に処理したい
+
+            ・take($cleanupUnusedFilesTakeCount)
+                上記に対して、先頭、$cleanupUnusedFilesTakeCount件分の取得のクエリとする
+                こうすることで「unused_file_checkers」の件数が膨大になっても
+                クエリ自体の負荷は、$cleanupUnusedFilesTakeCount件分となり
+                後続のループ処理も$cleanupUnusedFilesTakeCount件分の処理量しかない
+            
+            1回の処理でクリーンナップ処理を完全にやってしまうのではなく
+            $cleanupUnusedFilesTakeCount件分ずつ処理して、高負荷にならないようにする
+            消し漏れを防ぐため、check_countの昇順で行う配慮とする。
+
+            削除対象であるものは、
+                sotrageからの削除と、「unused_file_checkers」からのレコード削除を行う。
+            削除対象でないものは、
+                「unused_file_checkers」のcheck_countをカウントアップし、
+                次回以降の処理対象を抽出時の優先度を下げる。
+            
+            ユーザは古いものも新しいものも、画面操作で削除してくる可能性があるため(どれを削除するか事前にわからない)
+            check_countで優先度を管理しながら、当コマンドが複数回、実行されていく中で、
+            徐々に、不要なファイルが削除されていく状況となるような運用にする。
+        */
+
+        // 処理対象から除外すべき現在時刻からの期間
+        $exclusionPeriod = Carbon::now('Asia/Tokyo')->subDays($exclusionDays)->subHours($exclusionHours)->subMinutes($exclusionMinutes)->subSeconds($exclusionSeconds);
+
+        $unusedFileCheckers = UnusedFileChecker::where('type', $type)
+            ->where('created_at', '<', $exclusionPeriod)
+            ->orderBy('check_count', 'asc')
+            ->orderBy('id', 'asc')
+            ->take($cleanupUnusedFilesTakeCount)
+            ->get();
+
+        $toDeleteList = []; // 蓄積リスト(削除対象であるもの)
+        $toKeepList = [];   // 蓄積リスト(削除対象ではないもの)
+
+        foreach ($unusedFileCheckers as $unusedFileChecker) {
+            $uuid = $unusedFileChecker->uuid;
+            $fileName = $unusedFileChecker->file_name;
+
+            $exists = false;
+
+            if ($isAvatar) {
+                // UserImageモデルでデータを確認
+                $exists = UserImage::where('uuid', $uuid)
+                    ->where('file_name', $fileName)
+                    ->exists();
+            }
+            
+            if ($isPost) {
+                // PostImageモデルでデータを確認
+                $exists = PostImage::where('uuid', $uuid)
+                    ->where('file_name', $fileName)
+                    ->exists();
+            }
+
+            // 判定結果に応じてリストに追加
+            if ($exists) {
+                $toKeepList[] = [
+                    'type' => $type,
+                    'uuid' => $uuid,
+                    'file_name' => $fileName,
+                ];
+            } else {
+                $toDeleteList[] = [
+                    'type' => $type,
+                    'uuid' => $uuid,
+                    'file_name' => $fileName,
+                ];
+            }
+        }
+
+        /*
+            ループ処理の不整合を回避するため
+            ( ループ処理中に、ループ対象のソースが変わる不整合)
+
+            上記のループ処理を終えた後に、蓄積分について別個に処理をすべき
+        */
+
+        // 削除対象であるリストのループ処理
+        foreach ($toDeleteList as $item) {
+
+            // ストレージから削除
+            $helper->deleteImageOnStorage($item['type'], $item['uuid']);
+
+            // DBからレコード削除
+            $QueryBuilder = $this->getCommonUnusedFileQueryBuilder($item['type'], $item['uuid'], $item['file_name']);
+            $QueryBuilder->delete();
+
+            $this->outputInfo("{$item['type']}, {$item['uuid']}, {$item['file_name']} : を削除しました。");
+        }
+
+        // 削除対象ではないリストのループ処理
+        foreach ($toKeepList as $item) {
+
+            // check_countのカウントアップ
+            $QueryBuilder = $this->getCommonUnusedFileQueryBuilder($item['type'], $item['uuid'], $item['file_name']);
+            $unusedFileChecker = $QueryBuilder->first();
+            if($unusedFileChecker) {
+
+                $fromCheckCount = $unusedFileChecker->check_count;
+                $toCheckCount = $fromCheckCount + 1;
+
+                $unusedFileChecker->check_count = $toCheckCount;
+                $unusedFileChecker->updated_at = now();
+                $unusedFileChecker->save();
+    
+                $this->outputInfo("{$item['type']}, {$item['uuid']}, {$item['file_name']} : のcheck_countを{$fromCheckCount}から{$toCheckCount}にカウントアップしました。");    
+            } else {
+                throw new \Exception("invalid QueryBuilder type : {$item['type']}, uuid : {$item['uuid']}, file_name : {$item['file_name']}");
+            }
+        }
+    }
+
+    /**
+     * 「unused_file_checkers」を$type, $uuid, $fileNameで絞ったクエリビルダを返す
+     */
+    private function getCommonUnusedFileQueryBuilder($type, $uuid, $fileName)
+    {
+        return UnusedFileChecker::where('type', $type)
+            ->where('uuid', $uuid)
+            ->where('file_name', $fileName);
+    }
+}

--- a/app/Console/Commands/InsertUnusedFileCheckers.php
+++ b/app/Console/Commands/InsertUnusedFileCheckers.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\UnusedFileChecker;
+use Carbon\Carbon;
+
+class InsertUnusedFileCheckers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'maketestdata:unused_file_checkers';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'unused_file_checkersに指定したディレクトリからデータベースに登録する。';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $types = [
+            'avatar',
+            'post',
+        ];
+
+        /*
+            このコマンドは本番環境では使いません
+            「unused_file_checkers」のテストデータを作成するためのコマンドです。
+            
+            CleanupUnusedFiles.phpの実装と同時に、
+            アップロードしたファイルを保存時に、「unused_file_checkers」にデータ登録する実装にしたが
+            その段階では、storageにファイルはあるが、「unused_file_checkers」にはデータが無かった
+
+            storageにあるファイルをls -ltrのイメージとなるように、
+            古いもの順にソートかけてファイルの最終更新日時より、
+            CleanupUnusedFiles.phpの実装での絞りに使ってるcreated_atに値を指定してデータ登録する
+            
+            storageにあるが「unused_file_checkers」にデータがない状況にて、
+            「unused_file_checkers」のデータを作るためのコマンドである。
+
+            ローカル環境での完全にテスト用のコマンド。
+        */
+
+        foreach ($types as $type) {
+            $directoryPath = storage_path("app/public/images/{$type}");
+
+            if (!\File::exists($directoryPath)) {
+                $this->error("directory not found: {$directoryPath}");
+                continue;
+            }
+
+            // ディレクトリ内のUUIDフォルダを取得
+            $uuidDirectories = \File::directories($directoryPath);
+            // ls -ltrのイメージになるように古いもの順で並び替え
+            usort($uuidDirectories, function ($a, $b) {
+                return filemtime($a) - filemtime($b);
+            });
+
+            // 各UUIDフォルダの中身を確認
+            foreach ($uuidDirectories as $uuidDirectory) {
+
+                // uuidのフォルダ内に1ファイルの構成だから基本的に1回しかループを回らないはず
+
+                // uuid
+                $uuid = basename($uuidDirectory);
+
+                $files = \File::files($uuidDirectory);
+                // ls -ltrのイメージになるように古いもの順で並び替え
+                usort($files, function ($a, $b) {
+                    return filemtime($a) - filemtime($b);
+                });
+
+                foreach ($files as $file) {
+                    // fileName
+                    $fileName = $file->getFilename();
+
+                    $exists = UnusedFileChecker::where('type', $type)
+                        ->where('uuid', $uuid)
+                        ->where('file_name', $fileName)
+                        ->exists();
+                    if ($exists) {
+                        $this->info("already exists. uuid: {$uuid}, fileName: {$fileName}, type: {$type}");
+                    } else {
+                        // ファイルの最終更新日時を取得し、日本時間に変換
+                        $fileCreatedAt = Carbon::createFromTimestamp(filemtime($file))->timezone('Asia/Tokyo');
+
+                        // insert
+                        $unusedFileChecker = new UnusedFileChecker;
+                        $unusedFileChecker->type = $type;
+                        $unusedFileChecker->check_count = 0;
+                        $unusedFileChecker->uuid = $uuid;
+                        $unusedFileChecker->file_name = $fileName;
+                        $unusedFileChecker->created_at = $fileCreatedAt;
+                        $unusedFileChecker->save();
+
+                        $this->info("Inserted record. uuid: {$uuid}, fileName: {$fileName}, type: {$type}");
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/PrepareLockFiles.php
+++ b/app/Console/Commands/PrepareLockFiles.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class PrepareLockFiles extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'prepare:lock-files {user?} {group?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '複数のロック名のロックファイルをストレージに準備する。';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $user = $this->argument('user');
+        $group = $this->argument('group');
+
+        $lockNames = [
+            'avatar',
+            'post',
+        ];
+
+        foreach ($lockNames as $lockName) {
+            // ロックファイルのパスを指定
+            $lockFilePath = storage_path("app/public/{$lockName}.lock");
+
+            // ロックファイルが存在しなければ作成
+            if (!\File::exists($lockFilePath)) {
+                // ゼロバイトのロックファイルを作成
+                \File::put($lockFilePath, '');
+                $this->info("created at: {$lockFilePath}");
+            } else {
+                $this->info("already exists: {$lockFilePath}");
+            }
+
+            if($user && $group) {
+                /*
+                    例として、
+                        php artisan prepare:lock-files www-data www-data
+                    での実行時
+                        $userは、www-data
+                        $groupは、www-data
+                    である。
+                    このとき、
+                        chown www-data:www-data ロックファイル
+                    のLinuxコマンドに相当する処理がしたい
+                    さもなければ、
+                        ロックファイルの所有者が、
+                        php artisan prepare:lock-files www-data www-data
+                        の実行ユーザ(rootなど)となってしまい
+                        app/Helpers/Helper.phpのdoWithLock()が権限エラーで
+                        正常動作しないだろう。
+
+                    dockerコンテナ内をroot以外で作業する環境のケースは、
+                    sudoコマンドが使えるようにDockerfileを構成し、docker compose buidしているなどの前提で
+                        sudo php artisan prepare:lock-files www-data www-data
+                    などすればよろしいだろう。
+                */
+                $isOK = true;
+                if ($isOK) {
+                    if (!chown($lockFilePath, $user)) {
+                        $this->error("Failed to chwon {$lockFilePath} to {$user}");
+                        $isOK = false;
+                    }
+                }
+                if ($isOK) {
+                    if (!chgrp($lockFilePath, $group)) {
+                        $this->error("Failed to chgrp {$lockFilePath} to {$group}");
+                        $isOK = false;
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/app/UnusedFileChecker.php
+++ b/app/UnusedFileChecker.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UnusedFileChecker extends Model
+{
+    /**
+     * 「unused_file_checkers」のinsert処理
+     */
+    public static function isert($type, $uuid, $fileName)
+    {
+        // insert
+        $unusedFileChecker = new UnusedFileChecker;
+        $unusedFileChecker->type = $type;
+        $unusedFileChecker->check_count = 0;
+        $unusedFileChecker->uuid = $uuid;
+        $unusedFileChecker->file_name = $fileName;
+        $unusedFileChecker->save();
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -230,4 +230,17 @@ return [
 
     //TOPIC_POSTS_TITLE
     'TopicPostsTitle' => env('TOPIC_POSTS_TITLE', 'Topic Posts'),
+
+    /*
+        CleanupUnusedFiles.phpでの
+        Carbon::now('Asia/Tokyo')->subDays($exclusionDays)->subHours($exclusionHours)->subMinutes($exclusionMinutes)->subSeconds($exclusionSeconds);
+        で利用する指定値
+    */
+    'exclusionDays' => env('EXCLUSION_DAYS', 1),
+    'exclusionHours' => env('EXCLUSION_HOURS', 0),
+    'exclusionMinutes' => env('EXCLUSION_MINUTES', 0),
+    'exclusionSeconds' => env('EXCLUSION_SECONDS', 0),
+
+    // CleanupUnusedFiles.phpでのtype毎の処理件数
+    'cleanupUnusedFilesTakeCount' => env('CLEANUP_UNUSED_FILES_TAKE_COUNT', 100),
 ];

--- a/database/migrations/2024_09_18_210712_create_unused_file_checkers_table.php
+++ b/database/migrations/2024_09_18_210712_create_unused_file_checkers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUnusedFileCheckersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('unused_file_checkers', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->string('type');
+            $table->bigInteger('check_count')->unsigned();
+            
+            $table->string('uuid');
+            $table->string('file_name');
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('unused_file_checkers');
+    }
+}


### PR DESCRIPTION
## issue
- Closes Draft 不要ファイルのクリーンナップコマンドおよび、ロックファイル作成コマンドなど

MTGで説明しとおり
現状）
編集モードのときに、
アップロードの追加／削除時に、storageの追加、削除と、
および、
user_images
または、
post_images
のDELETE/INSERTによる画面でアップロード分として表示されている分を
DB反映している

今後の改修イメージ）
削除時に、storageの削除はしないで放置する
編集モードのときに、編集系の画面で、更新する　のボタンを押した時の
DB処理で、
user_images
または、
post_images
のDELETE/INSERTによる画面でアップロード分として表示されている分を
DB反映する方向性

上記、対応すると、削除はアップロードのサムネイルのUIを画面から消すだけで
storageのファイルは残したまま放置になる。
また、
新規投稿時は、元々、投稿するまでDB反映されないため
アップロードだけして、投稿しませんでしたのケースでも
同様に、不要なファイルが残ったまま

不要ファイルのクリーンナップ処理の必要性が生じたため
Laravelのコマンドの自作の方法で、その実装をした

php artisan cleanup:unused-files
のコマンドで
CleanupUnusedFiles.php
が動くようになっている

ここで不要ファイルのクリーンナップ処理を実装した。
実装内容は、CleanupUnusedFiles.phpのコメント部に詳細書いた

アップロード時に、今回新設した、unused_file_checkersテーブルに
check_countが0でレコード作成する実装を追加した。

CleanupUnusedFiles.phpのクリーンナップ処理では、
config/app.phpで指定値での、直近の期間を除いて
check_countの昇順で、N件取得( このN件も、config/app.phpで指定値 )
取得値について、
user_imagesや、post_imagesになければ、削除対象の不要ファイルと判断し
storageのファイル削除(uuidのフォルダごと削除)および、unused_file_checkersからレコード削除

user_imagesや、post_imagesにあれば、削除対象でない残しておくべきファイルと判断し、
check_countのカウントアップをする。

ところで、

画面側の操作により、
user_images
または、
post_images
のDELETE/INSERTがうごくのであるが、
ちょうど、DELETE/INSERT処理のDELETEして、INSERTする前のタイミングで
クリーンナップ処理が裏で動くなどして、
消しはいけないファイルが消されてしまう、レアケースでの可能性を
防ぐために。

Helper.phpで定義した、doWithLock()
での排他ロックをかけたコールバック実行で
DELETE/INSERTの処理と、
クリーンナップ処理の本体部分の処理を囲っている

排他ロックのやり方の詳細は、doWithLock()内のコメントを参照のこと。

ps -ef | grep "apache"
id www-data
で、
dockerコンテナ内のapacheの実行ユーザが
ユーザ名 : www-data
グループ名 : www-data
であることを確認したうえで、
php artisan prepare:lock-files www-data www-data
を実行すると、
PrepareLockFiles.php
が、
所有者 : www-data、所有グループ : www-data
にて、
storage/app/public
に、
avatar.lock
post.lock
のゼロバイトファイルを作る。
Helper.phpで定義した、doWithLock()は、
'avatar'、'post'
のいずれかを引数指定すると
avatar.lock
post.lock
に対するflock()での排他ロックをしたうえで、コールバック実行する実装となっている


## 動作手順

php artisan migrate
で、新設の
unused_file_checkers
のテーブル定義をしてもらう必要がある。

前述の
```
ps -ef | grep "apache"
id www-data
で、
dockerコンテナ内のapacheの実行ユーザが
ユーザ名 : www-data
グループ名 : www-data
であることを確認したうえで、
php artisan prepare:lock-files www-data www-data
を実行すると、
PrepareLockFiles.php
が、
所有者 : www-data、所有グループ : www-data
にて、
storage/app/public
に、
avatar.lock
post.lock
のゼロバイトファイルを作る。
```
で、環境を作ることが必要。

それから、今、ある程度、sotrageにファイルがあるが、
unused_file_checkers
のデータはゼロ件のため
php artisan maketestdata:unused_file_checkers
で、
InsertUnusedFileCheckers.php
が動き、
sotrageの内容にしたがって、
unused_file_checkersへデータ投入する
(  開発時のテストデータ投入のため、作成した、シーダーともいえない使い方なのでコマンドにした )


## 考慮してほしいこと

画面側の操作により、
user_images
または、
post_images
のDELETE/INSERTの部分は、
今、Helper.phpのdoWithLock()のコールバック実行の範囲にしてる
たしかに、これでクリーンナップ処理とで、
排他ロックの制御ができるが、

この副作用として、複数ユーザが同時に画像のアップロードがある
編集画面利用時でも、そのユーザ同士で
排他ロックがかかり、タイミングによっては、少し、待たされる（スピナー表示時間がその分、わずかに長くなる）
副作用がある

この件は、
doWithLock()をラップして、
同じようにコールバック実行するfunctionを準備し、
日本時間で深夜などのメンテナンス時間の場合は、
doWithLock()を使った排他ロックしてのコールバック実行する。
それ以外の時間帯の場合は、
そのまま引数で受けたコールバック処理で
コールバックする
（　doWithLock()を使った排他ロックを使わずに、そのままコールバック )

そして、
クリーンナップ処理のcronなどによる、スケジュール実行の登録を
その深夜の時間帯だけとする。

上記のようにすることで、
```
この副作用として、複数ユーザが同時に画像のアップロードがある
編集画面利用時でも、そのユーザ同士で
排他ロックがかかり、タイミングによっては、少し、待たされる（スピナー表示時間がその分、わずかに長くなる）
副作用がある
```
に相当する副作用について、その深夜の時間以外は、なくすことができるのではないかと
考えている
どこかのタイミングで、その改修をいれれば、いいなぁ
と思っているが、
今回のプルリクでは、この対応は保留にしました。


# 今後
直近は、下記の対応を改修を行う
********************
今後の改修イメージ）
削除時に、storageの削除はしないで放置する
編集モードのときに、編集系の画面で、更新する　のボタンを押した時の
DB処理で、
user_images
または、
post_images
のDELETE/INSERTによる画面でアップロード分として表示されている分を
DB反映する方向性
********************
