### PR TITLE
#903 投稿編集画面・更新(yuki)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -29,7 +29,12 @@ class PostsController extends Controller
     // 投稿編集画面
     public function edit($id)
     {
+        $user = \Auth::user();
         $post = Post::findOrFail($id);
+        // 投稿者以外であればエラーを出す
+        if($user->id !== $post->user_id){
+            abort(403);
+        }
         $data = [
             'post' => $post,
         ];

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -11,7 +11,7 @@ class PostsController extends Controller
 {
     public function index()
     {
-        $posts = Post::orderBy('id','desc')->paginate(10);
+        $posts = Post::orderBy('id', 'desc')->paginate(10);
 
         return view('welcome', [
             'posts' => $posts,
@@ -25,14 +25,18 @@ class PostsController extends Controller
         $post->save();
         return back();
     }
+
+    // 投稿編集画面
     public function edit($id)
     {
         $post = Post::findOrFail($id);
-        $data=[
+        $data = [
             'post' => $post,
         ];
         return view('posts.edit', $data);
     }
+
+    // 投稿更新
     public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -25,4 +25,20 @@ class PostsController extends Controller
         $post->save();
         return back();
     }
+    public function edit($id)
+    {
+        $post = Post::findOrFail($id);
+        $data=[
+            'post' => $post,
+        ];
+        return view('posts.edit', $data);
+    }
+    public function update(PostRequest $request, $id)
+    {
+        $post = Post::findOrFail($id);
+        $post->content = $request->content;
+        $post->user_id = $request->user()->id;
+        $post->save();
+        return redirect("/");
+    }
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+@section('content')
+    <h2 class="mt-5">投稿を編集する</h2>
+    <form method="POST" action="{{ route('post.update', $post->id) }}">
+    @csrf
+    @method('PUT')
+        <div class="form-group">
+            <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </form>
+@endsection

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <h2 class="mt-5">投稿を編集する</h2>
+    @include('commons.error_messages')
     <form method="POST" action="{{ route('post.update', $post->id) }}">
     @csrf
     @method('PUT')

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -15,7 +15,7 @@
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('post.edit', $post->user_id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -15,7 +15,7 @@
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="{{ route('post.edit', $post->user_id) }}" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('post.edit', $post->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,5 +37,9 @@ Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
         Route::post('', 'PostsController@store')->name('post.store');
+        // 投稿編集画面
+        Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
+        // 投稿更新
+        Route::put('{id}', 'PostsController@update')->name('post.update');
     });
 });


### PR DESCRIPTION
プルリク

## issue
- Closes #903

## 概要
- 投稿編集画面・更新

## 動作確認手順
- 画面
更新するボタンを押下すると更新されていることを確認
- データベース
更新するボタンを押下すると元データが変更され、更新されていることを確認

## 考慮して欲しいこと
## 確認して欲しいこと
PostsController.phpのedit関数の
```
$data=[
            'post' => $post,
        ];
```
変数1つの場合、配列にして渡す以外の方法はありますか？