### PR TITLE
#1245　フォロー機能によるタイムライン変更（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -61,7 +61,7 @@ class UsersController extends Controller
         // フォローした人を取得
         $followingId = $user->follows()->pluck('follow_id');
         // フォローした人の投稿を取得
-        $posts = Post::whereIn('user_id', $followingId)->orderBy('created_at', 'desc')->paginate(10);
+        $posts = Post::whereIn('user_id', $followingId)->orderBy('id', 'desc')->paginate(10);
         $data = [
             'user' => $user,
             'posts' => $posts,
@@ -77,7 +77,7 @@ class UsersController extends Controller
         // フォロワーを取得
         $followerId = $user->followUsers()->pluck('user_id');
         // フォロワーの投稿を取得
-        $posts = Post::whereIn('user_id', $followerId)->orderBy('created_at', 'desc')->paginate(10);  //最後はget(); の代わりにpaginate(10);
+        $posts = Post::whereIn('user_id', $followerId)->orderBy('id', 'desc')->paginate(10);  //最後はget(); の代わりにpaginate(10);
         $data = [
             'user' => $user,
             'posts' => $posts,

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,9 +19,9 @@
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
-                <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン</a></li>
-                <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
-                <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
+                <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::routeIs('user.show') ? 'active' : '' }}">タイムライン<br><div class="badge badge-secondary">{{ $countPosts ?? '' }}</div></a></li>
+                <li class="nav-item"><a href="{{ route('timelineFollowing', $user->id) }}" class="nav-link {{ Request::routeIs('timelineFollowing') ? 'active' : '' }}">フォロー中<br><div class="badge badge-secondary">{{ $countFollowing ?? '' }}</div></a></li>
+                <li class="nav-item"><a href="{{ route('timelineFollowers', $user->id) }}" class="nav-link {{ Request::routeIs('timelineFollowers') ? 'active' : '' }}">フォロワー<br><div class="badge badge-secondary">{{ $countFollowers ?? '' }}</div></a></li>
             </ul>
             @include('posts.posts', ['posts' => $posts])
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,8 +22,12 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ユーザ
 Route::get('/', 'UsersController@index')->name('user.index');
-Route::prefix('users')->group(function() {
-    Route::get('{id}', 'UsersController@show')->name('user.show');
+Route::prefix('users/{id}')->group(function() {
+    // ユーザ詳細
+    Route::get('', 'UsersController@show')->name('user.show');
+    // フォロー中・フォロワーのタブ
+    Route::get('timelineFollowing', 'UsersController@timelineFollowing')->name('timelineFollowing');
+    Route::get('timelineFollowers', 'UsersController@timelineFollowers')->name('timelineFollowers');
 });
 
 // ログイン後


### PR DESCRIPTION
## issue
- Closes #1245 

## 概要
- フォロー機能によるタイムライン変更

## 動作確認手順
- 実際にローカルで、いろいろなユーザの詳細ページから３つのタブをクリックして問題なく表示されることを確認。

## 確認していただきたいこと
- タブ下に表示される「カウント数」に関して、３つとも共通のデータとしてそれぞれのタブのメソッド内に入れておかないとエラーになることがあったので、ユーザコントローラーの一番下にカウント用の共通メソッドを作成しました
