### PR TITLE
ユーザアイコンに画像使用（いずみ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -7,6 +7,7 @@ use App\User;
 use Illuminate\Http\Request;
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 
 class UsersController extends Controller
 {
@@ -38,7 +39,6 @@ class UsersController extends Controller
     public function update(UserRequest $request, $id)
     {
         $user = User::findOrFail($id);
-
         if ($request->filled('name')) {
             $user->name = $request->name;
         }
@@ -48,12 +48,18 @@ class UsersController extends Controller
         if ($request->filled('password')) {
             $user->password = bcrypt($request->password);
         }
-
+        if ($request->hasFile('avatar')) {
+            if ($user->avatar) {
+                Storage::delete($user->avatar);
+            }
+            $path = $request->file('avatar')->store('public/avatars');
+            $user->avatar = $path;
+        }
         $user->save();
-        
         session()->flash('flash-message', 'ユーザ情報が更新されました。');
-        
-        return redirect()->route('user.show', ['id' => $user->id ]);
+        return redirect()->route('user.show', [
+            'id' => $user->id
+        ]);
     }
 
     public function destroy($id)

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -26,7 +26,8 @@ class UserRequest extends FormRequest
         return [
             'name' => ['nullable', 'string', 'max:255'],
             'email' => ['nullable', 'string', 'email', 'max:255', 'unique:users,email,'. $this->id],
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'password' => ['required', 'string', 'min:4', 'confirmed'],
+            'avatar' => ['nullable', 'image', 'mimes:jpeg,png']
         ];
     }
 
@@ -34,6 +35,7 @@ class UserRequest extends FormRequest
     {
         return [
             'password.confirmed' => 'パスワードが一致しません',
+            'avatar.image' => '画像ファイルを選択してください。'
         ];
     }
 }

--- a/database/migrations/2024_11_20_000827_add_avatar_to_users_table.php
+++ b/database/migrations/2024_11_20_000827_add_avatar_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAvatarToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColum('avatar');
+        });
+    }
+}

--- a/resources/views/commons/posts_list.blade.php
+++ b/resources/views/commons/posts_list.blade.php
@@ -1,10 +1,13 @@
 @foreach ($posts as $post)
     <li class="mb-3 text-center">
         <div class="text-left d-inline-block w-75 mb-2">
-            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+            @if($post->user->avatar)
+                <img class="mr-2 rounded-circle" src="{{ Storage::url($post->user->avatar) }}" alt="現在のプロフィール画像" style="width: 55px; height: 55px;">
+            @else
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+            @endif 
             <p class="mt-3 mb-0 d-inline-block">
                 <a href="{{ route('user.show', $post->user->id) }}" class="mr-3">{{ $post->user->name }}</a>
-
             </p>
         </div>
         <div class="text-left d-inline-block w-75">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -22,10 +22,18 @@
         <ul class="list-unstyled">
             <li class="mb-3 text-center">
                 <div class="text-left d-inline-block w-75 mb-2">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像" style="width: 40px; height: 40px;">
-                    <p class="mt-3 mb-0 d-inline-block">
-                        <a href="{{ route('user.show', $post->user->id) }}">{{ $comment->user->name }}</a>
-                    </p>
+                    <div class="d-inline-block">
+                        @if($comment->user->avatar)
+                            <img class="mr-2 rounded-circle" src="{{ Storage::url($comment->user->avatar) }}" alt="現在のプロフィール画像" style="width: 45px; height: 45px;">
+                        @else
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($comment->user->email) }}" alt="ユーザのアバター画像" style="width: 45px; height: 45px;">
+                        @endif
+                    </div>
+                    <div class="d-inline-block align-middle">
+                        <p class="mt-3 mb-3">
+                            <a href="{{ route('user.show', $post->user->id) }}">{{ $comment->user->name }}</a>
+                        </p>
+                    </div>
                 </div>
                 <div class="text-left d-inline-block w-75">
                     <p style="font-size: 14px;" class="mb-2">{{ $comment->body }}</p>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,30 +1,49 @@
 @extends('layouts.app')
 @section('content')
 <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
-    <form method="POST" action="{{ route('user.update', $user->id) }}">
+    <form method="POST" action="{{ route('user.update', $user->id) }}" enctype="multipart/form-data">
         {{-- Error Messages --}}
         @include('commons.error_messages')
         @csrf
         @method('PUT')
-        <input type="hidden" name="id" value="{{ old('id', $user->id) }}" />
-        <div class="form-group">
-            <label for="name">ユーザ名</label>
-            <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
-        </div>
+        <div style="display: flex; justify-content: space-between; gap: 20px; padding: 20px;"> 
+            <div style="flex: 1; max-width: 60%; padding-right: 20px;">
+                <input type="hidden" name="id" value="{{ old('id', $user->id) }}" />
+                <div class="form-group">
+                    <label for="name">ユーザ名</label>
+                    <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
+                </div>
 
-        <div class="form-group">
-            <label for="email">メールアドレス</label>
-            <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
-        </div>
+                <div class="form-group">
+                    <label for="email">メールアドレス</label>
+                    <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
+                </div>
 
-        <div class="form-group">
-            <label for="password">パスワード</label>
-            <input class="form-control" type="password" name="password" />
-        </div>
+                <div class="form-group">
+                    <label for="password">パスワード</label>
+                    <input class="form-control" type="password" name="password" />
+                </div>
 
-        <div class="form-group">
-            <label for="password_confirmation">パスワードの確認</label>
-            <input class="form-control" type="password" name="password_confirmation" />
+                <div class="form-group">
+                    <label for="password_confirmation">パスワードの確認</label>
+                    <input class="form-control" type="password" name="password_confirmation" />
+                </div>
+            </div>
+            <div style="flex: 0 0 30%; display: flex; flex-direction: column; align-items: center; gap: 10px;">
+                <div>
+                    <label for="avatar" >プロフィール画像</label>
+                    <input type="file" name="avatar" id="avatar" style="padding: 8px;">
+                </div>
+                @if($user->avatar)
+                <div>
+                    <img src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像" style="border-radius: 50%; object-fit: cover; width: 150px; height: 150px;">
+                </div>
+                @else
+                <div class="card-body">
+                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 200) }}" alt="ユーザのアバター画像">
+                </div>
+                @endif
+            </div>
         </div>
 
         <div class="d-flex justify-content-between">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -11,7 +11,11 @@
                 @include('commons.follow_button',['user'=> $user])
             </div>
             <div class="card-body">
-                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像">
+                @if($user->avatar)
+                    <img class="rounded-circle img-fluid" src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像">
+                @else
+                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像">
+                @endif  
                 @auth
                     @if (Auth::id() === $user->id)
                         <div class="mt-3">


### PR DESCRIPTION
## issue

## 概要
- ユーザアイコンに画像を設定できるようにしました

## 動作確認
- http://localhost:8080/login にアクセスしログイン後、ユーザ詳細画面に遷移
メールアドレス === user1@user.com
パスワード === user1
- 「ユーザ情報の編集」ボタンを押し、プロフィール画像のファイルを選択し更新
- ユーザ詳細画面にプロフィール画像が設定されていることを確認
- トップページの投稿一覧のユーザアイコンにも変更が反映されていることを確認

## 考慮してほしいこと

## 確認してほしいこと
