### PR TITLE
flyデプロイ(大川)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# excludes from the docker image/build
+
+# 1. Ignore Laravel-specific files we don't need
+bootstrap/cache/*
+storage/framework/cache/*
+storage/framework/sessions/*
+storage/framework/views/*
+storage/logs/*
+storage/app/public/*
+public/storage
+*.env*
+.rr.yml
+rr
+frankenphp
+vendor
+
+# 2. Ignore common files/directories we don't need
+fly.toml
+.vscode
+.idea
+**/*node_modules
+**.git
+**.gitignore
+**.gitattributes
+**.sass-cache
+**/*~
+**/*.log
+**/.DS_Store
+**/Thumbs.db
+public/hot
+

--- a/.fly/entrypoint.sh
+++ b/.fly/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Run user scripts, if they exist
+for f in /var/www/html/.fly/scripts/*.sh; do
+    # Bail out this loop if any script exits with non-zero status code
+    bash "$f" || break
+done
+chown -R www-data:www-data /var/www/html
+
+if [ $# -gt 0 ]; then
+    # If we passed a command, run it as root
+    exec "$@"
+else
+    exec supervisord -c /etc/supervisor/supervisord.conf
+fi

--- a/.fly/scripts/caches.sh
+++ b/.fly/scripts/caches.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+/usr/bin/php /var/www/html/artisan config:cache --no-ansi -q
+/usr/bin/php /var/www/html/artisan route:cache --no-ansi -q
+/usr/bin/php /var/www/html/artisan view:cache --no-ansi -q

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,104 @@
+# syntax = docker/dockerfile:experimental
+
+# Default to PHP 8.2, but we attempt to match
+# the PHP version from the user (wherever `flyctl launch` is run)
+# Valid version values are PHP 7.4+
+ARG PHP_VERSION=8.2
+ARG NODE_VERSION=18
+FROM fideloper/fly-laravel:${PHP_VERSION} as base
+
+# PHP_VERSION needs to be repeated here
+# See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG PHP_VERSION
+
+LABEL fly_launch_runtime="laravel"
+
+# copy application code, skipping files based on .dockerignore
+COPY . /var/www/html
+
+RUN composer install --optimize-autoloader --no-dev \
+    && mkdir -p storage/logs \
+    && php artisan optimize:clear \
+    && chown -R www-data:www-data /var/www/html \
+    && echo "MAILTO=\"\"\n* * * * * www-data /usr/bin/php /var/www/html/artisan schedule:run" > /etc/cron.d/laravel \
+    && cp .fly/entrypoint.sh /entrypoint \
+    && chmod +x /entrypoint
+
+# Laravel 11 made changes to how trusting all proxies works, see https://laravel.com/docs/11.x/requests#trusting-all-proxies and https://laravel.com/docs/10.x/requests#trusting-all-proxies
+RUN if php artisan --version | grep -q "Laravel Framework 1[1-9]"; then \
+    sed -i='' '/->withMiddleware(function (Middleware \$middleware) {/a\
+        \$middleware->trustProxies(at: "*");\
+' bootstrap/app.php; \
+  else \
+    sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php; \
+fi
+
+# If we're using Octane...
+RUN if grep -Fq "laravel/octane" /var/www/html/composer.json; then \
+        rm -rf /etc/supervisor/conf.d/fpm.conf; \
+        if grep -Fq "spiral/roadrunner" /var/www/html/composer.json; then \
+            mv /etc/supervisor/octane-rr.conf /etc/supervisor/conf.d/octane-rr.conf; \
+            if [ -f ./vendor/bin/rr ]; then ./vendor/bin/rr get-binary; fi; \
+            rm -f .rr.yaml; \
+        else \
+            mv .fly/octane-swoole /etc/services.d/octane; \
+            mv /etc/supervisor/octane-swoole.conf /etc/supervisor/conf.d/octane-swoole.conf; \
+        fi; \
+        rm /etc/nginx/sites-enabled/default; \
+        ln -sf /etc/nginx/sites-available/default-octane /etc/nginx/sites-enabled/default; \
+    fi
+
+# Multi-stage build: Build static assets
+# This allows us to not include Node within the final container
+FROM node:${NODE_VERSION} as node_modules_go_brrr
+
+RUN mkdir /app
+
+RUN mkdir -p  /app
+WORKDIR /app
+COPY . .
+COPY --from=base /var/www/html/vendor /app/vendor
+
+# Use yarn or npm depending on what type of
+# lock file we might find. Defaults to
+# NPM if no lock file is found.
+# Note: We run "production" for Mix and "build" for Vite
+RUN if [ -f "vite.config.js" ]; then \
+        ASSET_CMD="build"; \
+    else \
+        ASSET_CMD="production"; \
+    fi; \
+    if [ -f "yarn.lock" ]; then \
+        yarn install --frozen-lockfile; \
+        yarn $ASSET_CMD; \
+    elif [ -f "pnpm-lock.yaml" ]; then \
+        corepack enable && corepack prepare pnpm@latest-8 --activate; \
+        pnpm install --frozen-lockfile; \
+        pnpm run $ASSET_CMD; \
+    elif [ -f "package-lock.json" ]; then \
+        npm ci --no-audit; \
+        npm run $ASSET_CMD; \
+    else \
+        npm install; \
+        npm run $ASSET_CMD; \
+    fi;
+
+# From our base container created above, we
+# create our final image, adding in static
+# assets that we generated above
+FROM base
+
+# Packages like Laravel Nova may have added assets to the public directory
+# or maybe some custom assets were added manually! Either way, we merge
+# in the assets we generated above rather than overwrite them
+COPY --from=node_modules_go_brrr /app/public /var/www/html/public-npm
+RUN rsync -ar /var/www/html/public-npm/ /var/www/html/public/ \
+    && rm -rf /var/www/html/public-npm \
+    && chown -R www-data:www-data /var/www/html/public
+
+# アプリから画像が見えるようにシンボリックリンク作成を追加
+RUN php artisan storage:link
+
+EXPOSE 8080
+
+ENTRYPOINT ["/entrypoint"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,40 @@
+# fly.toml app configuration file generated for laravelapp-a-haduki-dra on 2024-09-25T22:33:35+09:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'laravelapp-a-haduki-dra'
+primary_region = 'nrt'
+console_command = 'php /var/www/html/artisan tinker'
+
+[build]
+  [build.args]
+    NODE_VERSION = '18'
+    PHP_VERSION = '7.4'
+
+[env]
+  APP_ENV = 'production'
+  LOG_CHANNEL = 'stderr'
+  LOG_LEVEL = 'info'
+  LOG_STDERR_FORMATTER = 'Monolog\Formatter\JsonFormatter'
+  SESSION_DRIVER = 'cookie'
+  SESSION_SECURE_COOKIE = 'true'
+  FLY_REGION = "nrt"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+
+[[mounts]]
+  source = "storage_volume"
+  destination = "/var/www/html/storage/app/public"
+  processes = ['app']


### PR DESCRIPTION
## issue
- Closes #129 

slackの411のチャットで
短文の連続で、
事前に説明したとおり

storage/logs
と
storage/app/public
の2つを永続化したかった
しかし、fly.ioの制約で1つしか永続化できない

HANさんのアドバイスで、
storage/logsをfly.ioを永続化し
storage/app/publicへの保存はやめて
代わりにクラウド保存をするのが通常的な考え方ではないかとのこと。

その方向性で一旦、調査し、
「Cloudflare R2」での実装調査実現できました。
とても、勉強になりました。
本来であれば、この方法なのだろう、
今後は、この考え方をしていこうとはおもました。

本来であれば、その考え方なんだろうと思いました。
しかし、残念なことに現在チーム開発での
Laravelや、PHPのバージョンが古めであり
この本来の考え方が使えない状況だということがわかりました。

それはどういうことかというと、

「Cloudflare R2」での実装調査実現できました。
環境変数のON、OFFで
ONの時だけ「Cloudflare R2」環境へのアップロード
OFFの時は、これまで通りローカルのstorageへのアップロード
で、普段の他のチームメンバーでの開発環境もキープできる
構成に本当に実現できて、すごく勉強になりました。

しかし、上記の「Cloudflare R2」は、エラーを無視する環境変数を定義しての動作成功でした

Cloudflare R2で利用時に、AWS SDK for PHPを使ってます。
AWS SDK for PHPは、PHP 8.0.xおよびそれ以前のバージョンのサポートを2025年1月13日に終了することを発表してます
つまり、
PHP 8.1.x以上である必要があります。

2025年1月14日移行は、
エラーを無視する環境変数を定義しても、
動かなくなります

そのため、
PHP 8.1.x以上である必要があります。

しかし、
PHP 8.1.x以上にするには、Laravelを9.xのレベルまで
バージョンアップが必要になります。
（　まさか、そんなことだとは思いませんでした。ちょっとした環境調整で済むだろうと思ってましたが
       かなりの無理筋でした )

全、置換えレベルの話になり、これまで、開発してきたものを
その環境で、全部、動くようにする必要性があり

断念しました。

「Cloudflare R2」での実装は、お蔵入りになってしまいました。
(  今後の個人の勉強用には、とってます。  )

結果的に、元のローカルのstorage保存だけの実装に戻してます。

storage/app/public
のみfly.ioで永続化して
fly.ioでの動作環境でデプロイしました。

storage/logs
は、消えます。
そのため原因調査でログを見ることができません。

デプロイしたアプリは、

https://laravelapp-a-haduki-dra.fly.dev/
で動きます

一旦、ある程度データを投入してます
そうしなければ、動作確認できないからです。

最終的には、
flyにログインし、
php artisan migrate:fresh
でDB値空にできます。
storage/app/public/imagesのimagesのフォルダごとrm -rfで消せば空にできます

なので、今のところは、ある程度データ入れっぱなしにしておきます

# 課題
cronなどのスケジュール実行について調べようとしましたが
下記の理由により一旦、保留にしました。
fly.toml
で
auto_stop_machines = 'stop'
の設定にしています。
これは、数分間(たしか、10分だったか)
アクセスがないと、flyのVMが停止します
GETのリクエストが来ると起きます
そのため、そのときのリクエストに対する反応は遅いです
それが
auto_stop_machines = 'stop'
の設定です
こうして、使ってる時間が長くならないようにしておかないと
無料枠では使えないと思います

たしか、
auto_stop_machines = 'off'
だと思うが、これでデプロイすれば、常時起動になるようですが
これだと課金されてしまう可能性が高いです

問題は、cronみたいなことをするには、常時起動でないと動かないということです
ですので、cronはあきらめました。

その代わり
cron-job.org
というもので、指定したURLに、GETや、POST、PUT、DELETE
などのスケジュール登録ができるようです
それで、決まった時間に起こして、APIとかで不要ファイル削除の処理を実行する方向性も
一旦、考えた

その件を、HANさんに相談すると

それで10分間を起こすということを1日に何度もすれば
10分利用時間が重なり、月の無料枠のうち、普通の画面利用が残り少なくなるのではないか
とのご指摘
（　やるとしたら、数日に1回ぐらいしかできないなぁっと思った )

また、

考え方として、画像をアップロードしている画面の処理で
破棄確認のようなハンドリングをして、
そのタイミングで、なるべく不要ファイルを削除する処理を入れ込むのが
適切な考え方ではないか、とのことご指摘でした。

しかし、ブラウザの×ボタンのイベントを拾うことは
については、WEBの仕様で現在は難しいです。

ですので、完全に不要ファイルを消すことはできませんが
ブラウザの×ボタンで閉じる人がどれだけいるのかという話です

少なくできれば、flyに直接入って、不要ファイルを削除するコマンドを直接起動でもよいのか
とも思えた。


なので、一旦、このファイルの削除以前に破棄確認などのハンドリングができるか
そこで、削除処理入れ込めるか
おそらく、画面で覚えてるもののうち、既にDB値となってるものを
除いて賞味、要らない分の削除だろうと思うが

という話の流れになり

一旦は、このプルリクでは、スケジュール実行や、削除処理は、対応してません。
