### PR TITLE
プロフィール画像の削除（いずみ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Log;
 
 class UsersController extends Controller
 {
@@ -66,7 +65,6 @@ class UsersController extends Controller
     public function deleteAvatar()
     {
         $user = auth()->user();
-        Log::info('deleteAvatar called', ['user_id' => $user->id]);
         if ($user->avatar) {
             Storage::delete($user->avatar);
             $user->avatar = null;

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\UserRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 
 class UsersController extends Controller
 {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -62,6 +62,19 @@ class UsersController extends Controller
         ]);
     }
 
+    public function deleteAvatar()
+    {
+        $user = auth()->user();
+        Log::info('deleteAvatar called', ['user_id' => $user->id]);
+        if ($user->avatar) {
+            Storage::delete($user->avatar);
+            $user->avatar = null;
+            $user->save();
+            session()->flash('flash-message', 'プロフィール画像が削除されました。');
+        }
+        return back();
+    }
+
     public function destroy($id)
     {
         $user = User::findOrFail($id);

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.app')
 @section('content')
+@include('commons.flash_message')
+@yield('scripts')
 <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
     <form method="POST" action="{{ route('user.update', $user->id) }}" enctype="multipart/form-data">
         {{-- Error Messages --}}
@@ -36,7 +38,12 @@
                 </div>
                 @if($user->avatar)
                 <div>
-                    <img src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像" style="border-radius: 50%; object-fit: cover; width: 150px; height: 150px;">
+                    <img src="{{ Storage::url($user->avatar) }}?{{ time() }}" alt="現在のプロフィール画像" style="border-radius: 50%; object-fit: cover; width: 150px; height: 150px;">
+                    <form method="POST" action="{{ route('profile.avatar.delete') }}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">プロフィール画像を削除</button>
+                    </form>
                 </div>
                 @else
                 <div class="card-body">
@@ -48,7 +55,7 @@
 
         <div class="d-flex justify-content-between">
             <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-            
+
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -2,65 +2,67 @@
 @section('content')
 @include('commons.flash_message')
 @yield('scripts')
+
 <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+<!-- プロフィール画像 -->
+<div class="row">
+    <div class="col-md-4 text left">
+        <div class="d-flex flex-column align-items-center">
+            <label for="avatar">プロフィール画像</label>
+            <input type="file" name="avatar" id="avatar" style="padding: 8px;">
+        @if($user->avatar)
+            <div class="mt-3">
+                <img src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像" style="border-radius: 50%; object-fit: cover; width: 150px; height: 150px;">
+                <form method="POST" action="{{ route('profile.avatar.delete') }}">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger" style="mt-20;">プロフィール画像を削除</button>
+                </form>
+            </div>
+        @else
+            <div class="card-body">
+                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 200) }}" alt="ユーザのアバター画像">
+            </div>
+        @endif
+    </div>
+</div>
+<!-- ユーザ情報 -->
+<div class="col-md-8">
     <form method="POST" action="{{ route('user.update', $user->id) }}" enctype="multipart/form-data">
         {{-- Error Messages --}}
         @include('commons.error_messages')
         @csrf
         @method('PUT')
-        <div style="display: flex; justify-content: space-between; gap: 20px; padding: 20px;"> 
-            <div style="flex: 1; max-width: 60%; padding-right: 20px;">
-                <input type="hidden" name="id" value="{{ old('id', $user->id) }}" />
-                <div class="form-group">
-                    <label for="name">ユーザ名</label>
-                    <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
-                </div>
 
-                <div class="form-group">
-                    <label for="email">メールアドレス</label>
-                    <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
-                </div>
+        <input type="hidden" name="id" value="{{ old('id', $user->id) }}" />
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name', $user->name) }}" name="name" />
+        </div>
 
-                <div class="form-group">
-                    <label for="password">パスワード</label>
-                    <input class="form-control" type="password" name="password" />
-                </div>
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{ old('email', $user->email) }}" name="email" />
+        </div>
 
-                <div class="form-group">
-                    <label for="password_confirmation">パスワードの確認</label>
-                    <input class="form-control" type="password" name="password_confirmation" />
-                </div>
-            </div>
-            <div style="flex: 0 0 30%; display: flex; flex-direction: column; align-items: center; gap: 10px;">
-                <div>
-                    <label for="avatar" >プロフィール画像</label>
-                    <input type="file" name="avatar" id="avatar" style="padding: 8px;">
-                </div>
-                @if($user->avatar)
-                <div>
-                    <img src="{{ Storage::url($user->avatar) }}?{{ time() }}" alt="現在のプロフィール画像" style="border-radius: 50%; object-fit: cover; width: 150px; height: 150px;">
-                    <form method="POST" action="{{ route('profile.avatar.delete') }}">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit" class="btn btn-danger">プロフィール画像を削除</button>
-                    </form>
-                </div>
-                @else
-                <div class="card-body">
-                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 200) }}" alt="ユーザのアバター画像">
-                </div>
-                @endif
-            </div>
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password_confirmation" />
         </div>
 
         <div class="d-flex justify-content-between">
             <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
-
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>
-
-    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+</div>
+    
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -6,22 +6,22 @@
 <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
 <!-- プロフィール画像 -->
 <div class="row">
-    <div class="col-md-4 text left">
+    <div class="col-md-4 text center">
         <div class="d-flex flex-column align-items-center">
-            <label for="avatar">プロフィール画像</label>
-            <input type="file" name="avatar" id="avatar" style="padding: 8px;">
+            <label for="avatar" style="margin: 10px;">プロフィール画像</label>
+            
         @if($user->avatar)
             <div class="mt-3">
-                <img src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像" style="border-radius: 50%; object-fit: cover; width: 150px; height: 150px;">
+                <img src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像" style="border-radius: 50%; object-fit: cover; width: 300px; height: 300px;">
                 <form method="POST" action="{{ route('profile.avatar.delete') }}">
                     @csrf
                     @method('DELETE')
-                    <button type="submit" class="btn btn-danger" style="mt-20;">プロフィール画像を削除</button>
+                    <button type="submit" class="btn btn-danger" style="margin: 31px;">画像を削除</button>
                 </form>
             </div>
         @else
             <div class="card-body">
-                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 200) }}" alt="ユーザのアバター画像">
+                <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
             </div>
         @endif
     </div>
@@ -33,7 +33,11 @@
         @include('commons.error_messages')
         @csrf
         @method('PUT')
-
+        <div class="form-group">
+                <label for="avatar">新しいプロフィール画像</label>
+                <input type="file" name="avatar" id="avatar" class="form-control">
+            </div>
+    
         <input type="hidden" name="id" value="{{ old('id', $user->id) }}" />
         <div class="form-group">
             <label for="name">ユーザ名</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
+use App\Http\Controllers\UsersController;
 
 // トップページの表示と検索機能
 Route::get('/', 'SearchController@index')->name('search.index');
@@ -52,6 +53,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('{id}/edit', 'UsersController@edit')->name('user.edit');
         Route::put('{id}', 'UsersController@update')->name('user.update');
     });
+    Route::delete('/profile/avatar', 'UsersController@deleteAvatar')->name('profile.avatar.delete');
 });
 
 // Follow & Unfollow

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,6 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
-use App\Http\Controllers\UsersController;
 
 // トップページの表示と検索機能
 Route::get('/', 'SearchController@index')->name('search.index');


### PR DESCRIPTION
## issue

## 概要
プロフィール画像の削除

## 動作確認手順
- http://localhost:8080/ へアクセスしログイン後、ユーザ詳細ページへ遷移
　メールアドレス === hug@hug.com
   パスワード === 07280728
- プロフィール画像が登録されていなければ登録後、画像を削除ボタンを押す
- プロフィール画像がデフォルトのアバター画像になっていることを確認

## 考慮してほしいこと
- MTGでゆきひろさんに教えていただいたviewの表示方法ですが、私には難しかったので別の方法で実装しました。教えていただいたのに上手くできず申し訳ございません。

## 確認してほしいこと
