### PR TITLE
修正・人気投稿の表示（竹内）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -13,7 +13,7 @@ class PostsController extends Controller
     public function index()
     {
         $posts = Post::orderBy('id','desc')->paginate(10);
-        $topPosts = Post::withMostFavorite(5)->get();
+        $topPosts = $this->mostFavorite();
         return view('welcome', ['posts' => $posts, 'topPosts' => $topPosts]);
     }
 
@@ -65,4 +65,13 @@ class PostsController extends Controller
         }
         return back()->with('alertMessage', '投稿を削除しました');
     }
+
+    public function mostFavorite()
+    {
+        return Post::withCount('favoriteUsers')
+        ->whereHas('favoriteUsers')
+        ->orderBy('favorite_users_count', 'desc')
+        ->paginate(5);
+    }
+
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -24,14 +24,6 @@ class Post extends Model
         return $this->hasMany(Reply::class);
     }
 
-    public function scopeWithMostFavorite($query, $limit = 5)
-    {
-        return $query->withCount('favoriteUsers')
-        ->having('favorite_users_count', '>', '0')
-        ->orderBy('favorite_users_count', 'desc')
-        ->take($limit);
-    }
-
     public function tags()
     {
         return $this->belongsToMany(Tag::class)->withTimestamps();


### PR DESCRIPTION
## issue

## 概要
- 人気投稿の表示の修正

## 動作確認
### 背景 
- デプロイしたところ、仮想カラムのfavorite_users_countが正しく定義できていない為エラーとなったので以下を修正したところデプロイできました。
### 変更内容
 - Postモデルに記述していた、scopeWithMostFavoriteメソッドを削除。
 - 新たにPostsControllerでmostFavoriteメソッドを記述。
 - havingをwhereHasへ変更しfavoritesテーブルのレコードが存在する時のみいいねを取得できるように修正しました。
 
 
## 考慮して欲しいこと
特にございません

## 確認して欲しいこと
デプロイする際はデプロイ専用のブランチを用意した方がいいのでしょうか？理由も合わせて頂けますと幸いです。
