### PR TITLE
#1246 検索機能 (おおつき)

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -597,4 +597,35 @@ class Helper
     }
 
     /* #endregion */ // YouTube関連
+
+    /* #region 検索クエリ */
+
+    /**
+     * 検索クエリ共通化
+     */
+    public function commonSearch($argQuery, $column, $keyword, $strCategoryId = "")
+    {
+        $query = null;
+        if($keyword) {
+            $escapedKeyword  = str_replace(['\\', '%', '_'], ['\\\\\\', '\%', '\_'], $keyword);
+            $query = $argQuery->where($column, 'LIKE', '%' . $escapedKeyword . '%');
+        } else {
+            $query = $argQuery;
+        }
+
+        if($strCategoryId) {
+            $categoryId = intval($strCategoryId);
+
+            $query = $query->join('category_post', "posts.id", '=', 'category_post.post_id')
+                            ->where('category_post.category_id', $categoryId)
+                            ->select('posts.*');
+        }
+
+        return $query->orderBy('id', 'desc')
+                ->paginate(10)
+                ->appends(['q' => $keyword, 'c' => $strCategoryId, ]);
+    }
+
+    /* #endregion */ // 検索クエリ
+
 }

--- a/app/Helpers/ViewHelper.php
+++ b/app/Helpers/ViewHelper.php
@@ -3,6 +3,7 @@
 namespace App\Helpers;
 
 use Thomaswelton\LaravelGravatar\Facades\Gravatar;
+use App\Category;
 
 /**
  * viewの処理のヘルパークラス
@@ -335,6 +336,41 @@ class ViewHelper extends Helper
             $ret = 'checked';
         }
 
+        return $ret;
+    }
+
+    /**
+     * 検索結果画面などに表示する検索条件の文字列を取得する。
+     */
+    public function getSearchConditionString($q, $c) {
+        $ret = "";
+
+        $joinString = "";
+        if($q && $c) {
+            $joinString = ", ";
+        }
+
+        if($q) {
+            $ret .= "キーワード: " . $q;
+        }
+
+        $ret .= $joinString;
+
+        if($c) {
+            $categoryId = intval($c);
+            $category = Category::findOrFail($categoryId);
+
+            $ret .= "カテゴリ: " . $category->name;
+        }
+
+        return $ret;
+    }
+
+    /**
+     * 検索結果がない時に表示する文字列を取得する。
+     */
+    public function getSearchNotFoundString() {
+        $ret = '(´・ω・｀)見つかりませんでした。';
         return $ret;
     }
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -174,4 +174,26 @@ class PostsController extends Controller
 
         return redirect($request->previousUrl);
     }
+
+    /**
+     * 投稿内容を検索する。
+     */
+    public function search(Request $request)
+    {
+        $q = trim($request->input('q'));
+        $c = trim($request->input('c'));
+        if (filled($q) || filled($c)) {
+            $helper = Helper::getInstance();
+            $postQuery = Post::query();
+            $posts = $helper->commonSearch($postQuery, 'content', $q, $c);
+        } else {
+            return back();
+        }
+
+        return view('searches.results', [
+            'posts' => $posts,
+            'q' => $q,
+            'c' => $c,
+        ]);
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -215,4 +215,27 @@ class UsersController extends Controller
             'toggleOnOff' => $request->toggleOnOff,
         ]);
     }
+
+    /**
+     * ユーザ名を検索する。
+     */
+    public function search(Request $request)
+    {
+        $q = trim($request->input('q'));
+        // ユーザはカテゴリでの絞りはないけどパラメータを引き継ぐために取得をしておく
+        $c = trim($request->input('c'));
+        if (filled($q)) {
+            $helper = Helper::getInstance();
+            $userQuery = User::query();
+            $users = $helper->commonSearch($userQuery, 'name', $q);
+        } else {
+            return back();
+        }
+
+        return view('searches.results', [
+            'users' => $users,
+            'q' => $q,
+            'c' => $c,
+        ]);
+    }
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,8 +1,54 @@
 body {
+    /* フッターを下部に固定、class="d-flex flex-column"を適用 */
     min-height: 100vh;
 }
 
 /* bootstrapのbg-infoの背景色を置き換える */
 .bg-info {
     background-color: black !important;
+}
+
+/* 子要素の検索inputがfocusされたら親要素もfocusする */
+#search-bar:focus-within {
+    outline: auto;
+    /* for Chrome */
+    outline: auto -webkit-focus-ring-color;
+}
+
+/* 検索inputのスタイルをリセット、focusされたらでるoutlineをなくす */
+#search {
+    padding: 0;
+    margin: 0;
+    border: 0;
+    outline: 0;
+}
+
+@media screen and (max-width: 575px) {
+    #search-form {
+        padding-top: .5rem;
+        padding-bottom: .5rem;
+    }
+}
+
+@media screen and (min-width: 576px) {
+    #nav-item-search {
+        display: flex;
+        align-items: center;
+    }
+
+    #search-form {
+        padding-right: .5rem;
+    }
+}
+
+@media screen and (min-width: 768px) {
+    #search-bar {
+        width: 320px;
+    }
+}
+
+@media screen and (min-width: 1200px) {
+    #search-bar {
+        width: 500px;
+    }
 }

--- a/resources/views/commons/categories_links.blade.php
+++ b/resources/views/commons/categories_links.blade.php
@@ -6,7 +6,7 @@
         <ul>
             @foreach ($categories as $category)
                 <li>
-                    <a href="#">{{ $category->name }}</a>
+                    <a href="{{ route('post.search')}}?c={{ $category->id }}">{{ $category->name }}</a>
                 </li>
             @endforeach
         </ul>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -7,6 +7,20 @@
         <div class="collapse navbar-collapse" id="nav-bar">
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
+
+                @unless (Request::routeIs('signup') || Request::routeIs('login'))
+                    <li class="nav-item" id="nav-item-search">
+                        <form method="GET" action="{{ route('post.search')}}" id="search-form">
+                            <div class="form-group m-0">
+                                <div id="search-bar" class="form-control form-control-sm d-flex align-items-center p-0">
+                                    <label for="search" class="text-dark px-2 m-0"><i class="fas fa-search"></i></label>
+                                    <input id="search" type="search" name="q" value="{{ request('q') }}" placeholder="検索" autocomplete="off" class="flex-grow-1">
+                                </div>
+                            </div>
+                        </form>
+                    </li>
+                @endunless
+
                 @if (Auth::check())
                     <li class="nav-item"><a href="{{ route('user.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                     <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>

--- a/resources/views/posts/search.blade.php
+++ b/resources/views/posts/search.blade.php
@@ -1,0 +1,15 @@
+@if ($posts->isNotEmpty())
+    @foreach ($posts as $post)
+        @php
+            $user = $post->user;
+            //「$followsParam」を作成する。
+            $followsParam = $viewHelper->createFollowsParam($user);
+        @endphp
+        @include('posts.show', ['user' => $user, 'post' => $post, 'followsParam' => $followsParam])
+    @endforeach
+    <div class="m-auto" style="width: fit-content">
+        {{ $posts->links('pagination::bootstrap-4') }}
+    </div>
+@else
+    <h5 class="text-center mt-5">{{ $viewHelper->getSearchNotFoundString() }}</h5>
+@endif

--- a/resources/views/searches/results.blade.php
+++ b/resources/views/searches/results.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+@section('content')
+    @php
+        require_once app_path('Helpers/ViewHelper.php');
+        $viewHelper = \App\Helpers\ViewHelper::getInstance();
+
+        $isActivePostsSearch = Request::routeIs('post.search');
+        $isActiveUsersSearch = Request::routeIs('user.search');
+    @endphp
+    <h5 class="text-center mb-3">「{{ $viewHelper->getSearchConditionString($q, $c) }}」の検索結果</h5>
+    <ul class="nav nav-tabs nav-justified mb-3">
+        <li class="nav-item"><a href="{{ route('post.search', ['q' => $q, 'c' => $c,]) }}" class="nav-link {{ $isActivePostsSearch ? 'active' : '' }}">ポスト</a></li>
+        <li class="nav-item">
+            @if ($q)
+                {{-- キーワードの検索条件がある時：ユーザーのタブ切替ができる --}}
+                <a href="{{ route('user.search', ['q' => $q, 'c' => $c,]) }}" class="nav-link {{ $isActiveUsersSearch ? 'active' : '' }}">ユーザー</a>
+            @else
+                {{-- キーワードの検索条件がない時：ユーザーのタブ切替ができない --}}
+                <a href="#" style="cursor: not-allowed;" title="カテゴリでのユーザーの検索結果の表示はできない">ユーザー</a>
+            @endif
+        </li>
+    </ul>
+
+    @if ($isActivePostsSearch)
+        @include('posts.search', ['posts' => $posts])
+    @endif
+
+    @if ($isActiveUsersSearch)
+        @include('users.search', ['users' => $users])
+    @endif
+
+@endsection

--- a/resources/views/users/search.blade.php
+++ b/resources/views/users/search.blade.php
@@ -1,0 +1,5 @@
+@if ($users->isNotEmpty())
+    @include('users.follows', ['users' => $users])
+@else
+    <h5 class="text-center mt-5">{{ $viewHelper->getSearchNotFoundString() }}</h5>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,10 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
+// 検索
+Route::get('posts/search', 'PostsController@search')->name('post.search');
+Route::get('users/search', 'UsersController@search')->name('user.search');
+
 // ユーザ
 Route::group(['prefix' => 'users/{id}'],function(){
 


### PR DESCRIPTION
## issue
- Closes #1246 

## 概要
- 検索機能

## 動作確認手順

**検索キーワード入力フォーム関連**
- 検索キーワード入力フォームは共通ヘッダー内にあり、ログイン画面と新規ユーザ登録画面では非表示になることを確認
- キーワード送信はSubmitボタンがないので、PCではEnterまたはReturnする
- ブラウザの画面幅によって入力フォーム幅もレスポンシブに変化を確認

**検索結果画面関連**
- 検索結果画面は「ポスト」と「ユーザー」タブで表示されることを確認（初回遷移時はポスト表示、ユーザー非表示）
- 検索結果は投稿内容とユーザー名に対して、キーワードによるLIKE句あいまい検索が行われていることを確認
- 各タブを押下時にキーワードで検索されることを確認
- ページネーションのリンク先でキーワードを保持しながら、検索結果の続きに遷移できることを確認
- 検索結果がない場合は専用メッセージが表示されることを確認

**カテゴリ絞り込み検索関連**
- 投稿内のカテゴリが押下されたら、同じカテゴリが指定されている投稿一覧が表示できていることを確認
- カテゴリでの絞り込み検索結果はポストタブみの表示で、ユーザータブは押下できないことを確認