### PR TITLE
ユーザアイコンのファイル容量の制限(いずみ)

### DIFF
--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -35,7 +35,8 @@ class UserRequest extends FormRequest
     {
         return [
             'password.confirmed' => 'パスワードが一致しません',
-            'avatar.image' => '画像ファイルを選択してください。'
+            'avatar.image' => '画像ファイルを選択してください',
+            'avatar.max' => '最大2MBまでの画像ファイルを選択してください'
         ];
     }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -27,7 +27,7 @@ class UserRequest extends FormRequest
             'name' => ['nullable', 'string', 'max:255'],
             'email' => ['nullable', 'string', 'email', 'max:255', 'unique:users,email,'. $this->id],
             'password' => ['required', 'string', 'min:4', 'confirmed'],
-            'avatar' => ['nullable', 'image', 'mimes:jpeg,png']
+            'avatar' => ['nullable', 'image', 'mimes:jpeg,png,jpg', 'max:2048']
         ];
     }
 

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -3,6 +3,8 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
 
 class UserRequest extends FormRequest
 {
@@ -38,5 +40,13 @@ class UserRequest extends FormRequest
             'avatar.image' => '画像ファイルを選択してください',
             'avatar.max' => '最大2MBまでの画像ファイルを選択してください'
         ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        // 失敗したバリデーションルールを確認
+        // dd($validator->failed());
+
+        parent::failedValidation($validator); // 通常の処理も確認する場合
     }
 }


### PR DESCRIPTION
## issue

## 概要
ユーザアイコンのファイル容量の制限(いずみ)

## 動作確認手順
- 既にアップロードされているファイルが2MB以下であり、表示がされていることを確認
- 2MB以上のファイルがアップロードされた時エラーメッセージが出ることを確認

## 考慮してほしいこと

## 確認してほしいこと
- エラーメッセージの確認のため、2.54MBのファイルをアップロードした時「The avatar failed to upload.」というエラーメッセージが出たのですがこれで合っていますか？「最大2MBまでの画像ファイルを選択してください」と出ることを予想していたのですが…