### PR TITLE
#1324　投稿への返信：返信の更新・削除機能

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -54,4 +54,14 @@ class RepliesController extends Controller
         $reply->save();
         return redirect()->route('reply.index', $reply->post->id)->with('successMessage', '返信内容を更新しました');
     }
+
+    // 返信の削除
+    public function destroy(Request $request, $id)
+    {
+        $reply = Reply::findOrFail($id);
+        if ($reply->user_id === \Auth::id()){
+            $reply->delete();
+        }
+        return back()->with('alertMessage', '返信を削除しました');
+    }
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -32,4 +32,26 @@ class RepliesController extends Controller
         $reply->save();
         return redirect()->back()->with('successMessage', '返信しました');
     }
+
+    // 返信編集画面の表示
+    public function edit($id)
+    {
+        $reply = Reply::findOrFail($id);
+        $user = \Auth::user();
+
+        if ($user->id !== $reply->user_id) {
+            abort(403);
+        }
+
+        return view('replies.edit', ['reply' => $reply]);
+    }
+
+    // 返信の編集処理
+    public function update(ReplyRequest $request, $id)
+    {
+        $reply = Reply::findOrFail($id);
+        $reply->content = $request->content;
+        $reply->save();
+        return redirect()->route('reply.index', $reply->post->id)->with('successMessage', '返信内容を更新しました');
+    }
 }

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('content')
+@if (session('alertMessage'))
+    <div class="alert alert-success text-center w-25 mx-auto">
+        {{ session('successMessage') }}
+    </div>
+@endif
+    <h2 class="mt-5">返信内容を編集する</h2>
+    @include('commons.error_messages')
+    <form method="POST" action="{{ route('reply.update', $reply->id) }}">
+        @csrf
+        @method('PUT')
+        <div class="form-group">
+            <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $reply->content) }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </form>
+@endsection

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -20,7 +20,7 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('reply.update', $reply->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -15,7 +15,7 @@
                 </div>
                 @if(Auth::id() === $reply->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        <form method="" action="">
+                        <form method="POST" action="{{ route('reply.delete', $reply->id) }}">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,10 @@ Route::group(['middleware' => 'auth'], function(){
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
         // 返信の追加処理
         Route::post('{id}/reply', 'RepliesController@store')->name('reply.store');
+        // 返信の編集画面
+        Route::get('{id}/reply/edit', 'RepliesController@edit')->name('reply.edit');
+        // 返信の編集処理
+        Route::put('{id}/reply/edit', 'RepliesController@update')->name('reply.update');
     });
     // いいね機能
     Route::group(['prefix' => 'posts/{id}'], function(){

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,14 +63,18 @@ Route::group(['middleware' => 'auth'], function(){
         Route::put('{id}/edit', 'PostsController@update')->name('post.update');
         // 投稿の削除
         Route::delete('{id}', 'PostsController@destroy')->name('post.delete');
-        // 返信の追加処理
-        Route::post('{id}/reply', 'RepliesController@store')->name('reply.store');
-        // 返信の編集画面
-        Route::get('{id}/reply/edit', 'RepliesController@edit')->name('reply.edit');
-        // 返信の編集処理
-        Route::put('{id}/reply/edit', 'RepliesController@update')->name('reply.update');
-        // 返信の削除
-        Route::delete('{id}/reply/delete', 'RepliesController@destroy')->name('reply.delete');
+
+        // 返信関係
+        Route::prefix('{id}/reply')->group(function(){
+            // 返信の追加処理
+            Route::post('', 'RepliesController@store')->name('reply.store');
+            // 返信の編集画面
+            Route::get('edit', 'RepliesController@edit')->name('reply.edit');
+            // 返信の編集処理
+            Route::put('edit', 'RepliesController@update')->name('reply.update');
+            // 返信の削除
+            Route::delete('delete', 'RepliesController@destroy')->name('reply.delete');
+        });
     });
     // いいね機能
     Route::group(['prefix' => 'posts/{id}'], function(){

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,6 +69,8 @@ Route::group(['middleware' => 'auth'], function(){
         Route::get('{id}/reply/edit', 'RepliesController@edit')->name('reply.edit');
         // 返信の編集処理
         Route::put('{id}/reply/edit', 'RepliesController@update')->name('reply.update');
+        // 返信の削除
+        Route::delete('{id}/reply/delete', 'RepliesController@destroy')->name('reply.delete');
     });
     // いいね機能
     Route::group(['prefix' => 'posts/{id}'], function(){


### PR DESCRIPTION
## issue
 - Closes #1324 

## 概要
 - 投稿への返信：返信の更新・削除機能の実装

## 動作確認手順
### 更新処理
 - ログイン後、返信画面へアクセス。
http://localhost:8080/posts/15/reply
 - 編集ボタンをクリックすると編集画面へ遷移することを確認。
 - 編集画面にてフォームに入力し、更新ボタンを押すと、返信一覧へ戻り、  
フラッシュメッセージが表示される。
 - フォームに空のまま、もしくは140字を超えて更新ボタンを押すとバリデーションの  
エラーメッセージが表示される。
 - 編集画面のパスで返信idを渡しているが、ログインユーザー以外の返信idに書き換えた場合、403エラーとなる。
 - Adminerでrepliesテーブルにて対象の返信が更新されていることを確認。

### 削除処理
 - ログイン後、返信画面へアクセス。
http://localhost:8080/posts/15/reply
 - 削除ボタンをクリックすると該当の返信が削除され、一覧から消えることを確認。
 - 削除が実行されると、フラッシュメッセージが表示される。
 - Adminerでrepliesテーブルにて対象の返信が削除されていることを確認。

## 考慮してほしいこと
 - 特にありません。

## 確認してほしいこと
 - 特にありません。