### PR TITLE
#1324 返信機能：新規返信の登録機能の実装（小宮山）

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -19,4 +19,16 @@ class RepliesController extends Controller
         ];
         return view('replies.index', $data);
     }
+
+    public function store(Request $request, $id)
+    {
+        $post = Post::findOrFail($id);
+        $user = \Auth::user();
+        $reply = new Reply;
+        $reply->content = $request->content;
+        $reply->user_id = $user->id;
+        $reply->post_id = $post->id;
+        $reply->save();
+        return redirect()->back()->with('successMassage', '返信しました');
+    }
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\User;
 use App\Post;
 use App\Reply;
+use App\Http\Requests\ReplyRequest;
 
 class RepliesController extends Controller
 {
@@ -20,7 +21,7 @@ class RepliesController extends Controller
         return view('replies.index', $data);
     }
 
-    public function store(Request $request, $id)
+    public function store(ReplyRequest $request, $id)
     {
         $post = Post::findOrFail($id);
         $user = \Auth::user();
@@ -29,6 +30,6 @@ class RepliesController extends Controller
         $reply->user_id = $user->id;
         $reply->post_id = $post->id;
         $reply->save();
-        return redirect()->back()->with('successMassage', '返信しました');
+        return redirect()->back()->with('successMessage', '返信しました');
     }
 }

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|max:140',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'content' => '返信',
+        ];
+    }
+}

--- a/resources/views/replies/index.blade.php
+++ b/resources/views/replies/index.blade.php
@@ -43,7 +43,7 @@
     </div>
     <div class="text-center mb-3">
     @if(Auth::check())
-        <form method="" action="" class="d-inline-block w-75">
+        <form method="POST" action="{{ route('reply.store', $post->id) }}" class="d-inline-block w-75">
             @csrf
             <div class="form-group">
                 <textarea class="form-control" name="content" rows="4"></textarea>

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,8 @@ Route::group(['middleware' => 'auth'], function(){
         Route::put('{id}/edit', 'PostsController@update')->name('post.update');
         // 投稿の削除
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
+        // 返信の追加処理
+        Route::post('{id}/reply', 'RepliesController@store')->name('reply.store');
     });
     // いいね機能
     Route::group(['prefix' => 'posts/{id}'], function(){


### PR DESCRIPTION
## issue
 - Closes #1324 

## 概要
 - 返信機能：新規返信の登録機能

## 動作確認手順
 - ログイン後、返信一覧画面へアクセスする。
 ※ユーザー1ログイン情報  
メールアドレス：user1@test.com  
パスワード：password  
※返信一覧画面  
http://localhost:8080/posts/15/reply

 - 返信フォームにて文字列を入力し、返信ボタンを押すと  
返信内容が一覧に反映され、セッションメッセージが表示されることを確認。
 - Adminerでrepliesテーブルにレコードが保存されていることを確認。
 - フォームに空の状態、もしくは140文字を超えた場合でフォーム送信すると、  
バリデーションメッセージが表示されることを確認。

## 考慮してほしいこと
 - 特にありません。

## 確認してほしいこと
 - 特にありません。