### PR TITLE
#1358 返信に対するいいね機能（小宮山）

### DIFF
--- a/app/Http/Controllers/ReplyFavoritesController.php
+++ b/app/Http/Controllers/ReplyFavoritesController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ReplyFavoritesController extends Controller
+{
+    public function store($id)
+    {
+        \Auth::user()->replyFavorite($id);
+        return back();
+    }
+
+    public function destroy($id)
+    {
+        \Auth::user()->replyUnFavorite($id);
+        return back();
+    }
+}

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -22,4 +22,9 @@ class Reply extends Model
     {
         return $this->belongsTo(Post::class);
     }
+
+    public function replyFavoriteUsers()
+    {
+        return $this->belongsToMany(User::class,'reply_favorites','reply_id','user_id')->withTimestamps();
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -138,4 +138,43 @@ class User extends Authenticatable
     {
         return $this->favorites()->where('post_id', $postId)->exists();
     }
+
+
+    // 返信に対するいいね機能・リレーション
+    public function replyFavorites()
+    {
+        return $this->belongsToMany(Reply::class, 'reply_favorites', 'user_id', 'reply_id');
+    }
+
+    // いいねをする
+    public function replyFavorite($replyId)
+    {
+        $exist = $this->isReplyFavorite($replyId);
+        if ($exist) {
+            return false;
+        }
+        else {
+            $this->replyFavorites()->attach($replyId);
+            return true;
+        }
+    }
+
+    // いいねを外す
+    public function replyUnfavorite($replyId)
+    {
+        $exist = $this->isReplyFavorite($replyId);
+        if ($exist) {
+            $this->replyFavorites()->detach($replyId);
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    // いいねしているかどうか確認
+    public function isReplyFavorite($replyId)
+    {
+        return $this->replyFavorites()->where('reply_id', $replyId)->exists();
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -143,7 +143,7 @@ class User extends Authenticatable
     // 返信に対するいいね機能・リレーション
     public function replyFavorites()
     {
-        return $this->belongsToMany(Reply::class, 'reply_favorites', 'user_id', 'reply_id');
+        return $this->belongsToMany(Reply::class, 'reply_favorites', 'user_id', 'reply_id')->withTimestamps();
     }
 
     // いいねをする

--- a/database/migrations/2024_12_11_153227_create_reply_favorites_table.php
+++ b/database/migrations/2024_12_11_153227_create_reply_favorites_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateReplyFavoritesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reply_favorites', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('reply_id')->unsigned()->index();
+            $table->timestamps();
+            // 外部キー
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('reply_id')->references('id')->on('replies')->onDelete('cascade');
+            $table->unique(['user_id', 'reply_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('reply_favorites');
+    }
+}

--- a/resources/views/favorite/reply_favorite_button.blade.php
+++ b/resources/views/favorite/reply_favorite_button.blade.php
@@ -1,0 +1,28 @@
+@php
+    $countReplyFavoriteUsers = $reply->replyFavoriteUsers()->count();
+@endphp
+
+@if (Auth::check())
+    @if (Auth::user()->isReplyFavorite($reply->id))
+        <form method="POST" action="{{ route('reply.unfavorite', $reply->id) }}#reply-{{ $reply->id }}"class="d-inline-block" data-toggle="tooltip" title="いいねを取り消す">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn m-0 p-1 shadow-none"><i class="bi bi-heart-fill"></i></button>
+        </form>
+    @else
+        <form method="POST" action="{{ route('reply.favorite', $reply->id) }}#reply-{{ $reply->id }}" class="d-inline-block" data-toggle="tooltip" title="いいね">
+            @csrf
+            <button type="submit" class="btn m-0 p-1 shadow-none"><i class="bi bi-heart"></i></button>
+        </form>
+    @endif
+@else
+    <a href="{{ route('login') }}" class="btn m-0 p-1 shadow-none" data-toggle="tooltip" title="いいねしてログイン"><i class="bi bi-heart"></i></a>
+@endif
+<span id="favorite-count-{{ $reply->id }}" class="badge badge-pill">{{ $countReplyFavoriteUsers }}</span>
+
+<script>
+    // ツールチップ初期化処理
+    document.addEventListener('DOMContentLoaded', function () {
+        $('[data-toggle="tooltip"]').tooltip();
+    });
+</script>

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -12,6 +12,11 @@
                         <p class="mb-2">{!! nl2br(e($reply->content)) !!}</p>
                         <p class="text-muted">{{$reply->created_at}}</p>
                     </div>
+                    <div class="d-flex align-items-center w-75 mb-2 mx-auto">
+                        <div class="mr-4">
+                            @include('favorite.reply_favorite_button', ['reply' => $reply])
+                        </div>
+                    </div>
                 </div>
                 @if(Auth::id() === $reply->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">

--- a/routes/web.php
+++ b/routes/web.php
@@ -80,6 +80,10 @@ Route::group(['middleware' => 'auth'], function(){
             Route::put('edit', 'RepliesController@update')->name('reply.update');
             // 返信の削除
             Route::delete('delete', 'RepliesController@destroy')->name('reply.delete');
+            //返信に対するいいねの登録
+            Route::post('favorite', 'ReplyFavoritesController@store')->name('reply.favorite');
+            // 返信に対するいいねの削除
+            Route::delete('unfavorite', 'ReplyFavoritesController@destroy')->name('reply.unfavorite');
         });
     });
 });


### PR DESCRIPTION
## issue
 - Closes #1358 

## 概要
 - 返信に対するいいね機能の実装

## 動作確認手順
 - 下記コマンドを実行。
 - マイグレーションの実行
php artisan migrate
 - Adminerでreply_favoritesテーブルが作成されていることを確認。
 - ログイン後、返信一覧画面にアクセスし、ハートマークをクリックすると、いいねが登録され、  
再度クリックすると解除される。  
また、Adminerでreply_favoritesテーブルが更新されることを確認。

## 考慮してほしいこと
 - 特にありません。

## 確認してほしいこと
 - 特にありません。