### PR TITLE
改行コードをbrタグに変更しつつurlをaタグにするのを部品化しつつ投稿内容と返信内容の表示で適用させて投稿と返信の最大文字数を設定値化してバリデーションチェックに適用させる(大川)

### DIFF
--- a/app/Helpers/ViewHelper.php
+++ b/app/Helpers/ViewHelper.php
@@ -382,4 +382,15 @@ class ViewHelper extends Helper
         $ret = [ 'previousUrl' => urlencode(\Request::fullUrl()) ];
         return $ret;
     }
+
+    /**
+     * 文字列中のurlを_blankのaタグに変換する。
+     */
+    function toLink($content)
+    {
+        $pat = '/((http|https):\/\/[-_.!~*\'()a-zA-Z0-9;\/?:@&=+$,%#]+)/';
+        $replace = '<a href="$1" target="_blank">$1</a>';
+        $ret = preg_replace($pat, $replace, $content);
+        return $ret;
+    }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -23,8 +23,9 @@ class PostRequest extends FormRequest
      */
     public function rules()
     {
+        $contentMaxLength = config('app.contentMaxLength');
         return [
-            'content' => 'required|max:140',
+            'content' => "required|max:{$contentMaxLength}",
         ];
     }
 

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -23,8 +23,9 @@ class ReplyRequest extends FormRequest
      */
     public function rules()
     {
+        $contentMaxLength = config('app.contentMaxLength');
         return [
-            'comment' => 'required|max:140',
+            'comment' => "required|max:{$contentMaxLength}",
         ];
     }
 

--- a/config/app.php
+++ b/config/app.php
@@ -280,7 +280,7 @@ return [
         投稿内容の最大文字数
 
         2024/10/15時点
-        postsのcontenがvarchar(255)
+        postsのcontentがvarchar(255)
         repliesのcommentがvarchar(255)
         だから一旦、255にしたが
         本当はもっと増やしたいが、一旦は、255にしとく

--- a/config/app.php
+++ b/config/app.php
@@ -275,4 +275,15 @@ return [
 
     // CleanupUnusedFiles.phpでのtype毎の処理件数
     'cleanupUnusedFilesTakeCount' => env('CLEANUP_UNUSED_FILES_TAKE_COUNT', 100),
+
+    /*
+        投稿内容の最大文字数
+
+        2024/10/15時点
+        postsのcontenがvarchar(255)
+        repliesのcommentがvarchar(255)
+        だから一旦、255にしたが
+        本当はもっと増やしたいが、一旦は、255にしとく
+    */
+    'contentMaxLength' => env('CONTENT_MAX_LENGTH', '255'),
 ];

--- a/resources/views/commons/show_content.blade.php
+++ b/resources/views/commons/show_content.blade.php
@@ -2,8 +2,8 @@
     nl2br(e($currentContent))
     で改行コードをbrタグに変更するなどして
     それでも残った文字列について、「$viewHelper->toLink()」を行うことで
-    改行はweb画面上見えつつも、http://や、https://などについては、_blankする
-    *.blade.phpの実装を、当コンポーネントで部品化する。
+    改行はweb画面上見えつつも、http://や、https://などについては、_blank指定のaタグに変換する。
+    上記のの実装を、当コンポーネントで部品化する。
 --}}
 @php
     require_once app_path('Helpers/ViewHelper.php');

--- a/resources/views/commons/show_content.blade.php
+++ b/resources/views/commons/show_content.blade.php
@@ -1,0 +1,12 @@
+{{-- 
+    nl2br(e($currentContent))
+    で改行コードをbrタグに変更するなどして
+    それでも残った文字列について、「$viewHelper->toLink()」を行うことで
+    改行はweb画面上見えつつも、http://や、https://などについては、_blankする
+    *.blade.phpの実装を、当コンポーネントで部品化する。
+--}}
+@php
+    require_once app_path('Helpers/ViewHelper.php');
+    $viewHelper = \App\Helpers\ViewHelper::getInstance();
+@endphp
+{!! $viewHelper->toLink( nl2br(e($currentContent)) ) !!}

--- a/resources/views/posts/replies.blade.php
+++ b/resources/views/posts/replies.blade.php
@@ -14,7 +14,7 @@
     </div>
     <div class="text-left d-inline-block w-75">
         <p class="text-muted">
-        <span style="font-size: 30px;">{{ $post->content }}</span>
+        <span style="font-size: 30px;">@include('commons.show_content', ['currentContent' => $post->content, ])</span>
         </p>
     </div>
     <hr noshade="">
@@ -30,7 +30,7 @@
     </div>
     <div class="text-left d-inline-block w-75">
         <p class="text-muted">
-        {{ $reply->comment }}
+        @include('commons.show_content', ['currentContent' => $reply->comment, ])
         </p>
         @if(Auth::id() === $reply->user_id)
             <form method="POST" action="{{ route('reply.delete', $reply->id) }}">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -42,7 +42,7 @@
             <div class="">
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2"></p>
-                    <p class="text-muted">{!! nl2br(e($post->content)) !!}</p>
+                    <p class="text-muted">@include('commons.show_content', ['currentContent' => $post->content, ])</p>
                     @include('commons.carousel', ['post' => $post])
                     @include('commons.categories_links', ['post' => $post])
                     <p class="text-muted">{{ $post->created_at }}</p>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,7 +9,7 @@
             <h1><i class="fab fa-telegram fa-lg pr-3"></i>{{ config('app.TopicPostsTitle') }}</h1>
         </div>
     </div>
-    <h5 class="text-center mb-3"><img src="{{ asset('img/tamori.png') }}" style="margin-top: -5px;" alt="Tamori">な気分の話題について{{ $contentMaxLength = config('app.contentMaxLength') }}字以内で会話しよう！</h5>
+    <h5 class="text-center mb-3"><img src="{{ asset('img/tamori.png') }}" style="margin-top: -5px;" alt="Tamori">な気分の話題について{{ config('app.contentMaxLength') }}字以内で会話しよう！</h5>
     @auth
         <div class="w-75 m-auto">@include('commons.error_messages')</div>
         <div class="text-center mb-3">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,7 +9,7 @@
             <h1><i class="fab fa-telegram fa-lg pr-3"></i>{{ config('app.TopicPostsTitle') }}</h1>
         </div>
     </div>
-    <h5 class="text-center mb-3"><img src="{{ asset('img/tamori.png') }}" style="margin-top: -5px;" alt="Tamori">な気分の話題について140字以内で会話しよう！</h5>
+    <h5 class="text-center mb-3"><img src="{{ asset('img/tamori.png') }}" style="margin-top: -5px;" alt="Tamori">な気分の話題について{{ $contentMaxLength = config('app.contentMaxLength') }}字以内で会話しよう！</h5>
     @auth
         <div class="w-75 m-auto">@include('commons.error_messages')</div>
         <div class="text-center mb-3">


### PR DESCRIPTION
## issue
- Closes 改行コードをbrタグに変更しつつurlをaタグにするのを部品化しつつ投稿内容と返信内容の表示で適用させて投稿と返信の最大文字数を設定値化してバリデーションチェックに適用させる(大川)

対応内容は、まさに、
コミットコメントのとおり
です。


「改行コードをbrタグに変更しつつ」
は、
nl2br(e($currentContent))
のこと

「urlをaタグにするのを」
は、
ViewHelper.php
の
function toLink($content)
のこと

「部品化しつつ」
は、
show_content.blade.php
のこと

「投稿内容と返信内容の表示で適用させて」
は、
投稿内容や、返信内容の表示部で
@include('commons.show_content', [
を使ってる箇所のこと

「投稿と返信の最大文字数を設定値化して」
は、
config/app.php
の
```
    /*
        投稿内容の最大文字数

        2024/10/15時点
        postsのcontenがvarchar(255)
        repliesのcommentがvarchar(255)
        だから一旦、255にしたが
        本当はもっと増やしたいが、一旦は、255にしとく
    */
    'contentMaxLength' => env('CONTENT_MAX_LENGTH', '255'),
```
のこと

「バリデーションチェックに適用させる」
は、
ReplyRequest.php
と
PostRequest.php
の
public function rules()
での利用箇所のこと。

以上
