### PR TITLE
#127　フォロー機能（小宮山）

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    public function store($id)
+    {
+        \Auth::user()->follow($id);
+        return back();
+    }
+
+    public function destroy($id)
+    {
+        \Auth::user()->unfollow($id);
+        return back();
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,46 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    // フォロワーを取得
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'follows', 'following_id', 'follower_id');
+    }
+
+    // ユーザーがフォローしている人を取得
+    public function followings()
+    {
+        return $this->belongsToMany(User::class, 'follows', 'follower_id', 'following_id');
+    }
+
+    // フォローする
+    public function follow($userId)
+    {
+        $exist = $this->isFollowing($userId);
+        if ($exist) {
+            return false;
+        } else {
+            $this->followings()->attach($userId);
+            return true;
+        }
+    }
+
+    // フォロー解除
+    public function unfollow($userId)
+    {
+        $exist = $this->isFollowing($userId);
+        if ($exist) {
+            $this->followings()->detach($userId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // フォローしているかどうか確認
+    public function isFollowing($userId)
+    {
+        return $this->followings()->where('following_id', $userId)->exists();
+    }
 }

--- a/database/migrations/2024_11_02_152851_create_follows_table.php
+++ b/database/migrations/2024_11_02_152851_create_follows_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('follower_id')->unsigned()->index(); //フォローする側
+            $table->bigInteger('following_id')->unsigned()->index(); //フォローされる側
+            $table->timestamps();
+
+            // 外部キー制約
+            $table->foreign('follower_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('following_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['follower_id', 'following_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,0 +1,14 @@
+@if (Auth::check() && Auth::id() !== $user->id)
+    @if (Auth::user()->isFollowing($user->id))
+        <form method="POST" action="{{ route('user.unfollow', $user->id) }}">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">フォローを外す</button>
+        </form>
+    @else
+        <form method="POST" action="{{ route('user.follow', $user->id) }}">
+            @csrf
+            <button type="submit" class="btn btn-success">フォローする</button>
+        </form>
+    @endif
+@endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -15,6 +15,9 @@
                         @endif
                 </div>
             </div>
+            <div class="mt-2">
+                @include('follow.follow_button', ['user' => $user])
+            </div>
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,4 +31,10 @@ Route::group(['middleware' => 'auth'], function(){
         // 投稿編集処理
         Route::put('{id}/edit', 'PostsController@update')->name('post.update');
     });
+
+    // フォロー機能
+    Route::group(['prefix' => 'users/{id}'], function(){
+        Route::post('follow', 'FollowController@store')->name('user.follow');
+        Route::delete('unfollow', 'FollowController@destroy')->name('user.unfollow');
+    });
 });


### PR DESCRIPTION
## issue
 - Closes #127 

## 概要
 - フォロー機能（フォローボタンの作成まで）

## 動作確認手順
 - user1でログインする
メールアドレス：user1@test.com  
パスワード：password

 - ログインしているユーザー（user1）以外のユーザー詳細ページへアクセスする
 - ユーザーアイコン下の「フォローする」ボタンをクリックする
 <img width="400" alt="スクリーンショット 2024-11-04 15 04 26" src="https://github.com/user-attachments/assets/f357a0d3-f7ad-4183-a0f5-bd3abf2cce04">

- 「フォローする」ボタンが「フォローを外す」に変わることを確認

 - Adminerでfollowsテーブルにレコードが追加されていることを確認
http://localhost:8088/

 - 「フォローを外す」ボタンをクリックする
 - 「フォローを外す」ボタンが「フォローする」に変わることを確認
 - Adminerでfollowsテーブルの対象のレコードが消えていることを確認
http://localhost:8088/

## 考慮してほしいこと
特にありません

## 確認してほしいこと
特にありません