### PR TITLE
投稿内容と返信内容の半角スペースの表示対応、および、返信画面での戻るボタン対応(大川)

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -27,9 +27,14 @@ class RepliesController extends Controller
     {
         $post = Post::findOrFail($id);
         $reply = $post->replies()->orderBy('id', 'desc');
+
+        // クエリパラメータに乗ってる遷移元のURLを取得する。
+        $previousUrl = $this->getPreviousUrlByQueryParameter();
+
         $data=[
             'post' => $post,
             'replies' => $reply,
+            'previousUrl' => $previousUrl,
         ];
         $data += $this->replyCounts($post);
         return view('posts.replies',$data);

--- a/resources/views/commons/show_content.blade.php
+++ b/resources/views/commons/show_content.blade.php
@@ -1,12 +1,16 @@
 {{-- 
     nl2br(e($currentContent))
     で改行コードをbrタグに変更するなどして
-    それでも残った文字列について、「$viewHelper->toLink()」を行うことで
+    それでも残った文字列について、「$viewHelper->convShowContent()」を行うことで
     改行はweb画面上見えつつも、http://や、https://などについては、_blank指定のaタグに変換する。
-    上記のの実装を、当コンポーネントで部品化する。
+    さらに、半角スペースもweb上、textareで入力した時の値と同様に見えるように対処する。
+    それを「  デフォルトのfont-sizeや、継承元のfont-sizeが変わってしまう  」preタグを使わずに実現する。
+    上記の実装を、当コンポーネントで部品化する。
+    他の様々な問題点が将来あったとしても、ViewHelper.phpなどを総動員して利用コードの修正なしで
+    吸収して解決可能な布石を作るため部品化する。
 --}}
 @php
     require_once app_path('Helpers/ViewHelper.php');
     $viewHelper = \App\Helpers\ViewHelper::getInstance();
 @endphp
-{!! $viewHelper->toLink( nl2br(e($currentContent)) ) !!}
+{!! $viewHelper->convShowContent( nl2br(e($currentContent)) ) !!}

--- a/resources/views/posts/replies.blade.php
+++ b/resources/views/posts/replies.blade.php
@@ -52,8 +52,18 @@
             <div class="form-group">
                 <textarea id="comment" class="form-control" name="comment" rows="5">{{ old('comment') }}</textarea>
             </div>
-            <div class="form-group mt-4">
-                <button class="btn btn-success float-right mb-3 mr-3">返信する</button>
+
+            {{-- 
+                2024/10/15
+                それでいいかは別として、投稿編集画面にあわせ「戻る」を右に一旦する。
+                「返信する」のclass属性より「float-right」を一旦削除
+                「返信する」と「戻る」縦の位置がそろわなかったため
+                devの「class="form-group mt-4"」を「class="d-flex justify-content-between"」に変更した
+                「戻る」に「style="height: 38px;"」を書いておかないとデザイン崩れる。38pxは微調整の結果。
+            --}}
+            <div class="d-flex justify-content-between">
+                <button class="btn btn-success mb-3 mr-3">返信する</button>
+                <a href="{{ $previousUrl }}" class="btn btn-info" style="margin-top: -2px; width: 95px; height: 38px;">戻る</a>
             </div>
             <input type="hidden" name='postId' value="{{ $post->id }}">
         </form>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -9,7 +9,6 @@
 
     $previousUrlParameter = $viewHelper->getPreviousUrlParameter();
 @endphp
-
 <ul class="list-unstyled">
 
     <li class="mb-3 text-center">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -6,7 +6,10 @@
         // 「$followsParam」が未定義の場合(呼び元で指定がない場合)は、デフォルト値を指定
         $followsParam = \App\User::createDefaultFollowsParam();
     }
+
+    $previousUrlParameter = $viewHelper->getPreviousUrlParameter();
 @endphp
+
 <ul class="list-unstyled">
 
     <li class="mb-3 text-center">
@@ -54,9 +57,6 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        @php
-                            $previousUrlParameter = $viewHelper->getPreviousUrlParameter();
-                        @endphp
                         <a href="{{ route('post.edit', ['id' => $post->id] + $previousUrlParameter) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
@@ -74,7 +74,7 @@
                         @auth
                             <div class="col-6 px-4 pt-3"> 
                             <button type="button" class="btn btn-primary">
-                                <a class="text-decoration-none" href="{{ route('reply.show', $post->id) }}" style="color:white;">返信する</a>
+                                <a class="text-decoration-none" href="{{ route('reply.show', [$post->id] + $previousUrlParameter) }}" style="color:white;">返信する</a>
                             </button>
                             </div>
                         @endauth


### PR DESCRIPTION
## issue
- Closes 投稿内容と返信内容の半角スペースの表示対応、および、返信画面での戻るボタン対応

対応内容は、まさに、
コミットコメントのとおり
です。

投稿内容と返信内容の半角スペースの表示対応
と、
返信画面での戻るボタン対応

です。

ただし、半角スペース対応については、
途中の半角スペースは対応できたが
開始、終了の位置の半角スペースは対応できてない

実装的にも、そこは、ぬけがあるようには見えた。

が、しかし、それ以前に、

そもそも、リクエストデータがトリミングされていることが
デバッガーでの調査でわかった。

これは、なぜかというとおそらく、

app/Http/Kernel.php

にて、

```
    protected $middleware = [
        \App\Http\Middleware\TrustProxies::class,
        \App\Http\Middleware\CheckForMaintenanceMode::class,
        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
        \App\Http\Middleware\TrimStrings::class,
        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
    ];
```

に、
\App\Http\Middleware\TrimStrings::class,

があるからと思われる

★それを除いたら他に影響あるのかなどがあり、安直に消せない★

よって、
テキストエリアでの開始位置、終了位置についての半角スペースについては、
今回の実装では対応できていない

しかし、それをやろうとすると、
調査なども含め大変になりそうなので一旦、今回は保留とした。

＜追記：補足説明＞
textエリアで前後に半角スペース入れても
PostsController.php
の
store()や、update()
や、
RepliesController
の
store()
に来た時に、
リクエストの値がトリミングされて
トリミングされた値でDB保存されている





show_content.blade.phpの内部で、吸収可能性が高い構造に前プルリクで対応できているため

また、

機会があれば、調査ということにした。




戻る　も、戻り先について、urlだけでなく、画面の縦スクロール位置も引き回して
元の画面で、そして、縦スクロール位置まであわして、今まさに、編集してた
投稿、または、返信　について、ユーザが見てる位置にピタッと画面表示までできたら最高レベルだけど
そこまで、やろうとすると、また、大変なので
一旦は、保留ということにした。
