### PR TITLE
#1324 返信機能：返信一覧取得まで（小宮山）

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "cSpell.words": [
-        "endforeach",
-        "fullhuman"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "endforeach",
+        "fullhuman"
+    ]
+}

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\User;
+use App\Post;
+
+class RepliesController extends Controller
+{
+    public function index($id)
+    {
+        $post = Post::findOrFail($id);
+        return view('replies.index', [
+            'post' => $post,
+        ]);
+    }
+}

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -5,14 +5,18 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\User;
 use App\Post;
+use App\Reply;
 
 class RepliesController extends Controller
 {
     public function index($id)
     {
         $post = Post::findOrFail($id);
-        return view('replies.index', [
+        $replies = $post->replies()->orderBy('id', 'asc')->paginate(10);
+        $data = [
             'post' => $post,
-        ]);
+            'replies' => $replies,
+        ];
+        return view('replies.index', $data);
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -18,4 +18,9 @@ class Post extends Model
     {
         return $this->belongsToMany(User::class,'favorites','post_id','user_id')->withTimestamps();
     }
+
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Reply extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'content', 'user_id', 'post_ed',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -44,6 +44,11 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
+
     // フォロワーを取得
     public function followers()
     {

--- a/database/migrations/2024_11_20_141256_create_replies_table.php
+++ b/database/migrations/2024_11_20_141256_create_replies_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replies', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('content', 140);
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replies');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(RepliesTableSeeder::class);
     }
 }

--- a/database/seeds/RepliesTableSeeder.php
+++ b/database/seeds/RepliesTableSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class RepliesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        for($userId = 1; $userId <= 5; $userId++){ // ユーザー
+            for($postId = 1; $postId <=15; $postId++){
+                for($i = 1; $i <= 3; $i++){
+                DB::table('replies')->insert([
+                    'content' => '私はユーザー'. $userId. 'です。'. 'テスト投稿'. $postId. 'への'. $i. '回目の返信です。',
+                    'user_id' => $userId,
+                    'post_id' => $postId,
+                ]);
+                }
+            }
+        }
+    }
+}

--- a/database/seeds/RepliesTableSeeder.php
+++ b/database/seeds/RepliesTableSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class RepliesTableSeeder extends Seeder
 {
@@ -11,14 +12,21 @@ class RepliesTableSeeder extends Seeder
      */
     public function run()
     {
-        for($userId = 1; $userId <= 5; $userId++){ // ユーザー
-            for($postId = 1; $postId <=15; $postId++){
-                for($i = 1; $i <= 3; $i++){
-                DB::table('replies')->insert([
-                    'content' => '私はユーザー'. $userId. 'です。'. 'テスト投稿'. $postId. 'への'. $i. '回目の返信です。',
-                    'user_id' => $userId,
-                    'post_id' => $postId,
-                ]);
+        $userIds = range(1, 5);
+        $postIds = range(1,15);
+
+        foreach ($postIds as $postId) {
+            $post = DB::table('posts')->where('id', $postId)->first();
+
+            if ($post) {
+                foreach ($userIds as $userId) {
+                    for ($i = 1; $i <=3; $i++) {
+                        DB::table('replies')->insert([
+                            'content' => '私はユーザー' . $userId . 'です。これは「' . $post->content . '」に対する返信' . $i . '回目です。',
+                            'post_id' => $postId,
+                            'user_id' => $userId,
+                        ]);
+                    }
                 }
             }
         }

--- a/public/css/replies/index.css
+++ b/public/css/replies/index.css
@@ -1,0 +1,6 @@
+.post-content{
+    background-color: #e2f9f9;
+    padding: 20px 0;
+    border-radius: 6px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -12,8 +12,13 @@
                         <p class="mb-2">{!! nl2br(e($post->content)) !!}</p>
                         <p class="text-muted">{{$post->created_at}}</p>
                     </div>
-                    <div class="text-left d-inline-block w-75">
-                        @include('favorite.favorite_button', ['post' => $post])
+                    <div class="d-flex align-items-center w-75 mb-2 mx-auto">
+                        <div class="mr-4">
+                            @include('replies.reply_button')
+                        </div>
+                        <div class="mr-4">
+                            @include('favorite.favorite_button', ['post' => $post])
+                        </div>
                     </div>
                 </div>
                 @if(Auth::id() === $post->user_id)

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -1,0 +1,53 @@
+@extends('layouts.app')
+@section('content')
+    @if (session('successMessage'))
+        <div class="alert alert-success text-center w-30 mx-auto">
+            {{ session('successMessage') }}
+        </div>
+    @elseif (session('alertMessage'))
+        <div class="alert alert-danger text-center w-30 mx-auto">
+            {{ session('alertMessage') }}
+        </div>
+    @endif
+    <div class="mb-3 text-center">
+        <div class="text-left d-inline-block w-75 mb-2">
+            <img class="mr-2 rounded-circle" src="{{Gravatar::src($post->user->email, 55)}}" alt="ユーザのアバター画像">
+            <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a></p>
+        </div>
+        <div class="">
+            <div id="post-{{ $post->id }}">
+                <div class="text-left d-inline-block w-75">
+                    <p class="mb-2">{!! nl2br(e($post->content)) !!}</p>
+                    <p class="text-muted">{{$post->created_at}}</p>
+                </div>
+            </div>
+            @if(Auth::id() === $post->user_id)
+                <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                    <form method="POST" action="{{ route('post.delete',$post->id)}}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">削除</button>
+                    </form>
+                    <a href="{{ route('post.edit', $post->id) }}" class="btn btn-primary">編集する</a>
+                </div>
+            @endif
+        </div>
+    </div>
+    <div class="w-75 m-auto">
+    @include('commons.error_messages')
+    </div>
+    <div class="text-center mb-3">
+    @if(Auth::check())
+        <form method="" action="" class="d-inline-block w-75">
+            @csrf
+            <div class="form-group">
+                <textarea class="form-control" name="content" rows="4"></textarea>
+                <div class="text-left mt-3">
+                    <button type="submit" class="btn btn-primary">返信する</button>
+                </div>
+            </div>
+        </form>
+    @endif
+    </div>
+    {{-- @include('replies.replies', ['posts' => $posts]) --}}
+@endsection

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -49,5 +49,5 @@
         </form>
     @endif
     </div>
-    {{-- @include('replies.replies', ['posts' => $posts]) --}}
+    @include('replies.replies', ['post' => $post])
 @endsection

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -1,4 +1,9 @@
 @extends('layouts.app')
+
+@section('css')
+    <link rel="stylesheet" href="{{ asset('css/replies/index.css') }}">
+@endsection
+
 @section('content')
     @if (session('successMessage'))
         <div class="alert alert-success text-center w-30 mx-auto">
@@ -9,7 +14,7 @@
             {{ session('alertMessage') }}
         </div>
     @endif
-    <div class="mb-3 text-center">
+    <div class="post-content mb-4 text-center">
         <div class="text-left d-inline-block w-75 mb-2">
             <img class="mr-2 rounded-circle" src="{{Gravatar::src($post->user->email, 55)}}" alt="ユーザのアバター画像">
             <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{$post->user->name}}</a></p>

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -1,6 +1,6 @@
 <ul class="list-unstyled">
     @foreach($replies as $reply)
-        <li class="mb-3 text-center">
+        <li class="mb-3 text-center pl-4 pr-4">
             <hr class="my-4">
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{Gravatar::src($reply->user->email, 55)}}" alt="ユーザのアバター画像">

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -1,0 +1,30 @@
+<ul class="list-unstyled">
+    @foreach($replies as $reply)
+        <li class="mb-3 text-center">
+            <hr class="my-4">
+            <div class="text-left d-inline-block w-75 mb-2">
+                <img class="mr-2 rounded-circle" src="{{Gravatar::src($reply->user->email, 55)}}" alt="ユーザのアバター画像">
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $reply->user->id) }}">{{$reply->user->name}}</a></p>
+            </div>
+            <div class="">
+                <div id="post-{{ $reply->id }}">
+                    <div class="text-left d-inline-block w-75">
+                        <p class="mb-2">{!! nl2br(e($reply->content)) !!}</p>
+                        <p class="text-muted">{{$reply->created_at}}</p>
+                    </div>
+                </div>
+                @if(Auth::id() === $reply->user_id)
+                    <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                        <form method="" action="">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">削除</button>
+                        </form>
+                        <a href="" class="btn btn-primary">編集する</a>
+                    </div>
+                @endif
+            </div>
+        </li>
+    @endforeach
+</ul>
+<div class="m-auto" style="width: fit-content">{{ $replies->links('pagination::bootstrap-4') }}</div>

--- a/resources/views/replies/reply_button.blade.php
+++ b/resources/views/replies/reply_button.blade.php
@@ -1,9 +1,9 @@
-{{-- @php
-    $countFavoriteUsers = $post->favoriteUsers()->count();
-@endphp --}}
+@php
+    $countReplies = $post->replies()->count();
+@endphp
 
 <button class="btn m-0 p-1 shadow-none"><a class="text-dark" href="{{ route('reply.index', $post->id) }}" data-toggle="tooltip" title="返信"><i class="far fa-comment"></i></a></button>
-{{-- <span id="favorite-count-{{ $post->id }}" class="badge badge-pill">{{ $countFavoriteUsers }}</span> --}}
+<span id="reply-count-{{ $post->id }}" class="badge badge-pill">{{ $countReplies }}</span>
 
 <script>
     document.addEventListener('DOMContentLoaded', function () {

--- a/resources/views/replies/reply_button.blade.php
+++ b/resources/views/replies/reply_button.blade.php
@@ -1,0 +1,12 @@
+{{-- @php
+    $countFavoriteUsers = $post->favoriteUsers()->count();
+@endphp --}}
+
+<button class="btn m-0 p-1 shadow-none"><a class="text-dark" href="{{ route('reply.index', $post->id) }}" data-toggle="tooltip" title="返信"><i class="far fa-comment"></i></a></button>
+{{-- <span id="favorite-count-{{ $post->id }}" class="badge badge-pill">{{ $countFavoriteUsers }}</span> --}}
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        $('[data-toggle="tooltip"]').tooltip();
+    });
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,9 @@ Route::prefix('users/{id}')->group(function(){
     Route::get('followings', 'UsersController@followings')->name('user.followings');
 });
 
+// 返信ページの表示
+Route::get('posts/{id}/reply', 'RepliesController@index')->name('reply.index');
+
 // ログイン後（ユーザー編集画面・更新）
 Route::group(['middleware' => 'auth'], function(){
     Route::prefix('users/{id}')->group(function(){


### PR DESCRIPTION

## issue
 - Closes #1324 

## 概要
 - 投稿に返信する機能：返信の一覧取得まで

## 動作確認手順
 - 下記コマンドを実行する。

 - マイグレーションの実行
```
php artisan migrate
```
 - シーディングの実行
```
php artisan db:seed —class=RepliesTableSeeder
```
 - Adminerでrepliesテーブルにレコードが保存されていることを確認。

 - トップページへアクセスする。
http://localhost:8080/
 - 投稿の吹き出しマークをクリックすると返信ページへ遷移することを確認。
 - 例として以下のURLへアクセスすると、投稿id=1の投稿に対する返信一覧が表示されていることを確認。
http://localhost:8080/posts/1/reply
※上記URLの「1」は投稿idとなります。存在しないidの場合、404エラーページが表示されます。

## 考慮してほしいこと
 - 状況に応じて、下記コマンドで動作確認する必要あり。
```
php artisan migrate:fresh
php artisan db:seed —class=UsersTableSeeder
php artisan db:seed —class=PostsTableSeeder
php artisan db:seed —class=RepliesTableSeeder
```

## 確認してほしいこと
 - 特にありません。