### PR TITLE
youtube動画をurlで追加しカルーセルでの複数表示対応(大川)

### DIFF
--- a/app/Helpers/FileType.php
+++ b/app/Helpers/FileType.php
@@ -25,14 +25,27 @@ class FileType
     public const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
     // 許可した動画の拡張子
     public const VIDEO_EXTENSIONS = ['mp4', 'webm', 'ogv', 'm4v'];
+    // youTubeの拡張子(実際には存在しない拡張子だが、upload.jsにて、youtubeIdに、この拡張子を付与する形でファイル名を指定している)
+    public const YOUTUBE_EXTENSIONS = ['youtube'];
 
     public $isImage;
     public $isVideo;
+    public $isYoutube;
     public $isOther;
 
     public $isAvatar;
     public $isPost;
     public $isOtherType;
+
+    /**
+     * videoタグのtype属性に指定すべき値
+     */
+    public $typeValue = "";
+
+    /**
+     * YouTubeId
+     */
+    public $youtubeId = "";
 
     /**
      * ファイル名
@@ -49,6 +62,8 @@ class FileType
         $this->fileName = $argFileName;
         $this->type = $argType;
 
+        $tempArray = null;
+
         // ファイルの拡張子を取得して小文字に変換
         $extension = strtolower(pathinfo($this->fileName, PATHINFO_EXTENSION));
 
@@ -57,7 +72,44 @@ class FileType
 
         // 動画ファイルかどうか
         $this->isVideo = in_array($extension, self::VIDEO_EXTENSIONS);
+        if($this->isVideo) {
+            if($extension === 'mp4') {
+                $this->typeValue = 'video/mp4';
+            }
+            if($extension === 'webm') {
+                $this->typeValue = 'video/webm';
+            }
+            if($extension === 'ogv') {
+                $this->typeValue = 'video/ogg';
+            }
+            if($extension === 'm4v') {
+                $this->typeValue = 'video/x-m4v';
+            }
+        }
 
+        // youTubeかどうか
+        $this->isYoutube = in_array($extension, self::YOUTUBE_EXTENSIONS);
+
+        if($this->isYoutube) {
+            $tempArray = explode(".", $this->fileName);
+            $this->youtubeId = $tempArray[count($tempArray) - 2];
+        }
+
+        /*
+            特記事項
+            「 && !$this->isYoutube」の連結はあえて行わない
+
+            バリデーションチェックなどに影響ある。
+            $this->isYoutubeの時は、完全に別ロジック対応です。
+            間違って、バリデーションチェックが動いても
+            $this->isOtherのときと同じ、NGにしておきたい。
+
+            おそらくないと思うが、.youtube の拡張子のテキストファイルなどを
+            アップロードしてきたときに、誤動作にならいように、
+            $this->isOtherとしてのバリデーションチェックが働く形としたい
+            このような意図があり、
+            「 && !$this->isYoutube」の連結はあえて行わない
+        */
         // どちらにも該当しない場合
         $this->isOther = !$this->isImage && !$this->isVideo;
 

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -397,7 +397,11 @@ class Helper
     public function deleteImageOnStorage($imageType, $uuid, $fileName)
     {
         $fileType = new FileType($fileName, $imageType);
-        
+        if($fileType->isYoutube) {
+            // youTubeの場合は、そもそも、storage保存しないため、なにもしない
+            return;
+        }
+
         // storage/app/public　の配下の相対パス
         $folderRelativePath = $fileType->getFolderRelativePath($uuid);
 
@@ -507,4 +511,39 @@ class Helper
     }
 
     /* #endregion */ // 「$fileUuids、$fileNamesの検証と件数取得」
+
+    /* #region YouTube関連 */
+
+    /**
+     * youtubeIdを指定して、YouTube動画のサムネイル画像のURLを取得する。
+     */
+    public function getYoutubeThumbnailUrl($youtubeId)
+    {
+        $youtubeThumbnailUrl = "https://img.youtube.com/vi/{$youtubeId}/hqdefault.jpg";
+        return $youtubeThumbnailUrl;
+    }
+
+    /**
+     * YouTube動画のiframeのsrc属性値の値を取得する
+     */
+    public function getYoutubeIframeSrc($youtubeId)
+    {
+        /*
+            ＜特記事項＞
+            <script src="https://www.youtube.com/iframe_api"></script>
+            を通じた
+            const player = new YT.Player(iframe, {
+            で、
+            'onReady': function(event) {
+            が発火させるには、
+            &enablejsapi=1
+            を追加する必要があった。
+        */
+
+        $ret = "https://www.youtube.com/embed/{$youtubeId}?controls=1&loop=1&enablejsapi=1";
+
+        return $ret;
+    }
+
+    /* #endregion */ // YouTube関連
 }

--- a/app/PostImage.php
+++ b/app/PostImage.php
@@ -141,8 +141,19 @@ class PostImage extends Model
                     どのみち表示できたとしてもyoutubeIdである。
                     ツールチップのために、youtubeApiで動画のタイトルを取得するのは大掛かりすぎる
                     一旦は、ツールチップ表示は、あきらめました。
+
+                    ツールチップを、あきらめた代わりに、テキストボックスでコピペできるようにする。
             */
-            $ret = "<iframe src=\"{$asetValue}\" frameborder=\"0\"></iframe>";
+            $ret = 
+                "<iframe src=\"{$asetValue}\" frameborder=\"0\"></iframe>" .
+
+                // YouTubeのURLをコピペできるようにしておこう。(カルーセル表示中のYouTube動画が気になったときに、そのurlをコピペできるように)
+                "<div class=\"form-group d-flex align-items-center\">" .
+                    "<label class=\"mr-2 mb-0\">YouTubeURL</label>" .
+                    "<input type=\"text\" class=\"form-control mr-2\" value=\"https://www.youtube.com/watch?v={$fileType->youtubeId}\" readonly>" .
+                    "<button class=\"btn btn-primary btn-sm h-100\" onclick=\"navigator.clipboard.writeText(this.previousElementSibling.value).then(() => alert('copied!!'));\">copy</button>" .
+                "</div>"
+            ;
         } else if($fileType->isVideo) {
             // 動画の場合
 

--- a/config/app.php
+++ b/config/app.php
@@ -229,7 +229,7 @@ return [
     ],
 
     //TOPIC_POSTS_TITLE
-    'TopicPostsTitle' => env('TOPIC_POSTS_TITLE', 'Topic Posts'),
+    'TopicPostsTitle' => env('TOPIC_POSTS_TITLE', '６ちゃんねる powerd by ゆきひろ'),
 
     /*
         ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
@@ -268,9 +268,9 @@ return [
         Carbon::now('Asia/Tokyo')->subDays($exclusionDays)->subHours($exclusionHours)->subMinutes($exclusionMinutes)->subSeconds($exclusionSeconds);
         で利用する指定値
     */
-    'exclusionDays' => env('EXCLUSION_DAYS', 1),
+    'exclusionDays' => env('EXCLUSION_DAYS', 0),
     'exclusionHours' => env('EXCLUSION_HOURS', 0),
-    'exclusionMinutes' => env('EXCLUSION_MINUTES', 0),
+    'exclusionMinutes' => env('EXCLUSION_MINUTES', 15),
     'exclusionSeconds' => env('EXCLUSION_SECONDS', 0),
 
     // CleanupUnusedFiles.phpでのtype毎の処理件数

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,3 +1,8 @@
 body {
     min-height: 100vh;
 }
+
+/* bootstrapのbg-infoの背景色を置き換える */
+.bg-info {
+    background-color: black !important;
+}

--- a/public/js/carousel.js
+++ b/public/js/carousel.js
@@ -117,8 +117,29 @@ $(document).ready(function() {
         */
         let modalBody = modal.find('.modal-body');
 
+        // サイズ調整すべきターゲット
+        let sizeAdjustTarget = null;
+        // サイズ調整すべきアスペクト比
+        let sizeAdjustAspectRatio = null;
+
         let video = carousel[0].children[0].children[currentIndex].querySelector('video');
         if (video) {
+            sizeAdjustTarget = video;
+        }
+        let iframe = carousel[0].children[0].children[currentIndex].querySelector('iframe');
+        if (iframe) {
+            sizeAdjustTarget = iframe;
+
+            /*
+                viedeタグと異なり、YouTube動画のiframeタグは、
+                widthを指定しても、heightが調整されない。結果的に横長になってなってしまった
+
+                ただし、YouTube動画では、ほとんどの動画のアスペクト比が16:9であるとのこと
+                ですので、16:9になるようにheightを自動調整すればよい。
+            */
+            sizeAdjustAspectRatio = (9 / 16);
+        }
+        if (sizeAdjustTarget) {
             // 動画のカルーセルページの場合だけ、下記を適用する。
 
             setTimeout(function() {
@@ -130,7 +151,11 @@ $(document).ready(function() {
                 let ratioArray = [0.95, 0.9, 0.85, 0.8, 0.75, 0.7, 0.65, 0.6, 0.55, 0.5, 0.45, 0.4, 0.35, 0.3];
                 for(let index = 0 ; index < ratioArray.length ; ++index) {
                     let currentRatio = ratioArray[index];
-                    video.width = modalBody[0].clientWidth * currentRatio;
+                    sizeAdjustTarget.width = modalBody[0].clientWidth * currentRatio;
+
+                    if(sizeAdjustAspectRatio) {
+                        sizeAdjustTarget.height = sizeAdjustTarget.width * sizeAdjustAspectRatio;
+                    }
 
                     // 縦スクロールが発生しているかどうか
                     let isHeightScroll = (modalBody[0].scrollHeight > modalBody[0].clientHeight);

--- a/public/js/common.js
+++ b/public/js/common.js
@@ -64,10 +64,54 @@ function showToast(message, alertClass) {
     $('#toastContainer .toast').toast('show');
 }
 
+// iframeが指定されたYT.Playerのリスト
+let ytPlayers = [];
+
+// 「YouTube IFrame API」の「onYouTubeIframeAPIReady」で実行されるべき処理
+function procOnYouTubeIframeAPIReady() {
+
+    /*
+        onYouTubeIframeAPIReady の関数名は、
+        「YouTube IFrame API」の仕様で決まっている
+
+        「YouTube IFrame API」が準備OKになったら動く
+    */
+    const iframes = document.querySelectorAll('iframe');
+    iframes.forEach((iframe, index) => {
+        if (iframe.src.includes('youtube.com')) {
+            loadYtPlayer(iframe);
+        }
+    });
+}
+
+// 読み込まれたiframeでYT.Playerを初期化して、ytPlayersに追加する。
+function loadYtPlayer(iframe) {
+    const player = new YT.Player(iframe, {
+        events: {
+            'onReady': function(event) {
+                ytPlayers.push(player);
+            },
+            'onError': function(event) {
+                console.log("####  Error loading player iframe: ", iframe.src, event.data);
+            },
+        }
+    });
+}
+
 /**
- * ページ内のvideoタグで再生中のものは停止する。
+ * ページ内の動画で再生中のものは停止する。
  */
 function stopAllPlayingVideos() {
+
+    /*
+        再生中の動画を停止の操作をせずに、
+
+        カルーセルのページ切り替え後も、切替前のページの動画が再生状態のまま(裏で音声だけ聞こえる)
+        カルーセルを閉じた後も、動画が再生状態のまま(裏で音声だけ聞こえる)
+
+        状態を防ぐために、イメページ内にある動画について、停止の操作を行っておく。
+    */
+
     // ページ内の全てのvideoタグを取得
     const videos = document.querySelectorAll('video');
 
@@ -83,6 +127,115 @@ function stopAllPlayingVideos() {
             //*** video.currentTime = 0;
         }
     });
+
+    ytPlayers.forEach(player => {
+        player.pauseVideo();
+    });
+}
+
+/**
+ * ページ内の一番最後の「$(document).ready(function() {」ですべき処理
+ * 
+ * ブラウザのデバッガーで確認しずらいためfunction化した。
+ */
+function lastReadyProc() {
+    /*
+        <script src="https://www.youtube.com/iframe_api"></script>
+        は、「YouTube IFrame API」を使えるようにするためのものである
+        「new YT.Player()」のために必要である。
+        「&enablejsapi=1」をyoutubeのURLに付与してる状況で正しく動作する。
+
+        onYouTubeIframeAPIReady は、
+        「YouTube IFrame API」の仕様で決まっている
+        「YouTube IFrame API」が準備OKになったら動く
+
+        <script src="https://www.youtube.com/iframe_api"></script>
+        の方式でやろうとしたが、その場合は、onYouTubeIframeAPIReadyが動くタイミングでは、
+        DOM上に一部のiframeしか作成されていないタイミングであった。
+
+        そのため、ページの下の方にあるiframeについて、動画を停止させる制御がうまく動かなかった。
+
+        そこで、ページの一番下で実行される
+            $(document).ready(function() {
+        の当実装にて、動的に、
+            $.getScript("https://www.youtube.com/iframe_api", function() {
+        で、
+            「YouTube IFrame API」の読み込みを行うことにした。
+        ページの一番下で実行される
+
+        「  $(document).ready(function() {  」の当実装では、DOMが全て作成済のタイミングであるからだ。
+        
+        このようにして、意図通り、ページ内のyoutubeのiframeの全てに対して動画を停止させる制御が働くように配慮してます。
+    */
+
+    window.onYouTubeIframeAPIReady = function() {
+        console.log("onYouTubeIframeAPIReady");
+        
+        // 「YouTube IFrame API」の「onYouTubeIframeAPIReady」で実行されるべき処理
+        procOnYouTubeIframeAPIReady();
+    };
+
+    // 「YouTube IFrame API」を使えるようにする。「new YT.Player()」のために必要である。「&enablejsapi=1」をyoutubeのURLに付与するのが必要である。
+    $.getScript("https://www.youtube.com/iframe_api", function() {
+        console.log("YouTube IFrame API script loaded.");
+    });
+}
+
+/**
+ * urlからyoutubeIdを取得する。
+ */
+function getYouTubeId(url) {
+    let youtubeId = null;
+
+    if (!youtubeId) {
+        youtubeId = getYouTubeIdSubLogic(url, "https://www.youtube.com/watch?v=", "v=");
+    }
+    if (!youtubeId) {
+        youtubeId = getYouTubeIdSubLogic(url, "https://youtu.be/", "youtu.be/");
+    }
+    if (!youtubeId) {
+        youtubeId = getYouTubeIdSubLogic(url, "https://www.youtube.com/embed/", "embed/");
+    }
+    if (!youtubeId) {
+        youtubeId = getYouTubeIdSubLogic(url, "https://www.youtube.com/v/", "v/");
+    }
+    if (!youtubeId) {
+        youtubeId = getYouTubeIdSubLogic(url, "https://www.youtube.com/shorts/", "shorts/");
+    }
+
+    return youtubeId;
+}
+
+/**
+ * urlからyoutubeIdを取得する。(サブロジック)
+ */
+function getYouTubeIdSubLogic(url, pattern, splitString) {
+    if (url.startsWith(pattern) && url.length >= pattern.length + 11) {
+        // URLがpatternで始まっていて、かつ、URL全体の長さが「patternの文字数 + 11」以上の場合
+
+        // splitStringで分割
+        const splitResult = url.split(splitString);
+        
+        if (splitResult.length > 1 && splitResult[1].length >= 11) {
+            /*
+              splitResult[1]が存在し、かつ長さが11文字以上であることを確認
+              次の11桁内にsplitResultが含まれていないので、
+              次の11桁を取得可能な状況の場合
+            */
+            const youtubeId = splitResult[1].substring(0, 11);
+            return youtubeId;
+        }
+    }
+    return null;
+}
+
+/**
+ * youtubeIdを指定して、YouTube動画のサムネイル画像のURLを取得する。
+ */
+function getYoutubeThumbnailUrl(youtubeId)
+{
+    thumbnailRelativeFilePath = `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`;
+    return thumbnailRelativeFilePath;
 }
 
 /**
@@ -118,6 +271,9 @@ class FileType {
     static IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif'];
     static VIDEO_EXTENSIONS = ['mp4', 'webm', 'ogv', 'm4v'];
 
+    // youTubeの拡張子(実際には存在しない拡張子だが、upload.jsにて、youtubeIdに、この拡張子を付与する形でファイル名を指定している)
+    static YOUTUBE_EXTENSIONS = ['youtube'];
+
     constructor(argFileName) {
         this.fileName = argFileName;
 
@@ -130,6 +286,31 @@ class FileType {
         // 動画ファイルかどうか
         this.isVideo = FileType.VIDEO_EXTENSIONS.includes(extension);
 
+        // youTubeかどうか
+        this.isYoutube = FileType.YOUTUBE_EXTENSIONS.includes(extension);
+
+        this.youtubeId = "";
+
+        if(this.isYoutube) {
+            const tempArray = this.fileName.split(".");
+            this.youtubeId = tempArray[tempArray.length - 2];
+        }
+
+        /*
+            特記事項
+            「 && !$this.isYoutube」の連結はあえて行わない
+
+            バリデーションチェックなどに影響ある。
+            this.isYoutubeの時は、完全に別ロジック対応です。
+            間違って、バリデーションチェックが動いても
+            this.isOtherのときと同じ、NGにしておきたい。
+
+            おそらくないと思うが、.youtube の拡張子のテキストファイルなどを
+            アップロードしてきたときに、誤動作にならいように、
+            $this->isOtherとしてのバリデーションチェックが働く形としたい
+            このような意図があり、
+            「 && !$this.isYoutube」の連結はあえて行わない
+        */
         // どちらにも該当しない場合
         this.isOther = !this.isImage && !this.isVideo;
     }

--- a/resources/views/commons/upload.blade.php
+++ b/resources/views/commons/upload.blade.php
@@ -14,7 +14,7 @@
     $uploadImageMaxFilesize = config('app.uploadImageMaxFilesize');
 @endphp
 <div class="container" {!! $divContainerStyle !!}>
-    <div id="file-upload-container" style="margin: 20px;"></div>
+    <div id="file-upload-container" style="margin: 10px;"></div>
 
     {{-- アップロード済の画像をクライアントサイドでサムネイル表示のためhrefに指定するURLのベース部分 --}}
     <input id="file-upload-base-path" type="hidden" value="{{ asset('storage') }}" />

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -147,6 +147,9 @@
 
         <script>
             $(document).ready(function() {
+                //ページ内の一番最後の「$(document).ready(function() {」ですべき処理
+                lastReadyProc();
+
                 // スピナーを消す
                 hideSpinner();
             });

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -15,9 +15,8 @@
                 'post' => $post,
                 'enableVideoFlg' => 'ON',
             ])
-            {{-- margin-topをマイナス値にして上に移動させて「画像追加」ボタンの横に表示させている。 --}}
-            <div style="margin-left: 200px; margin-top: -50px; margin-bottom: 20px; color:red;">
-                投稿画像・動画の変更は「更新する」で適用されます。
+            <div style="margin-left: 25px; margin-top: -10px; margin-bottom: 20px; color:red;">
+                「投稿画像・動画、YouTube動画」の変更は「更新する」で適用されます。
             </div>
             <div class="d-flex justify-content-between">
                 <button type="submit" class="btn btn-primary">更新する</button>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -18,7 +18,7 @@
                 <div class="card-header">
 
                     @if ($followsParam->isFollowerIndicatorVisible)
-                        <div class="text-left d-inline-block w-75 mb-2">
+                        <div class="text-left d-inline-block w-75 mb-2" style="color: white;">
                             <i class="fas fa-user"></i>&nbsp;<span>フォローされています</span>
                         </div>
                     @endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,7 +9,7 @@
             <h1><i class="fab fa-telegram fa-lg pr-3"></i>{{ config('app.TopicPostsTitle') }}</h1>
         </div>
     </div>
-    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+    <h5 class="text-center mb-3">「陰謀ねた」について140字以内で会話しよう！</h5>
     @auth
         <div class="w-75 m-auto">@include('commons.error_messages')</div>
         <div class="text-center mb-3">


### PR DESCRIPTION
## issue
- Closes Draft youtube動画をurlで追加しカルーセルでの複数表示対応

upload.jsで、
「画像・動画追加」の右側に
YoutubeのURLを入力し、追加ボタンを押せるUIを追加しました。

アバター画像のアップロードは関係ありません。
下記は、welcome.phpだが、
```
                    @include('commons.upload', [
                        'multiFlg' => 'ON',
                        'editFlg' => 'OFF',
                        'imageType' => 'post',
                        'enableVideoFlg' => 'ON',
                    ])
```
のように、
'enableVideoFlg' => 'ON',
を指定していて
動画のアップロードが可能なモードでのアップロードUIが動作するケースで、
YoutubeのURLを入力し、追加ボタンを押せるUIを追加しました。

さらに、
'multiFlg' => 'ON',
のときは、
↑↓　ボタンをアップロード、追加済のサムネイル画像の左側に表示して
それにて、上下の順番を入れ替えられるようにしました。
DOMにある、順番を入れ替えてるだけです。

純粋にDOMにある順番でリクエストがとんでくるので、
その順番で、db処理は、post_imagesに対するDELETE/INSERTするため
フロントエンド側の実装調整だけで、バックエンドは変更なしで
順番入れ替え機能は対応できた。

順番入れ替えは、投稿編集画面でも機能します。
順番入れ替え、追加、削除
それらについて、
画像のアップロード
動画のアップロード
youtubeのurlでの動画追加
を自由に行って

新規投稿や、編集ができるようにしてます。

バリデーションエラー時も、操作中のUIを復元できてます。

youtubeの追加にあたっては、
post_imagesの
uuidの項目には、
youtube_uuid_marking
という文字列で固定で指定するようにしてます。

file_name項目には、
youtubeId に、.youtube という拡張子での
文字列を作って値してしてます

今、ファイルの種類の判定を拡張子でしているため
そういう値指定のほうが都合がよかった

youtubeのurlを入力し、追加ボタンを押すと
想定しているいくつかのurlのパターンから
youtubeIdを抜き取って処理してます

想定しているurlでなく、抜き取れない場合は、
クライアントのバリデーションエラー時で、
フラッシュとトーストがでます。

youtubeのケースでの
post_imagesのuuidや、file_nameについて、
指定値が、事実上、uuidや、file_nameと異なる値ですが
今までのロジックに溶け込ませるには、こうするのが
最も、簡単だった

それから、
FileType.phpや、common.jsのFileTypeクラスにおいては、
isOtherとなる判定に、isYoutubeでない
というのを含めなかった
ソースコードのコメントにも書いたのですが
画像や、動画のアップロード時のバリデーションチェックに影響させたくないからです。

youtube追加は別ロジックですので、

仮に、もし、*.youtubeという名前のファイルを追加時の
既存のバリデーションエラーとなってほしいため

あえて、
isOtherとなる判定に、isYoutubeでない
というのを含めなかった

以上の考え方にて、実装調整を行ってます。


他、
config/appをいじって、テーマの文言を調整してます。
style.cssをいじって、ヘッダーやフッダーに適用されてた
青っぽい色を、黒に変えてます。

他、
ユーザ詳細のアバター画像部分で、
人型アイコンおよび
フォローされています
の文字について、白にしてます。
背景が黒になってみえなかったから
元々、青っぽい色でも白のほうが見やすいから

## 考慮してほしいこと
だいたいのことは、上で書いたと思います。
後は、ソースコード上のコメントなどを参照いただければと思います。

削除の機能が後回しになり、残りの期間も少なく
手入力でのコマンド実行での運用の可能性も見える関係で
config/app.phpでの対象の絞り時間を短めにしてます。

それから、videoタグのtype属性の抜けの件は、
当プルリクで対応してます

それから、当初、アップロード時や、追加時は、
videoも、iframeのyoutubeもサムネイル画像でなく
その時点では、小さな枠の大きさで再生可能にしようとしていた。
下記の理由により、それはやめました
カルーセルで表示中で再生中のvideoや、iframeのyoutubeについて、
ユーザが動画の停止をせずに、
カルーセルを閉じたり、別のページに切り替えた時に
再生されっぱなしで、裏で音声だけ聞こえるような状況を防ぐために
ページ内の全動画を止めてます
その対応がvideoについて、前のプルリクで入れてたのですが
今回、その対応をiframeのyoutubeでも行うようにした
その時に、
common.jsの
function lastReadyProc() {
の実装部分のコメントにも書いているのであるが
完全にDOM要素が読み込み終わったタイミングで、
「YouTube IFrame API」のonYouTubeIframeAPIReadyのハンドラにて
function procOnYouTubeIframeAPIReady() {
や、
function loadYtPlayer(iframe) {
で、
'onReady': function(event) {
の発火で初期化が完了したYT.Playerのリストを
ytPlayersを保持して
そのytPlayersのリストを通じて
ページ内の動画の停止をしている

問題は、アップロード済のサムネイル画像が
動的にjavascript処理に追加しているものだということです。
これをもし、iframeのyoutubeで、urlから追加時点で再生可能とした時に

MutationObserverというjavascript部品で、DOMの変更イベントを拾って
動的に、ytPlayersのリストのメンテナンスなどして
再生されっぱなしを防ぐ制御などの考慮の話が
ややこしく

それなら、そこは、割愛し
videoも含め、アップロード時点では、サムネイル画像のままとした経緯があります。


以上です。
