### PR TITLE
コメント機能と投稿詳細画面の実装（いずみ）

### DIFF
--- a/app/Comment.php
+++ b/app/Comment.php
@@ -5,17 +5,17 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class Post extends Model
+class Comment extends Model
 {
-    use SoftDeletes;
+    protected $fillable = ['body', 'user_id', 'post_id'];
 
     public function user()
     {
         return $this->belongsTo(User::class);
     }
 
-    // public function comments()
-    // {
-    //     return $this->hasMany(Comments::class);
-    // }
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
 }

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Comment;
+use App\Post;
 
 class CommentController extends Controller
 {
@@ -18,6 +20,6 @@ class CommentController extends Controller
         $comment->post_id = $post->id;
         $comment->save();
 
-        return redirect()->ruote('search.index', $post->id);
+        return redirect()->route('post.show', $post->id);
     }
 }

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class CommentController extends Controller
+{
+    public function store(Request $request, Post $post)
+    {
+        $request->validate([
+            'body' => 'required|string|max:140',
+        ]);
+
+        $comment = new Comment();
+        $comment->body = $request->body;
+        $comment->user_id = auth()->id();
+        $comment->post_id = $post->id;
+        $comment->save();
+
+        return redirect()->ruote('search.index', $post->id);
+    }
+}

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -18,6 +18,7 @@ class PostsController extends Controller
         ]);
         abort(403);
     }
+    
     public function edit($id)
     {
         $post = Post::findOrFail($id);

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -9,6 +9,15 @@ use App\User;
 
 class PostsController extends Controller
 {
+    public function show($id)
+    {
+        $post = Post::findOrFail($id);
+        
+        return view('posts.show', [
+            'post' => $post,
+        ]);
+        abort(403);
+    }
     public function edit($id)
     {
         $post = Post::findOrFail($id);

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -13,7 +13,9 @@ class SearchController extends Controller
         $keyword = $request->input('keyword');
 
         $posts = Post::withCount('comments')->orderBy('id', 'desc');
-        $users = User::withCount('comments')->orderBy('id', 'desc');
+        $users = User::with(['posts' => function ($query) {
+            $query->withCount('comments');}])
+            ->orderBy('id', 'desc');
 
         if ($keyword !== null) {
             $posts->where('content', 'like', '%' . $keyword . '%');

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -12,18 +12,16 @@ class SearchController extends Controller
     {
         $keyword = $request->input('keyword');
 
-        $posts = Post::orderBy('id', 'desc');
-        $users = User::orderBy('id', 'desc');
+        $posts = Post::withCount('comments')->orderBy('id', 'desc');
+        $users = User::withCount('comments')->orderBy('id', 'desc');
 
-        if ($keyword) {
+        if ($keyword !== null) {
             $posts->where('content', 'like', '%' . $keyword . '%');
             $users->where('name', 'like', '%' . $keyword . '%');
         }
 
         $posts = $posts->paginate(10)->appends(['keyword' => $keyword]);
         $users = $users->paginate(10)->appends(['keyword' => $keyword]);
-
-        $posts = Post::withCount('comments')->orderBy('id', 'desc')->paginate(10); // コメント数の表示
 
         return view('welcome', [
             'posts' => $posts,

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -14,8 +14,8 @@ class SearchController extends Controller
 
         $posts = Post::withCount('comments')->orderBy('id', 'desc');
         $users = User::with(['posts' => function ($query) {
-            $query->withCount('comments');}])
-            ->orderBy('id', 'desc');
+            $query->withCount('comments');
+        }])->orderBy('id', 'desc');
 
         if ($keyword !== null) {
             $posts->where('content', 'like', '%' . $keyword . '%');

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -23,6 +23,8 @@ class SearchController extends Controller
         $posts = $posts->paginate(10)->appends(['keyword' => $keyword]);
         $users = $users->paginate(10)->appends(['keyword' => $keyword]);
 
+        $posts = Post::withCount('comments')->orderBy('id', 'desc')->paginate(10); // コメント数の表示
+
         return view('welcome', [
             'posts' => $posts,
             'users' => $users,

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -13,7 +13,7 @@ class UsersController extends Controller
     public function show($id, Request $request)
     {
         $user = User::findOrFail($id);
-        $posts = $user->posts()->orderBy('id', 'desc')->paginate(10);
+        $posts = $user->posts()->withCount('comments')->orderBy('id', 'desc')->paginate(10);
         $keyword = $request->input('keyword');
         
         return view('users.show', [

--- a/app/Post.php
+++ b/app/Post.php
@@ -14,8 +14,8 @@ class Post extends Model
         return $this->belongsTo(User::class);
     }
 
-    // public function comments()
-    // {
-    //     return $this->hasMany(Comments::class);
-    // }
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -83,6 +83,6 @@ class User extends Authenticatable
 
     public function comments()
     {
-        return $this->hasMany(Comment::class);
+        return $this->hasManyThrough(Comment::class, Post::class);
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -80,4 +80,9 @@ class User extends Authenticatable
             return false;
         }
     }
+
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
 }

--- a/database/migrations/2024_11_13_135522_create_comments_table.php
+++ b/database/migrations/2024_11_13_135522_create_comments_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+{
+    Schema::create('comments', function (Blueprint $table) {
+        $table->bigIncrements('id');
+        $table->text('body');
+        
+        // user_idとpost_idをunsignedBigIntegerで設定
+        $table->unsignedBigInteger('user_id');
+        $table->unsignedBigInteger('post_id');
+        
+        $table->timestamps();
+        $table->softDeletes();
+
+        // 外部キー制約を追加
+        $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+    });
+}
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/resources/views/commons/posts_list.blade.php
+++ b/resources/views/commons/posts_list.blade.php
@@ -4,13 +4,18 @@
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
             <p class="mt-3 mb-0 d-inline-block">
                 <a href="{{ route('user.show', $post->user->id) }}" class="mr-3">{{ $post->user->name }}</a>
-                <a href="{{ route('post.show', $post->id) }}">投稿詳細</a>
 
             </p>
         </div>
         <div class="text-left d-inline-block w-75">
             <p class="mb-2">{{ $post->content }}</p>
             <p class="text-muted">{{ $post->created_at }}</p>
+            <p>
+                <a href="{{ route('post.show', $post->id) }}">
+                    <i class="fas fa-comment"></i> <!-- 吹き出しアイコン -->
+                    {{ $post->comments_count }}
+                </a>
+            </p>
         </div>
         @if (Auth::id() === $post->user_id)
             <div class="d-flex justify-content-between w-75 pb-3 m-auto">

--- a/resources/views/commons/posts_list.blade.php
+++ b/resources/views/commons/posts_list.blade.php
@@ -3,7 +3,9 @@
         <div class="text-left d-inline-block w-75 mb-2">
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
             <p class="mt-3 mb-0 d-inline-block">
-                <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>
+                <a href="{{ route('user.show', $post->user->id) }}" class="mr-3">{{ $post->user->name }}</a>
+                <a href="{{ route('post.show', $post->id) }}">投稿詳細</a>
+
             </p>
         </div>
         <div class="text-left d-inline-block w-75">

--- a/resources/views/commons/posts_list.blade.php
+++ b/resources/views/commons/posts_list.blade.php
@@ -13,7 +13,7 @@
             <p>
                 <a href="{{ route('post.show', $post->id) }}">
                     <i class="fas fa-comment"></i> <!-- 吹き出しアイコン -->
-                    {{ $post->comments_count }}
+                    {{ $post->comments_count ?? 0 }}
                 </a>
             </p>
         </div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,6 +1,6 @@
 <ul class="list-unstyled">
     <!-- 検索結果がある場合 -->
-    @if(isset($keyword) && $keyword)
+    @if($keyword !== null && $keyword)
         <div class="text-left d-inline-block w-75 mb-2">
             <h5>「{{ $keyword }}」の検索結果</h5>
         </div>
@@ -41,7 +41,7 @@
     @else
         @include('commons.posts_list')
         <div class="m-auto" style="width: fit-content">
-            {{ $posts->appends(['keyword' => $keyword])->links('pagination::bootstrap-4') }}
+            {{ $posts->links('pagination::bootstrap-4') }}
         </div>
     @endif
 </ul>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -18,25 +18,26 @@
 
 <!-- コメント一覧 -->
 <h5>コメント一覧</h5>
-        @foreach($post->comments as $comment)
+    @foreach($post->comments as $comment)
         <ul class="list-unstyled">
             <li class="mb-3 text-center">
                 <div class="text-left d-inline-block w-75 mb-2">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像" style="width: 40px; height: 40px;">
                     <p class="mt-3 mb-0 d-inline-block">
                         <a href="{{ route('user.show', $post->user->id) }}">{{ $comment->user->name }}</a>
                     </p>
                 </div>
                 <div class="text-left d-inline-block w-75">
-                    <p class="mb-2">{{ $comment->body }}</p>
-                    <p class="text-muted">{{ $comment->created_at }}</p>
+                    <p style="font-size: 14px;" class="mb-2">{{ $comment->body }}</p>
+                    <p style="font-size: 14px;" class="text-muted">{{ $comment->created_at }}</p>
                 </div>
             </li>
         </ul>
-        @endforeach
-
+    @endforeach
         <!-- コメント投稿フォーム -->
-        <form action="{{ route('comments.store', $post->id) }}" method="POST">
+        {{-- Error Messages --}}
+        @include('commons.error_messages')
+        <form action="{{ route('comments.store', $post->id) }}" method="POST" class="w-75 mx-auto">
             @csrf
             <div class="form-group">
                 <textarea name="body" class="form-control" rows="4" placeholder="コメントを入力"></textarea>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -15,4 +15,36 @@
         </div>
     </li>
 </ul>
+
+<!-- コメント一覧 -->
+<h5>コメント一覧</h5>
+        @foreach($post->comments as $comment)
+        <ul class="list-unstyled">
+            <li class="mb-3 text-center">
+                <div class="text-left d-inline-block w-75 mb-2">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                    <p class="mt-3 mb-0 d-inline-block">
+                        <a href="{{ route('user.show', $post->user->id) }}">{{ $comment->user->name }}</a>
+                    </p>
+                </div>
+                <div class="text-left d-inline-block w-75">
+                    <p class="mb-2">{{ $comment->body }}</p>
+                    <p class="text-muted">{{ $comment->created_at }}</p>
+                </div>
+            </li>
+        </ul>
+        @endforeach
+
+        <!-- コメント投稿フォーム -->
+        <form action="{{ route('comments.store', $post->id) }}" method="POST">
+            @csrf
+            <div class="form-group">
+                <textarea name="body" class="form-control" rows="4" placeholder="コメントを入力"></textarea>
+            </div>
+            <div class="d-flex justify-content-end mt-3">
+                <button type="submit" class="btn btn-primary">コメントする</button>
+            </div>
+        </form>
+        <a href="{{ url('/') }}" class="btn btn-secondary mt-3">トップページへ戻る</a>
+    </div>
 @endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -34,9 +34,10 @@
             </li>
         </ul>
     @endforeach
-        <!-- コメント投稿フォーム -->
-        {{-- Error Messages --}}
-        @include('commons.error_messages')
+<!-- コメント投稿フォーム -->
+@auth
+    {{-- Error Messages --}}
+    @include('commons.error_messages')
         <form action="{{ route('comments.store', $post->id) }}" method="POST" class="w-75 mx-auto">
             @csrf
             <div class="form-group">
@@ -47,5 +48,5 @@
             </div>
         </form>
         <a href="{{ url('/') }}" class="btn btn-secondary mt-3">トップページへ戻る</a>
-    </div>
+@endauth
 @endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,0 +1,18 @@
+@extends('layouts.app')
+@section('content')
+<!-- 投稿詳細 -->
+<ul class="list-unstyled">
+    <li class="mb-3 text-center">
+        <div class="text-left d-inline-block w-75 mb-2">
+            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+            <p class="mt-3 mb-0 d-inline-block">
+                <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>
+            </p>
+        </div>
+        <div class="text-left d-inline-block w-75">
+            <p class="mb-2">{{ $post->content }}</p>
+            <p class="text-muted">{{ $post->created_at }}</p>
+        </div>
+    </li>
+</ul>
+@endsection

--- a/resources/views/users/users.blade.php
+++ b/resources/views/users/users.blade.php
@@ -9,7 +9,9 @@
                     <div class="text-left d-inline-block w-75 mb-2">
                         <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像">
                         <p class="mt-3 mb-0 d-inline-block">
-                            <a href="{{ route('user.show', $user->id) }}">{{ $user->name }}</a>
+                            <a href="{{ route('user.show', $user->id) }}" class="mr-3">{{ $user->name }}</a>
+                            <a href="{{ route('post.show', $user->id) }}">投稿詳細</a>
+
                         </p>
                     </div>
                     <div class="text-left d-inline-block w-75">

--- a/resources/views/users/users.blade.php
+++ b/resources/views/users/users.blade.php
@@ -19,8 +19,8 @@
                                 <p class="text-muted">{{ $post->created_at }}</p>
                                 <p>
                                     <a href="{{ route('post.show', $post->id) }}">
-                                        <i class="fas fa-comment"></i> <!-- 吹き出しアイコン -->
-                                        {{ $post->comments_count }}
+                                        <i class="fas fa-comment"></i> 
+                                        {{ $post->comments_count ?? 0 }}
                                     </a>
                                 </p>
                             @endforeach

--- a/resources/views/users/users.blade.php
+++ b/resources/views/users/users.blade.php
@@ -10,8 +10,6 @@
                         <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像">
                         <p class="mt-3 mb-0 d-inline-block">
                             <a href="{{ route('user.show', $user->id) }}" class="mr-3">{{ $user->name }}</a>
-                            <a href="{{ route('post.show', $user->id) }}">投稿詳細</a>
-
                         </p>
                     </div>
                     <div class="text-left d-inline-block w-75">
@@ -19,6 +17,12 @@
                             @foreach($user->posts as $post)
                                 <p class="mb-2">{{ $post->content }}</p>
                                 <p class="text-muted">{{ $post->created_at }}</p>
+                                <p>
+                                    <a href="{{ route('post.show', $post->id) }}">
+                                        <i class="fas fa-comment"></i> <!-- 吹き出しアイコン -->
+                                        {{ $post->comments_count }}
+                                    </a>
+                                </p>
                             @endforeach
                         @else
                             <p>このユーザには投稿がありません。</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,8 @@ Route::prefix('users')->group(function () {
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
+// 投稿詳細画面表示
+Route::get('posts/{id}/show', 'PostsController@show')->name('post.show');
 Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
         // 投稿新規登録
@@ -31,8 +33,6 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         // 投稿編集
         Route::put('{id}', 'PostsController@update')->name('post.update');
-        // 投稿詳細画面表示
-        Route::get('{id}/show', 'PostsController@show')->name('post.show');
         // コメント
         Route::post('{post}/comments', 'CommentController@store')->name('comments.store');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,7 +34,7 @@ Route::group(['middleware' => 'auth'], function () {
         // 投稿詳細画面表示
         Route::get('{id}/show', 'PostsController@show')->name('post.show');
         // コメント
-        Route::post('{id}/comments', 'CommentController@store')->name('comments.store');
+        Route::post('{post}/comments', 'CommentController@store')->name('comments.store');
     });
 });
 // ログイン

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,10 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         // 投稿編集
         Route::put('{id}', 'PostsController@update')->name('post.update');
+        // 投稿詳細画面表示
+        Route::get('{id}/show', 'PostsController@show')->name('post.show');
+        // コメント
+        Route::post('{id}/comments', 'CommentController@store')->name('comments.store');
     });
 });
 // ログイン


### PR DESCRIPTION
## issue

## 概要
- コメント機能と投稿詳細画面の実装

## 動作確認 ①
- http://localhost:8080/ へアクセスしトップページの投稿一覧のすべての投稿に吹き出しのアイコンとコメント数が表示されていることを確認
- 吹き出しアイコン押下後、ログインし投稿詳細画面に遷移することを確認
   メールアドレス===hug@hug.com
   パスワード===07280728
- 投稿にコメントされたものがコメント一覧に表示されていることを確認
- コメントフォームにコメント内容を記述しコメント後、コメント一覧にコメント内容が反映されることを確認
- 「トップページへ戻る」ボタン押下後 トップページへ遷移することを確認
## 動作確認 ②
- ユーザ詳細画面に遷移後投稿に吹き出しのアイコンとコメント数が表示されていることを確認
- 吹き出しアイコン押下後、投稿詳細画面に遷移することを確認
- 投稿にコメントされたものがコメント一覧に表示されていることを確認

## 考慮してほしいこと
- コメント機能のみの実装予定でしたが、投稿詳細ページがないと実装が難しいと感じたためコメント機能と投稿詳細画面を並行して実装しました。
- コメント機能と投稿詳細画面をそれぞれ分けてコミットしましたが、修正を加えながらの作業になってしまったためコミットを分けたことにあまり意味を成していません。申し訳ございません。

## 確認してほしいこと
機能の実装において、他タスクのbladeを調整してビューを整えるところまで（余白など）を機能の実装と理解していますが、どの程度の調整をするのが望ましいでしょうか？