### PR TITLE
#1266 コメント機能投稿・表示（しみず）

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -167,4 +167,13 @@ class Controller extends BaseController
     {
         return $user->posts()->orderBy('id', 'desc')->paginate(10);
     }
+
+    //replyのカウント
+    public function replyCounts($post)
+    {
+        $countReplies = $post->replies()->count();
+        return [
+            'countreplies' => $countReplies,
+        ];
+    }
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -34,7 +34,4 @@ class RepliesController extends Controller
         $data += $this->replyCounts($post);
         return view('posts.replies',$data);
     }
-    
-
-
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\ReplyRequest;
+use App\User;
+use App\Post;
+Use App\Reply;
+
+
+class RepliesController extends Controller
+{
+    public function store(ReplyRequest $request)
+    {
+        $reply = new Reply();
+        $reply->comment = $request->comment;
+        $reply->post_id = $request->postId;
+        $reply->user_id = \Auth::user()->id;
+        $reply->save();
+
+        $this->showFlashSuccess("返信しました。");
+        return back();
+    }
+ 
+    public function show($id)
+    {
+        $post = Post::findOrFail($id);
+        $reply = $post->replies()->orderBy('id', 'desc');
+        $data=[
+            'post' => $post,
+            'replies' => $reply,
+        ];
+        $data += $this->replyCounts($post);
+        return view('posts.replies',$data);
+    }
+    
+
+
+}

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'comment' => 'required|max:140',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'comment' => '返信',
+        ];
+    }
+    
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -49,6 +49,11 @@ class Post extends Model
         return $this->hasMany(PostImage::class);
     }
 
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
+
     /**
      * $thisに紐づく「post_images」をorder順に取得
      */

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Reply extends Model
+{
+    protected $fillable = [
+        'comment',
+        'post_id',
+        'user_id',
+    ];
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -124,6 +124,11 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
+
     /**
      * 最新の投稿を1件取得 (投稿なしの場合はnull返却)
      */

--- a/database/migrations/2024_10_03_162115_create_replies_table.php
+++ b/database/migrations/2024_10_03_162115_create_replies_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replies', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('comment');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->timestamps();
+
+            //外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replies');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,5 +14,6 @@ class DatabaseSeeder extends Seeder
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
         $this->call(CategoriesSeeder::class);
+        $this->call(RepliesTableSeeder::class);
     }
 }

--- a/database/seeds/RepliesTableSeeder.php
+++ b/database/seeds/RepliesTableSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class RepliesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $faker = Faker\Factory::create('ja_JP');
+
+        for($i = 1; $i <= 100; $i++){
+            DB::table('replies')->insert([
+                'comment' => $faker->realText(20),
+                'user_id' => rand(1, 29),
+                'post_id' => rand(1, 29),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/resources/views/posts/replies.blade.php
+++ b/resources/views/posts/replies.blade.php
@@ -3,50 +3,52 @@
 @php
     $user = $post->user;
 @endphp
-<div class="text-left d-inline-block w-75 mb-2">
-    @include('commons.avatar', [
-        'editFlg' => 'OFF',
-        'imageSize' => '100',
-        'user' => $user,
-        'class' => 'mr-2 rounded-circle',
-        ])
-    <p class="mt-3 mb-0 d-inline-block align-middle"><a href="{{ route('user.show', $user->id) }}" title="{{ $user->name }}"><span style="font-size: 30px;">{{ $user->truncateName() }}</span></a></p>
-</div>
-<div class="text-left d-inline-block w-75">
-    <p class="text-muted">
-    <span style="font-size: 30px;">{{ $post->content }}</span>
-    </p>
-</div>
-<hr noshade="">
-@foreach ($post->replies as $reply)
-<div class="text-left d-inline-block w-75 mb-2">
-    @include('commons.avatar', [
-        'editFlg' => 'OFF',
-        'imageSize' => '55',
-        'user' => $reply->user,
-        'class' => 'mr-2 rounded-circle',
-        ])
-    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $reply->user->id) }}" title="{{ $reply->user->name }}">{{ $reply->user->truncateName() }}</a></p>
-</div>
-<div class="text-left d-inline-block w-75">
-    <p class="text-muted">
-    {{ $reply->comment }}
-    </p>
-</div>
-@endforeach
-<hr noshade="">
-<p class="text-muted"><span style="font-size: 25px;">
-    この投稿に返信する
-</p></span>
-    @include('commons.error_messages')
-        <form method="POST" action="{{route('reply.store',$post->id )}}">
+    <div class="text-left d-inline-block w-75 mb-2">
+        @include('commons.avatar', [
+            'editFlg' => 'OFF',
+            'imageSize' => '100',
+            'user' => $user,
+            'class' => 'mr-2 rounded-circle',
+            ])
+        <p class="mt-3 mb-0 d-inline-block align-middle"><a href="{{ route('user.show', $user->id) }}" title="{{ $user->name }}"><span style="font-size: 30px;">{{ $user->truncateName() }}</span></a></p>
+    </div>
+    <div class="text-left d-inline-block w-75">
+        <p class="text-muted">
+        <span style="font-size: 30px;">{{ $post->content }}</span>
+        </p>
+    </div>
+    <hr noshade="">
+    @foreach ($post->replies as $reply)
+    <div class="text-left d-inline-block w-75 mb-2">
+        @include('commons.avatar', [
+            'editFlg' => 'OFF',
+            'imageSize' => '55',
+            'user' => $reply->user,
+            'class' => 'mr-2 rounded-circle',
+            ])
+        <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $reply->user->id) }}" title="{{ $reply->user->name }}">{{ $reply->user->truncateName() }}</a></p>
+    </div>
+    <div class="text-left d-inline-block w-75">
+        <p class="text-muted">
+        {{ $reply->comment }}
+        </p>
+    </div>
+    @endforeach
+    <hr noshade="">
+    @auth
+        <p class="text-muted"><span style="font-size: 25px;">
+            この投稿に返信する
+        </p></span>
+        @include('commons.error_messages')
+        <form method="POST" action="{{route('reply.store')}}">
             @csrf
             <div class="form-group">
                 <textarea id="comment" class="form-control" name="comment" rows="5">{{ old('comment') }}</textarea>
             </div>
             <div class="form-group mt-4">
-            <button class="btn btn-success float-right mb-3 mr-3">返信する</button>
+                <button class="btn btn-success float-right mb-3 mr-3">返信する</button>
             </div>
             <input type="hidden" name='postId' value="{{ $post->id }}">
         </form>
+    @endauth
 @endsection

--- a/resources/views/posts/replies.blade.php
+++ b/resources/views/posts/replies.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+@section('content')
+@php
+    $user = $post->user;
+@endphp
+<div class="text-left d-inline-block w-75 mb-2">
+    @include('commons.avatar', [
+        'editFlg' => 'OFF',
+        'imageSize' => '100',
+        'user' => $user,
+        'class' => 'mr-2 rounded-circle',
+        ])
+    <p class="mt-3 mb-0 d-inline-block align-middle"><a href="{{ route('user.show', $user->id) }}" title="{{ $user->name }}"><span style="font-size: 30px;">{{ $user->truncateName() }}</span></a></p>
+</div>
+<div class="text-left d-inline-block w-75">
+    <p class="text-muted">
+    <span style="font-size: 30px;">{{ $post->content }}</span>
+    </p>
+</div>
+<hr noshade="">
+@foreach ($post->replies as $reply)
+<div class="text-left d-inline-block w-75 mb-2">
+    @include('commons.avatar', [
+        'editFlg' => 'OFF',
+        'imageSize' => '55',
+        'user' => $reply->user,
+        'class' => 'mr-2 rounded-circle',
+        ])
+    <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $reply->user->id) }}" title="{{ $reply->user->name }}">{{ $reply->user->truncateName() }}</a></p>
+</div>
+<div class="text-left d-inline-block w-75">
+    <p class="text-muted">
+    {{ $reply->comment }}
+    </p>
+</div>
+@endforeach
+<hr noshade="">
+<p class="text-muted"><span style="font-size: 25px;">
+    この投稿に返信する
+</p></span>
+    @include('commons.error_messages')
+        <form method="POST" action="{{route('reply.store',$post->id )}}">
+            @csrf
+            <div class="form-group">
+                <textarea id="comment" class="form-control" name="comment" rows="5">{{ old('comment') }}</textarea>
+            </div>
+            <div class="form-group mt-4">
+            <button class="btn btn-success float-right mb-3 mr-3">返信する</button>
+            </div>
+            <input type="hidden" name='postId' value="{{ $post->id }}">
+        </form>
+@endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -64,18 +64,20 @@
                     <div class="row">
                         <div class="col-6 px-4 pt-3">
                             @if ($post->replies->count())
-                            <a href="{{ route('reply.show', $post->id, $user->id) }}">
+                            <a href="{{ route('reply.show', $post->id) }}">
                                 返信 {{$post->replies->count()}}件
                             </a>
                             @else
                             <a>返信はまだありません。</a>
                             @endif
                         </div>
-                        <div class="col-6 px-4 pt-3"> 
-                        <button type="button" class="btn btn-primary">
-                            <a class="text-decoration-none" href="{{ route('reply.show', $post->id, $user->id) }}" style="color:white;">返信する</a>
-                        </button>
-                        </div>
+                        @auth
+                            <div class="col-6 px-4 pt-3"> 
+                            <button type="button" class="btn btn-primary">
+                                <a class="text-decoration-none" href="{{ route('reply.show', $post->id) }}" style="color:white;">返信する</a>
+                            </button>
+                            </div>
+                        @endauth
                     </div>
                 </div>
             </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -60,6 +60,24 @@
                         <a href="{{ route('post.edit', ['id' => $post->id] + $previousUrlParameter) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
+                <div class="card bg-light d-inline-block w-75 px-5 pt-0 pb-3">
+                    <div class="row">
+                        <div class="col-6 px-4 pt-3">
+                            @if ($post->replies->count())
+                            <a href="{{ route('reply.show', $post->id, $user->id) }}">
+                                返信 {{$post->replies->count()}}件
+                            </a>
+                            @else
+                            <a>返信はまだありません。</a>
+                            @endif
+                        </div>
+                        <div class="col-6 px-4 pt-3"> 
+                        <button type="button" class="btn btn-primary">
+                            <a class="text-decoration-none" href="{{ route('reply.show', $post->id, $user->id) }}" style="color:white;">返信する</a>
+                        </button>
+                        </div>
+                    </div>
+                </div>
             </div>
         @endif
     </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,16 +58,21 @@ Route::group(['middleware' => 'auth'], function() {
         // 編集・更新
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
-        //返信画面
-        Route::get('{id}/replies', 'RepliesController@show')->name('reply.show');
-        //返信投稿
-        Route::post('{id}/replies','RepliesController@store')->name('reply.store');
     });
 
     // 「フォロー」
     Route::group(['prefix' => 'follows/{id}'],function(){
         Route::post('follow', 'FollowsController@store')->name('follow');
         Route::delete('unfollow', 'FollowsController@destroy')->name('unfollow');
+    });
+});
+
+//返信画面
+Route::prefix('replies')->group(function () {
+    Route::get('{id}', 'RepliesController@show')->name('reply.show');
+//投稿
+    Route::group(['middleware' => 'auth'], function () {
+        Route::post('','RepliesController@store')->name('reply.store');
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,10 @@ Route::group(['middleware' => 'auth'], function() {
         // 編集・更新
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
+        //返信画面
+        Route::get('{id}/replies', 'RepliesController@show')->name('reply.show');
+        //返信投稿
+        Route::post('{id}/replies','RepliesController@store')->name('reply.store');
     });
 
     // 「フォロー」


### PR DESCRIPTION
## issue
- Closes #1266 

## 概要
- 返信投稿・表示

## 動作確認手順
- 下記コマンドを実行
```
docker exec laravel_app bash -c "cd /var/www/html/laravelapp && php artisan migrate --seed"
```
- Adminerにて`reply`テーブルに100個のレコードが追加されることを確認
http://localhost:8088/?server=db&username=dbuser&db=laraveldb&select=replies
- ユーザ30には返信は入れていないため、返信はありませんが表示される
その後、返信するボタンで返信ができ、表示されるの
トップページにて返信の数が増えていることを確認

###考慮して欲しいこと
- 非表示ファイルと他の人が上げたファイルまでプルリクに上がってしまいました