### PR TITLE
パスワード入力欄の削除とプロフィール文入力欄の設定(いずみ)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -45,8 +45,10 @@ class UsersController extends Controller
         if ($request->filled('email')) {
             $user->email = $request->email;
         }
-        if ($request->filled('password')) {
-            $user->password = bcrypt($request->password);
+        if ($request->has('profile')) {
+            $user->profile = $request->profile;
+        } else {
+            $user->profile = 'プロフィール文が設定されていません';
         }
         if ($request->hasFile('avatar')) {
             if ($user->avatar) {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -47,9 +47,7 @@ class UsersController extends Controller
         }
         if ($request->has('profile')) {
             $user->profile = $request->profile;
-        } else {
-            $user->profile = 'プロフィール文が設定されていません';
-        }
+        } 
         if ($request->hasFile('avatar')) {
             if ($user->avatar) {
                 Storage::delete($user->avatar);

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -26,7 +26,7 @@ class UserRequest extends FormRequest
         return [
             'name' => ['nullable', 'string', 'max:255'],
             'email' => ['nullable', 'string', 'email', 'max:255', 'unique:users,email,'. $this->id],
-            'password' => ['required', 'string', 'min:4', 'confirmed'],
+            'profile' => ['nullable', 'string', 'max:140'],
             'avatar' => ['nullable', 'image', 'mimes:jpeg,png']
         ];
     }

--- a/database/migrations/2024_12_14_223159_add_profile_to_users_table.php
+++ b/database/migrations/2024_12_14_223159_add_profile_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProfileToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('profile')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('profile');
+        });
+    }
+}

--- a/resources/views/commons/posts_list.blade.php
+++ b/resources/views/commons/posts_list.blade.php
@@ -15,7 +15,7 @@
                             <h6 class="mb-0">
                                 <a href="{{ route('user.show', $post->user->id) }}" class="text-decoration-none text-dark">{{ $post->user->name }}</a>
                             </h6>
-                            <small class="text-muted">{{ $post->created_at->format('Y年m月d日 H:i') }}</small>
+                            <small class="text-muted">{{ $post->created_at }}</small>
                         </div>
                     </div>
                     <!-- コンテンツ部分 -->

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
         <link rel="stylesheet" href="{{ asset('/css/styles.css') }}">
+        @stack('styles')
     </head>
     <body>
         @include('commons.header')
@@ -17,5 +18,7 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script defer src="https://use.fontawesome.com/releases/v5.7.2/js/all.js"></script>
+        <script src="/js/app.js"></script>
+        @stack('scripts')
     </body>
 </html>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -52,9 +52,7 @@
         <div class="form-group">
             <label for="profile">プロフィール文</label>
             <textarea class="form-control" name="profile" rows="4">{{ old('profile', $user->profile) }}</textarea>
-            <div class="text-right mt-3">
-                <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i></button>
-            </div>
+            
         </div>
         <div class="d-flex justify-content-between">
             <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -34,9 +34,9 @@
         @csrf
         @method('PUT')
         <div class="form-group">
-                <label for="avatar">新しいプロフィール画像</label>
-                <input type="file" name="avatar" id="avatar" class="form-control">
-            </div>
+            <label for="avatar">新しいプロフィール画像</label><br>
+            <input type="file" name="avatar" id="avatar">
+        </div>
     
         <input type="hidden" name="id" value="{{ old('id', $user->id) }}" />
         <div class="form-group">
@@ -50,15 +50,12 @@
         </div>
 
         <div class="form-group">
-            <label for="password">パスワード</label>
-            <input class="form-control" type="password" name="password" />
+            <label for="profile">プロフィール文</label>
+            <textarea class="form-control" name="profile" rows="4">{{ old('profile', $user->profile) }}</textarea>
+            <div class="text-right mt-3">
+                <button type="submit" class="btn btn-primary"><i class="fas fa-check"></i></button>
+            </div>
         </div>
-
-        <div class="form-group">
-            <label for="password_confirmation">パスワードの確認</label>
-            <input class="form-control" type="password" name="password_confirmation" />
-        </div>
-
         <div class="d-flex justify-content-between">
             <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
             <button type="submit" class="btn btn-primary">更新する</button>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -5,11 +5,11 @@
 <div class="container">
 <div class="row">
     <aside class="col-sm-4 mb-5">
-        <div class="card-container">
-            <div class="card" onclick="toggleCard(this)">
-                <div class="card-front">
-                    <div class="card-header">
-                        <h3 class="card-title" style="display: inline-block; margin-right: 200px;">
+        <div class="userCard-container">
+            <div class="userCard" onclick="toggleCard(this)">
+                <div class="userCard-front">
+                    <div class="userCard-header">
+                        <h3 class="userCard-title" style="display: inline-block; margin-right: 200px;">
                             {{ $user->name }}
                         </h3>
                         @if (Auth::id() === $user->id)
@@ -22,7 +22,7 @@
                         {{-- Follow Button --}}
                         @include('commons.follow_button',['user'=> $user])
                     </div>
-                    <div class="card-body">
+                    <div class="userCard-body">
                         @if($user->avatar)
                             <img class="rounded-circle img-fluid" src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像">
                         @else
@@ -30,11 +30,11 @@
                         @endif  
                     </div>
                 </div>
-                <div class="card-back">
-                    <div class="card-header">
-                        <h4>{{ $user->name }}のプロフィール</h4>
+                <div class="userCard-back">
+                    <div class="userCard-header">
+                        <h4>{{ $user->name }}</h4>
                     </div>
-                    <div class="card-body">
+                    <div class="userCard-body">
                         @if($user->profile)
                             <p>{{ $user->profile }}</p>
                         @endif
@@ -63,15 +63,15 @@
         @endif
     </div>
 </div>
-<<<<<<< HEAD
 @endsection
 @push('styles')
     <style>
-        .card-container {
+        .userCard-container {
             perspective: 1000px;
         }
 
-        .card {
+        .userCard {
+            background-color: #f2f2f2;
             width: 100%;
             height: 500px;
             position: relative;
@@ -80,7 +80,8 @@
             cursor: pointer;
         }
 
-        .card-front, .card-back {
+        .userCard-front, .userCard-back {
+            background-color: #f2f2f2;
             position: absolute;
             width: 100%;
             height: 100%;
@@ -93,30 +94,27 @@
             overflow: hidden;
         }
 
-        .card-front {
+        .userCard-front {
             color: #2a0750;
             z-index: 2;
         }
 
-        .card-back {
+        .userCard-back {
             color: #2a0750;
             transform: rotateY(180deg);
             z-index: 1;
         }
 
-        .card.is-flipped {
+        .userCard.is-flipped {
             transform: rotateY(180deg);
         }
     </style>
 @endpush
 @push('scripts')
 <script>
-        function toggleCard(card) {
-            card.classList.toggle('is-flipped'); // クラスを切り替える
+        function toggleCard(userCard) {
+            userCard.classList.toggle('is-flipped'); // クラスを切り替える
         }
 </script>
 @endpush
-=======
-</div>
-@endsection
->>>>>>> develop_a_kannaduki_dra
+

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -5,10 +5,10 @@
 <div class="row">
     <aside class="col-sm-4 mb-5">
         <div class="card-container">
-            <div class="card bg-info" onclick="toggleCard(this)">
+            <div class="card" onclick="toggleCard(this)">
                 <div class="card-front">
                     <div class="card-header">
-                        <h3 class="card-title text-light" style="display: inline-block; margin-right: 200px;">
+                        <h3 class="card-title" style="display: inline-block; margin-right: 200px;">
                             {{ $user->name }}
                         </h3>
                         @if (Auth::id() === $user->id)
@@ -30,14 +30,12 @@
                     </div>
                 </div>
                 <div class="card-back">
-                    <div class="card-header text-light">
+                    <div class="card-header">
                         <h4>{{ $user->name }}のプロフィール</h4>
                     </div>
-                    <div class="card-body text-light">
+                    <div class="card-body">
                         @if($user->avatar)
                             <p>{{ $user->profile }}</p>
-                        @else
-                            <p>{{ 'プロフィール文が設定されていません' }}</p>
                         @endif
                     </div>
                 </div>
@@ -65,50 +63,54 @@
     </div>
 </div>
 @endsection
+@push('styles')
+    <style>
+        .card-container {
+            perspective: 1000px;
+        }
+
+        .card {
+            width: 100%;
+            height: 500px;
+            position: relative;
+            transform-style: preserve-3d;
+            transition: transform 0.6s ease-in-out;
+            cursor: pointer;
+        }
+
+        .card-front, .card-back {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            backface-visibility: hidden;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            border-radius: 10px;
+            overflow: hidden;
+        }
+
+        .card-front {
+            color: #2a0750;
+            z-index: 2;
+        }
+
+        .card-back {
+            color: #2a0750;
+            transform: rotateY(180deg);
+            z-index: 1;
+        }
+
+        .card.is-flipped {
+            transform: rotateY(180deg);
+        }
+    </style>
+@endpush
+@push('scripts')
 <script>
-    function toggleCard(card) {
-        card.classList.toggle('is-flipped'); // クラスを切り替える
-    }
+        function toggleCard(card) {
+            card.classList.toggle('is-flipped'); // クラスを切り替える
+        }
 </script>
-<style>
-    .card-container {
-        perspective: 1000px;
-    }
-
-    .card {
-        width: 100%;
-        height: 500px;
-        position: relative;
-        transform-style: preserve-3d;
-        transition: transform 0.6s ease-in-out;
-        cursor: pointer;
-    }
-
-    .card-front, .card-back {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        backface-visibility: hidden;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        border-radius: 10px;
-        overflow: hidden;
-    }
-
-    .card-front {
-        background-color: #17a2b8;
-        z-index: 2;
-    }
-
-    .card-back {
-        background-color: #117a8b;
-        transform: rotateY(180deg);
-        z-index: 1;
-    }
-
-    .card.is-flipped {
-        transform: rotateY(180deg);
-    }
-</style>
+@endpush

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -4,25 +4,43 @@
 @yield('scripts')
 <div class="row">
     <aside class="col-sm-4 mb-5">
-        <div class="card bg-info">
-            <div class="card-header">
-                <h3 class="card-title text-light">{{ $user->name }}</h3>
-                {{-- Follow Button --}}
-                @include('commons.follow_button',['user'=> $user])
-            </div>
-            <div class="card-body">
-                @if($user->avatar)
-                    <img class="rounded-circle img-fluid" src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像">
-                @else
-                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像">
-                @endif  
-                @auth
-                    @if (Auth::id() === $user->id)
-                        <div class="mt-3">
-                            <a href="{{ route('user.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
-                        </div>
-                    @endif
-                @endauth
+        <div class="card-container">
+            <div class="card bg-info" onclick="toggleCard(this)">
+                <div class="card-front">
+                    <div class="card-header">
+                        <h3 class="card-title text-light" style="display: inline-block; margin-right: 200px;">
+                            {{ $user->name }}
+                        </h3>
+                        @if (Auth::id() === $user->id)
+                            <div class="mt-3" style="display: inline-block;">
+                                <a href="{{ route('user.edit', $user->id) }}" style="text-decoration: none;">
+                                    <i class="fas fa-cog fa-2x"></i>
+                                </a>
+                            </div>
+                        @endif
+                        {{-- Follow Button --}}
+                        @include('commons.follow_button',['user'=> $user])
+                    </div>
+                    <div class="card-body">
+                        @if($user->avatar)
+                            <img class="rounded-circle img-fluid" src="{{ Storage::url($user->avatar) }}" alt="現在のプロフィール画像">
+                        @else
+                            <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像">
+                        @endif  
+                    </div>
+                </div>
+                <div class="card-back">
+                    <div class="card-header text-light">
+                        <h4>{{ $user->name }}のプロフィール</h4>
+                    </div>
+                    <div class="card-body text-light">
+                        @if($user->avatar)
+                            <p>{{ $user->profile }}</p>
+                        @else
+                            <p>{{ 'プロフィール文が設定されていません' }}</p>
+                        @endif
+                    </div>
+                </div>
             </div>
         </div>
     </aside>
@@ -47,3 +65,50 @@
     </div>
 </div>
 @endsection
+<script>
+    function toggleCard(card) {
+        card.classList.toggle('is-flipped'); // クラスを切り替える
+    }
+</script>
+<style>
+    .card-container {
+        perspective: 1000px;
+    }
+
+    .card {
+        width: 100%;
+        height: 500px;
+        position: relative;
+        transform-style: preserve-3d;
+        transition: transform 0.6s ease-in-out;
+        cursor: pointer;
+    }
+
+    .card-front, .card-back {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        backface-visibility: hidden;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        border-radius: 10px;
+        overflow: hidden;
+    }
+
+    .card-front {
+        background-color: #17a2b8;
+        z-index: 2;
+    }
+
+    .card-back {
+        background-color: #117a8b;
+        transform: rotateY(180deg);
+        z-index: 1;
+    }
+
+    .card.is-flipped {
+        transform: rotateY(180deg);
+    }
+</style>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -14,7 +14,7 @@
                         @if (Auth::id() === $user->id)
                             <div class="mt-3" style="display: inline-block;">
                                 <a href="{{ route('user.edit', $user->id) }}" style="text-decoration: none;">
-                                    <i class="fas fa-cog fa-2x"></i>
+                                    <i class="fas fa-pencil-alt fa-2x"></i>
                                 </a>
                             </div>
                         @endif
@@ -34,7 +34,7 @@
                         <h4>{{ $user->name }}のプロフィール</h4>
                     </div>
                     <div class="card-body">
-                        @if($user->avatar)
+                        @if($user->profile)
                             <p>{{ $user->profile }}</p>
                         @endif
                     </div>


### PR DESCRIPTION
## issue

## 概要
- ユーザ詳細画面のパスワード入力欄の削除とプロフィール文入力欄の設定

## 動作確認手順
- http://localhost:8080/ へアクセスしログイン後、ユーザ詳細画面へ遷移後歯車アイコンを押下し、パスワード入力欄が削除されていることとプロフィール文入力欄が設定されていることを確認
- プロフィール文入力欄に「テスト」と入力し更新後、ユーザ詳細画面のユーザ名やユーザアバターが表示されているカードを押下すると裏面にひっくり返り、プロフィール文が表示されていることを確認

## 考慮してほしいこと
- style.css に切り分けるとcssが効かなかったのでbladeに直接書きました。

## 確認してほしいこと
- ユーザ詳細画面のタイムラインの投稿一覧の吹き出しアイコン（コメント）と、投稿編集ボタンのビューが乱れてしまいました。users/show.blade.php の<style>タグ内のcssがその他のビューに影響していることは確認できたので、ひとつずつ処理を行いながらブラウザを確認しましたがcssが１つでも記載されているとビューが乱れることがわかりました。
- トップページの投稿一覧は問題なく表示されているので、タイムラインの投稿のビューのみ調整（吹き出しアイコンを上にずらすなど）するのはおかしくなると思いやっていません。
- クラス名をユニークなものにすると他に影響を与えないと思いプレフィックスを追加しましたが変化はありませんでした
- ユーザ詳細画面のユーザ名などが表示されているカードのみにcssを適用する方法はありますか？