### PR TITLE
#1252 投稿の検索機能（西山しょうこ）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -53,4 +53,14 @@ class PostsController extends Controller
         return back();
     }
 
+    public function searchPosts(Request $request)
+    {
+        $keyword = $request->input('keyword');
+        if (!empty($keyword)) {
+            $posts = Post::where('content', 'like', "%{$keyword}%")->orderBy('id', 'desc')->paginate(10);
+        } else {
+            $posts = Post::orderBy('id', 'desc')->paginate(10);
+        }
+        return view('welcome', ['posts' => $posts, 'keyword' => $keyword]);  
+    } 
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -63,6 +63,6 @@ class PostsController extends Controller
             $query->where('content', 'like', "%{$keyword}%"); // contentカラムにキーワードが含まれる投稿を検索条件に追加
         } 
         $posts = $query->orderBy('id', 'desc')->paginate(10); // if文を通らなかったら、そのまま投稿を全件表示
-        return view('welcome', compact('posts', 'keyword', 'submitted'));
+        return view('welcome', ['posts' => $posts, 'keyword' => $keyword, 'submitted' => $submitted]);
     } 
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -63,6 +63,12 @@ class PostsController extends Controller
             $query->where('content', 'like', "%{$keyword}%"); // contentカラムにキーワードが含まれる投稿を検索条件に追加
         } 
         $posts = $query->orderBy('id', 'desc')->paginate(10); // if文を通らなかったら、そのまま投稿を全件表示
-        return view('welcome', ['posts' => $posts, 'keyword' => $keyword, 'submitted' => $submitted]);
+        return view('welcome',
+            [
+                'posts' => $posts, 
+                'keyword' => $keyword, 
+                'submitted' => $submitted
+            ]
+        );
     } 
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -53,14 +53,16 @@ class PostsController extends Controller
         return back();
     }
 
-    public function searchPosts(Request $request)
+    // 通常のトップページと、投稿の検索機能も兼ねる
+    public function index(Request $request)
     {
-        $keyword = $request->input('keyword');
-        if (!empty($keyword)) {
-            $posts = Post::where('content', 'like', "%{$keyword}%")->orderBy('id', 'desc')->paginate(10);
-        } else {
-            $posts = Post::orderBy('id', 'desc')->paginate(10);
-        }
-        return view('welcome', ['posts' => $posts, 'keyword' => $keyword]);  
+        $keyword = $request->input('keyword'); // リクエストからキーワードを取得
+        $submitted = $request->has('keyword'); // キーワード（空でも良い）がリクエストに含まれていて「検索ボタン」を押されたかどうか確認
+        $query = Post::query(); // Postモデルの新しいクエリビルダーインスタンスを作成
+        if (!empty($keyword)) { // キーワードが空でない場合
+            $query->where('content', 'like', "%{$keyword}%"); // contentカラムにキーワードが含まれる投稿を検索条件に追加
+        } 
+        $posts = $query->orderBy('id', 'desc')->paginate(10); // if文を通らなかったら、そのまま投稿を全件表示
+        return view('welcome', compact('posts', 'keyword', 'submitted'));
     } 
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -10,13 +10,13 @@ use Illuminate\Support\Facades\Hash;
 
 class UsersController extends Controller
 {
-    public function index()
+    /*public function index()
     {
         $posts = Post::orderBy('id', 'desc')->paginate(10);
         return view('welcome', [
             'posts' => $posts
         ]);
-    }
+    } */
 
     public function show($id)
     {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -10,14 +10,6 @@ use Illuminate\Support\Facades\Hash;
 
 class UsersController extends Controller
 {
-    /*public function index()
-    {
-        $posts = Post::orderBy('id', 'desc')->paginate(10);
-        return view('welcome', [
-            'posts' => $posts
-        ]);
-    } */
-
     public function show($id)
     {
         $user = User::findOrFail($id);

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,10 @@
+.search-button {
+    color: white !important;
+    background-color: rgba(0, 0, 255, 0.774) !important;
+    border-color: rgba(0, 0, 255, 0.774) !important;
+}
+
+.search-button:hover {
+    background-color: darkblue !important;
+    border-color: darkblue !important;
+}

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -10,22 +10,16 @@
               @if (Auth::check())
                   <li class="nav-item"><a href="{{ route('user.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                   <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
-                  <li class="nav-item">
-                      <form action="{{ route('searchPosts') }}" method="GET" class="form-inline my-2 my-lg-0 ml-2">
-                          <input type="search" name="keyword" class="form-control mr-sm-2" value="{{ request('keyword') }}" placeholder="キーワードを入力" aria-label="検索">
-                          <button class="btn btn-outline-success my-2 my-sm-0 search-button" type="submit">投稿を検索</button>
-                      </form>
-                  </li>
               @else
                   <li class="nav-item"><a href="{{ route('login') }}" class="nav-link text-light">ログイン</a></li>
                   <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>
+              @endif
                   <li class="nav-item">
-                      <form action="{{ route('searchPosts') }}" method="GET" class="form-inline my-2 my-lg-0 ml-2">
-                          <input type="search" name="keyword" class="form-control mr-sm-2" value="{{ request('keyword') }}" placeholder="キーワードを入力" aria-label="検索">
-                          <button class="btn btn-outline-success my-2 my-sm-0 search-button" type="submit">投稿を検索</button>
+                      <form action="{{ route('index') }}" method="GET" class="form-inline my-2 my-lg-0 ml-2">
+                        <input type="search" name="keyword" class="form-control mr-sm-2" value="{{ request('keyword') }}" placeholder="キーワードを入力" aria-label="検索">
+                        <button class="btn btn-outline-success my-2 my-sm-0 search-button" type="submit">投稿を検索</button>
                       </form>
                   </li>
-              @endif
             </ul>
         </div>
     </nav>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -10,9 +10,21 @@
               @if (Auth::check())
                   <li class="nav-item"><a href="{{ route('user.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                   <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
+                  <li class="nav-item">
+                      <form action="{{ route('searchPosts') }}" method="GET" class="form-inline my-2 my-lg-0 ml-2">
+                          <input type="search" name="keyword" class="form-control mr-sm-2" value="{{ request('keyword') }}" placeholder="キーワードを入力" aria-label="検索">
+                          <button class="btn btn-outline-success my-2 my-sm-0 search-button" type="submit">投稿を検索</button>
+                      </form>
+                  </li>
               @else
                   <li class="nav-item"><a href="{{ route('login') }}" class="nav-link text-light">ログイン</a></li>
                   <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>
+                  <li class="nav-item">
+                      <form action="{{ route('searchPosts') }}" method="GET" class="form-inline my-2 my-lg-0 ml-2">
+                          <input type="search" name="keyword" class="form-control mr-sm-2" value="{{ request('keyword') }}" placeholder="キーワードを入力" aria-label="検索">
+                          <button class="btn btn-outline-success my-2 my-sm-0 search-button" type="submit">投稿を検索</button>
+                      </form>
+                  </li>
               @endif
             </ul>
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,8 @@
         <title>Topic Posts</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link rel="stylesheet" href="{{ asset('/css/style.css') }}">
+
     </head>
     <body>
       @include('commons.header')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,7 +6,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
         <link rel="stylesheet" href="{{ asset('/css/style.css') }}">
-
     </head>
     <body>
       @include('commons.header')

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -24,5 +24,8 @@
         </li>
     @endforeach    
 </ul>
-<div class="m-auto" style="width: fit-content">{{ $posts->links('pagination::bootstrap-4') }}</div>
-
+@if (!empty($keyword))
+<div class="m-auto" style="width: fit-content">{{ $posts->appends(['keyword' => request()->input('keyword')])->links('pagination::bootstrap-4') }}</div>
+@else
+<div class="m-auto" style="width: fit-content">{{ $posts->links('pagination::bootstrap-4') }}</div>   
+@endif

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,5 +1,5 @@
  @extends('layouts.app')
- @setion('content')
+ @section('content')
     <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
         <form method="POST" action="{{ route('user.update', $user->id) }}">
             @csrf

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,8 @@
 @extends('layouts.app')
 @section('content')
+@php
+    $keyword = $keyword ?? '';
+@endphp
 <div class="center jumbotron bg-info">
     <div class="text-center text-white mt-2 pt-1">
         <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
@@ -19,6 +22,6 @@
             </div>
         </form>
     </div>
-    @endif    
-@include('posts.posts', ['posts => $posts'])
+    @endif
+@include('posts.posts', ['posts' => $posts, 'keyword' => $keyword])
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,8 +1,5 @@
 @extends('layouts.app')
 @section('content')
-@php
-    $keyword = $keyword ?? '';
-@endphp
 <div class="center jumbotron bg-info">
     <div class="text-center text-white mt-2 pt-1">
         <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
@@ -22,6 +19,17 @@
             </div>
         </form>
     </div>
+    @endif
+    @if (isset($submitted) && $submitted)  {{-- 「検索ボタン」を押されている場合で、 --}}
+        @if ($keyword == "" || $keyword == NULL)
+            <p class="text-center">キーワードを入力してください。</p>
+        @else
+            @if (count($posts) > 0)
+                <p class="text-center">「{{ $keyword }}」で検索しました。</p>
+            @else
+                <p class="text-center">「{{ $keyword }}」を含む投稿が見つかりません…</p>
+            @endif
+        @endif
     @endif
 @include('posts.posts', ['posts' => $posts, 'keyword' => $keyword])
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ユーザ
-Route::get('/', 'UsersController@index')->name('user.index');
+// Route::get('/', 'UsersController@index')->name('user.index');
 Route::prefix('users/{id}')->group(function() {
     // ユーザ詳細
     Route::get('', 'UsersController@show')->name('user.show');
@@ -30,8 +30,8 @@ Route::prefix('users/{id}')->group(function() {
     Route::get('timelineFollowers', 'UsersController@timelineFollowers')->name('timelineFollowers');
 });
 
-// 投稿の検索機能
-Route::get('searchPosts', 'PostsController@searchPosts')->name('searchPosts');
+// 最初のページ・投稿の検索機能
+Route::get('/', 'PostsController@index')->name('index');
 
 // ログイン後
 Route::group(['middleware' => 'auth'], function() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,6 @@ Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ユーザ
-// Route::get('/', 'UsersController@index')->name('user.index');
 Route::prefix('users/{id}')->group(function() {
     // ユーザ詳細
     Route::get('', 'UsersController@show')->name('user.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,9 @@ Route::prefix('users/{id}')->group(function() {
     Route::get('timelineFollowers', 'UsersController@timelineFollowers')->name('timelineFollowers');
 });
 
+// 投稿の検索機能
+Route::get('searchPosts', 'PostsController@searchPosts')->name('searchPosts');
+
 // ログイン後
 Route::group(['middleware' => 'auth'], function() {
     // 投稿


### PR DESCRIPTION
## issue
- Closes #1252 

## 概要
- ~~進捗は実装したかったことの半分程ですが、現状できたところまでを一旦プルリク上げます。~~ 
- 投稿の検索機能の実装

## 実装できたこと・動作確認
- ログイン前・ログイン後　共にヘッダーの一番右端に「検索フォーム」と「投稿を検索」ボタンの表示
- あいまい検索を可能とした
- ログイン前・ログイン後それぞれ、以下の①～③をローカルにて手動確認
　①存在するキーワードを入力：該当する投稿のみが全て表示される。検索フォームには、入力キーワードが保持される。2ページ目へ続く場合にも、URL・検索フォーム内のどちらにも検索キーワードを保持したまま遷移し、ちゃんと該当する投稿が表示できた。**{キーワード}で検索しました。を表示（追加）**
　②存在しないキーワードを入力：何も表示されない（エラーにもならない）。**{キーワード}を含む投稿が見つかりません。を表示（追加）**
　③検索フォームに何も入力せず、検索ボタンを押す：投稿が全件、表示される。**キーワードを入力してください。を表示（追加）**
　
最終的には、自分が思い描いていたものに近い状態までもっていくことができました！

## 懸念点
- ~~思い描いていたことがピンポイントでネット検索で見つからない場合、どうしてもAIに頼りがちになり、どんどんAIに質問をしてコードを追加していくたびに辻褄が合わなくなったり、今まで正常に動いていたところにもエラーが増えてくるようになり、頭がパニックになり諦めてしまった。実力不足、知識不足を実感しているところです。
null、empty、空、値がない（？）、issetじゃない（？）…等の「入力されていない」・「存在しない」あたりの本当の意味が理解できなさすぎてコーディングの仕方がわからない。~~ **ご指導ありがとうございました**

## 本当は実装したかったこと
- ~~上記①の場合、該当する投稿の一番上に「｛キーワード｝を含む投稿が見つかりました」を表示~~
- ~~上記②の場合、投稿が表示されるはずだった場所に「｛キーワード｝を含む投稿が見つかりません…」を表示~~
- ~~上記③の場合、「キーワードを入力してください」を表示
　しっかりと理解できていないまま、if文を使って複雑な条件分岐をしてしまった。トップページ（web.blade.php）にどんどんコードを追加していくたびに複雑になってエラーも増えてきたので、諦めて全て削除しました。~~

~~現状で方向性は合っているのか、また、実装したかったことを実現するためのアドバイス等をいただきたいです。
よろしくお願いいたします。~~ **ご指導ありがとうございました**
