### PR TITLE
活動記録の編集・削除機能、マイページでの一覧表示（小宮山）

### DIFF
--- a/app/Http/Controllers/ActivitiesController.php
+++ b/app/Http/Controllers/ActivitiesController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 Use App\Area;
 Use App\Activity;
+Use App\User;
 use App\Http\Requests\ActivityRequest;
 
 class ActivitiesController extends Controller
@@ -79,5 +80,18 @@ class ActivitiesController extends Controller
             $activity->delete();
         }
         return back()->with('alertMessage', '活動記録を削除しました');
+    }
+
+    // ユーザーが所有する活動記録の一覧
+    public function userActivities($id)
+    {
+        $user = User::findOrFail($id);
+        if ($user->id !== \Auth::id()) {
+            abort(403);
+        }
+
+        $activities = $user->activities()->orderBy('id', 'desc')->paginate(10);
+
+        return view('activities.user_activities', ['activities' => $activities]);
     }
 }

--- a/app/Http/Controllers/ActivitiesController.php
+++ b/app/Http/Controllers/ActivitiesController.php
@@ -69,6 +69,15 @@ class ActivitiesController extends Controller
         $activity->date = $request->date;
         $activity->save();
 
-        return redirect()->route('post.index')->with('successMessage', 'ラ活記録を更新しました');
+        return redirect()->route('post.index')->with('successMessage', '活動記録を更新しました');
+    }
+
+    public function destroy($id)
+    {
+        $activity = Activity::findOrFail($id);
+        if ($activity->user_id === \Auth::id()){
+            $activity->delete();
+        }
+        return back()->with('alertMessage', '活動記録を削除しました');
     }
 }

--- a/app/Http/Controllers/ActivitiesController.php
+++ b/app/Http/Controllers/ActivitiesController.php
@@ -59,9 +59,11 @@ class ActivitiesController extends Controller
         $activity = Activity::findOrFail($id);
         $user = \Auth::user();
 
-        \Storage::disk('public')->delete($activity->image);
-        $path = $request->file('image')->store('shop-images', 'public');
-        $activity->image = $path;
+        if ($request->hasFile('image')) {
+            \Storage::disk('public')->delete($activity->image);
+            $path = $request->file('image')->store('shop-images', 'public');
+            $activity->image = $path;
+        }
 
         $activity->user_id = $user->id;
         $activity->shop_name = $request->shop_name;

--- a/app/Http/Controllers/ActivitiesController.php
+++ b/app/Http/Controllers/ActivitiesController.php
@@ -33,4 +33,42 @@ class ActivitiesController extends Controller
 
         return redirect()->route('post.index')->with('successMessage', '活動を記録しました');
     }
+
+    public function edit($id)
+    {
+        $activity = Activity::findOrFail($id);
+        $areas = Area::all();
+        $user = \Auth::user();
+
+        if ($user->id !== $activity->user_id) {
+            abort(403);
+        }
+
+        $data = [
+            'activity' => $activity,
+            'areas' => $areas,
+        ];
+
+        return view('activities.edit', $data);
+    }
+
+    public function update(ActivityRequest $request, $id)
+    {
+        $activity = Activity::findOrFail($id);
+        $user = \Auth::user();
+
+        \Storage::disk('public')->delete($activity->image);
+        $path = $request->file('image')->store('shop-images', 'public');
+        $activity->image = $path;
+
+        $activity->user_id = $user->id;
+        $activity->shop_name = $request->shop_name;
+        $activity->area_id = $request->area_id;
+        $activity->menu_name = $request->menu_name;
+        $activity->comment = $request->comment;
+        $activity->date = $request->date;
+        $activity->save();
+
+        return redirect()->route('post.index')->with('successMessage', 'ラ活記録を更新しました');
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -14,10 +14,15 @@ class UsersController extends Controller
     {
         $user = User::findOrFail($id);
         $posts = $user->posts()->orderBy('id', 'desc')->paginate(10);
+        $countActivities = $user->countActivities();
+        $countActivitiesThisMonth = $user->countActivitiesThisMonth();
+
         $data = [
             'user' => $user,
             'posts' => $posts,
             'tab' =>'timeline',
+            'countActivities' => $countActivities,
+            'countActivitiesThisMonth' => $countActivitiesThisMonth,
         ];
         $data += $this->userCounts($user);
         return view('users.show', $data);

--- a/app/Http/Requests/ActivityRequest.php
+++ b/app/Http/Requests/ActivityRequest.php
@@ -33,11 +33,11 @@ class ActivityRequest extends FormRequest
         ];
 
         // 新規登録時と更新時で条件分岐
+        $rulesImageExist = 'required';
         if ($this->isMethod('put')) {
-            $rules['image'] = 'nullable|image|mimes:jpg,jpeg,png|max:2048';
-        } else {
-            $rules['image'] = 'required|image|mimes:jpg,jpeg,png|max:2048';
+            $rulesImageExist = 'nullable';
         }
+        $rules['image'] = $rulesImageExist . '|image|mimes:jpg,jpeg,png|max:2048';
         return $rules;
     }
 

--- a/app/Http/Requests/ActivityRequest.php
+++ b/app/Http/Requests/ActivityRequest.php
@@ -26,12 +26,19 @@ class ActivityRequest extends FormRequest
     {
         return [
             'area_id' => 'required',
-            'image' => 'required|image|mimes:jpg,jpeg,png|max:2048',
             'shop_name' => 'required',
             'menu_name' => 'required',
             'comment' => 'nullable',
             'date' => 'required|date|before_or_equal:' . Carbon::yesterday()->format('Y-m-d'),
         ];
+
+        // 新規登録時と更新時で条件分岐
+        if ($this->isMethod('put')) {
+            $rules['image'] = 'nullable|image|mimes:jpg,jpeg,png|max:2048';
+        } else {
+            $rules['image'] = 'required|image|mimes:jpg,jpeg,png|max:2048';
+        }
+        return $rules;
     }
 
     public function attributes()

--- a/app/User.php
+++ b/app/User.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Carbon\Carbon;
 
 class User extends Authenticatable
 {
@@ -52,6 +53,21 @@ class User extends Authenticatable
     public function activities()
     {
         return $this->hasMany(Activity::class);
+    }
+
+    // 活動記録の総数を取得
+    public function countActivities()
+    {
+        return $this->activities()->count();
+    }
+
+    // 今月の活動記録の数を取得
+    public function countActivitiesThisMonth()
+    {
+        return $this->activities()
+            ->whereYear('date', Carbon::now()->year)
+            ->whereMonth('date', Carbon::now()->month)
+            ->count();
     }
 
     // フォロワーを取得

--- a/public/css/activities/form.css
+++ b/public/css/activities/form.css
@@ -1,4 +1,4 @@
-.create__content {
+.activity__content {
     background-color: rgba(255, 255, 255, 0.8);
     padding: 40px;
     border-radius: 8px;

--- a/public/css/activities/user_activities.css
+++ b/public/css/activities/user_activities.css
@@ -3,3 +3,123 @@
     padding: 40px;
     border-radius: 8px;
 }
+.date-nav{
+    margin-top: 20px;
+    display: flex;
+    align-items: flex-end;
+}
+.date-nav__button{
+    font-size: 14px;
+    font-weight: bold;
+    border: none;
+    background-color: rgba(255, 255, 255, 0);
+}
+.date-nav__link:hover{
+    text-decoration: none;
+}
+.content-f{
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+.activity__count {
+    width: 40%;
+    background-color: #2b4269;
+    color: #fff;
+    border-radius: 4px;
+    padding: 10px;
+    display: flex;
+    justify-content: center;
+    gap: 20%;
+}
+.activity__count-total,
+.activity__count-month {
+    margin: 0;
+    padding: 0;
+    font-size: 14px;
+}
+.activity__count-total span,
+.activity__count-month span {
+    font-size: 32px;
+    font-weight: bold;
+    display: inline-block;
+    margin-left: 6px;
+    margin-right: 6px;
+}
+.month-list{
+    margin-top: 20px;
+}
+.month-list__heading{
+    padding: 8px 16px;
+    border-bottom: 2px solid #d34441;
+    background-color: #f9ece2;
+    font-size: 24px;
+}
+.month-list__content-f{
+    margin-top: 20px;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: calc(10px + 1vw);
+    row-gap: calc(20px + 4vh);
+    justify-content: center;
+}
+.activity-card{
+    width: 100%;
+}
+.activity-card a{
+    text-decoration: none;
+    color: #000;
+    transition: opacity 0.3s;
+}
+.activity-card a:hover {
+    text-decoration: none;
+    color: #000;
+    opacity: 0.7;
+}
+.activity-card__img{
+    width: 100%;
+    aspect-ratio: 1 / 1;
+}
+.activity-card__img img{
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 4px;
+}
+.activity-card__shop-name p{
+    margin: 4px 0 0 0;
+    padding: 0;
+}
+
+
+@media(max-width: 991px) {
+    .content-f {
+        flex-direction: column;
+    }
+    .activity__count {
+        width: 100%;
+    }
+    .activity__count-total,
+    .activity__count-month {
+        font-size: 12px;
+    }
+    .activity__count-total span,
+    .activity__count-month span {
+        font-size: 24px;
+        font-weight: bold;
+        display: inline-block;
+        margin-left: 2px;
+        margin-right: 2px;
+    }
+}
+
+@media(max-width: 767px) {
+    .month-list__content-f {
+        grid-template-columns: repeat(3, 1fr);
+        gap: calc(10px + 1vw);
+        row-gap: calc(20px + 2vh);
+    }
+    .activity-card__shop-name p {
+        font-size: 14px;
+    }
+}

--- a/public/css/activities/user_activities.css
+++ b/public/css/activities/user_activities.css
@@ -1,0 +1,5 @@
+.activities__content {
+    background-color: rgba(255, 255, 255, 0.8);
+    padding: 40px;
+    border-radius: 8px;
+}

--- a/public/css/users/show.css
+++ b/public/css/users/show.css
@@ -62,7 +62,8 @@
 }
 .activity__count{
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
+    gap: 20%;
 }
 .activity__count-total, .activity__count-month{
     margin: 10px 0 0 0;

--- a/public/css/users/show.css
+++ b/public/css/users/show.css
@@ -1,5 +1,6 @@
 .content-f{
     display: flex;
+    flex-direction: row;
 }
 .card.custom-card{
     background-color: #ad302e;
@@ -45,6 +46,73 @@
     text-decoration: none;
     color: #fff;
 }
+.activity-card{
+    width: 100%;
+    background-color: #2b4269;
+    color: #fff;
+    border-radius: 4px;
+    padding: 20px;
+}
+.activity-card .activity__heading{
+    font-size: 18px;
+    font-weight: bold;
+    border-bottom: 1px solid #fff;
+    margin: 0;
+    padding: 0 0 10px 0;
+}
+.activity__count{
+    display: flex;
+    justify-content: space-between;
+}
+.activity__count-total, .activity__count-month{
+    margin: 10px 0 0 0;
+    padding: 0;
+    font-size: 14px;
+}
+.activity__count-total span, .activity__count-month span{
+    font-size: 32px;
+    font-weight: bold;
+    display: inline-block;
+    margin-left: 6px;
+    margin-right: 6px;
+}
+
+.activity__link{
+    margin-top: 10px;
+    padding: 6px 0;
+    text-align: center;
+    display: block;
+    width: 100%;
+    background-color: #fff;
+    text-decoration: none;
+    color: #2b4269;
+    border-radius: 4px;
+    transition: opacity 0.3s;
+}
+.activity__link:hover{
+    text-decoration: none;
+    color: #2b4269;
+    opacity: 0.7;
+}
+
+@media(max-width: 991px) {
+    .activity__count{
+        flex-direction: column;
+    }
+}
+
+@media(max-width: 767px) {
+    .activity__count-total,
+    .activity__count-month {
+        font-size: 12px;
+    }
+    .activity__count-total span,
+    .activity__count-month span {
+        font-size: 24px;
+        margin-left: 2px;
+        margin-right: 2px;
+    }
+}
 
 @media(max-width: 575px) {
     .content-f {
@@ -52,5 +120,20 @@
     }
     .custom-tabs {
         width: 100%;
+    }
+    .activity__count {
+        flex-direction: row;
+        justify-content: center;
+        gap: 10%;
+    }
+    .activity__count-total,
+    .activity__count-month {
+        font-size: 14px;
+    }
+    .activity__count-total span,
+    .activity__count-month span {
+        font-size: 32px;
+        margin-left: 6px;
+        margin-right: 6px;
     }
 }

--- a/resources/views/activities/activities.blade.php
+++ b/resources/views/activities/activities.blade.php
@@ -9,7 +9,7 @@
             <div class="">
                 <div id="activity-{{ $activity->id }}">
                     <div class="text-left d-inline-block w-75">
-                        <div class="activity-img" style="width: 80%; aspect-ratio: 1 / 1;">
+                        <div class="activity-img" style="width: 100%; aspect-ratio: 1 / 1;">
                             <img src="{{ asset('storage/' . $activity->image) }}" alt="ラーメンの画像" style="width: 100%; height: 100%; object-fit: cover; border-radius: 8px;">
                         </div>
                         <p class="mt-2" style="font-weight: bold; font-size: 20px;">{{ $activity->shop_name }}</p>

--- a/resources/views/activities/activities.blade.php
+++ b/resources/views/activities/activities.blade.php
@@ -24,7 +24,7 @@
                 </div>
                 @if(Auth::id() === $activity->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        <form method="POST" action="">
+                        <form method="POST" action="{{ route('activity.delete', $activity->id) }}">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>

--- a/resources/views/activities/activities.blade.php
+++ b/resources/views/activities/activities.blade.php
@@ -29,7 +29,7 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('activity.edit', $activity->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/resources/views/activities/edit.blade.php
+++ b/resources/views/activities/edit.blade.php
@@ -6,42 +6,43 @@
 
 @section('content')
     <div class="activity__content">
-        <h2 class="mt-2 mb-3">食べたラーメンを記録する</h2>
+        <h2 class="mt-2 mb-3">ラ活記録を編集する</h2>
         @include('commons.error_messages')
-        <form method="post" action="{{ route('activity.store') }}" enctype="multipart/form-data">
+        <form method="post" action="{{ route('activity.update', $activity->id) }}" enctype="multipart/form-data">
             @csrf
+            @method('PUT')
             <div class="form-group">
-                <div class="shop-image-preview" id="shopImagePreview"></div>
+                <div class="shop-image-preview" id="shopImagePreview" style="background-image: url('{{ asset('storage/' . $activity->image) }}')"></div>
                 <label class="shop-image-label" for="image">画像を選択する</label>
                 <input class="shop-image-input" id="image" type="file" name="image" accept="image/*">
             </div>
             <div class="form-group">
                 <label for="shop_name">店舗名</label>
-                <input class="form-control" type="text" value="{{ old('shop_name') }}" name="shop_name" id="shop_name" />
+                <input class="form-control" type="text" value="{{ old('shop_name', $activity->shop_name) }}" name="shop_name" id="shop_name" />
             </div>
             <div class="form-group">
                 <label for="area">エリア</label>
                 <select class="form-control create-form__select" name="area_id" id="area">
                     <option value="" disabled selected>選択してください</option>
                     @foreach ($areas as $area)
-                        <option value="{{ $area->id }}" {{ old('area_id') == $area->id ? 'selected' : '' }}>{{ $area->prefecture }}</option>
+                        <option value="{{ $area->id }}" {{ old('area_id', $activity->area_id) == $area->id ? 'selected' : '' }}>{{ $area->prefecture }}</option>
                     @endforeach
                 </select>
                 <i class="fas fa-caret-down custom-arrow"></i>
             </div>
             <div class="form-group">
                 <label for="menu_name">食べたメニュー</label>
-                <input class="form-control" type="text" value="{{ old('menu_name') }}" name="menu_name" id="menu_name" />
+                <input class="form-control" type="text" value="{{ old('menu_name', $activity->menu_name) }}" name="menu_name" id="menu_name" />
             </div>
             <div class="form-group">
                 <label for="comment">コメント</label>
-                <textarea class="form-control" name="comment" id="comment" rows="4">{{ old('comment') }}</textarea>
+                <textarea class="form-control" name="comment" id="comment" rows="4">{{ old('comment', $activity->comment) }}</textarea>
             </div>
             <div class="form-group">
                 <label for="date">食べた日付</label>
-                <input class="form-control" type="date" value="{{ old('date') }}" name="date" id="date" />
+                <input class="form-control" type="date" value="{{ old('date', $activity->date) }}" name="date" id="date" />
             </div>
-            <button type="submit" class="btn btn-primary">投稿する</button>
+            <button type="submit" class="btn btn-primary">更新する</button>
         </form>
     </div>
 @endsection

--- a/resources/views/activities/edit.blade.php
+++ b/resources/views/activities/edit.blade.php
@@ -12,7 +12,7 @@
             @csrf
             @method('PUT')
             <div class="form-group">
-                <div class="shop-image-preview" id="shopImagePreview" style="background-image: url('{{ asset('storage/' . $activity->image) }}')"></div>
+                <div class="shop-image-preview" id="shopImagePreview" style="background-image: url('{{ old('image') ? asset('storage/' . old('image')) : asset('storage/' . $activity->image) }}')"></div>
                 <label class="shop-image-label" for="image">画像を選択する</label>
                 <input class="shop-image-input" id="image" type="file" name="image" accept="image/*">
             </div>

--- a/resources/views/activities/month_activities.blade.php
+++ b/resources/views/activities/month_activities.blade.php
@@ -1,0 +1,21 @@
+<div class="activity-list">
+    @foreach ($activities as $month => $monthActivities)
+        <div class="month-list">
+            <h3 class="month-list__heading">{{ $month }}（{{ $monthActivities->count() }}）</h3>
+            <div class="month-list__content-f">
+                @foreach ($monthActivities as $activity)
+                    <div class="activity-card">
+                        <a href="">
+                            <div class="activity-card__img">
+                                <img src="{{ asset('storage/' . $activity->image) }}" alt="活動記録の画像">
+                            </div>
+                            <div class="activity-card__shop-name">
+                                <p>{{ $activity->shop_name}}</p>
+                            </div>
+                        </a>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endforeach
+</div>

--- a/resources/views/activities/user_activities.blade.php
+++ b/resources/views/activities/user_activities.blade.php
@@ -6,8 +6,24 @@
 
 @section('content')
     <div class="activities__content">
-        <h2 class="mt-2">ラ活の記録</h2>
-        <div class="activity-card"></div>
-        @include('activities.activities', ['activities' => $activities])
+        <div class="content-f">
+            <h2 class="mt-2">ラ活の記録</h2>
+            <div class="activity__count">
+                <p class="activity__count-total">トータル<span>{{ $countActivities }}</span>杯</p>
+                <p class="activity__count-month">今月<span>{{ $countActivitiesThisMonth }}</span>杯</p>
+            </div>
+        </div>
+        <div class="date-nav">
+            <button class="date-nav__button">
+                <a class="date-nav__link" href="{{ route('user.activities', ['id' => $user->id, 'date' => \Carbon\Carbon::parse($date)->subMonths(6)->format('Y-m')]) }}">＜</a>
+            </button>
+            <div class="date-nav__date">
+                {{ \Carbon\Carbon::parse($date)->subMonths(5)->format('Y年m月') }} 〜 {{ \Carbon\Carbon::parse($date)->format('Y年m月') }}
+            </div>
+            <button class="date-nav__button">
+                <a class="date-nav__link" href="{{ route('user.activities', ['id' => $user->id, 'date' => \Carbon\Carbon::parse($date)->addMonths(6)->format('Y-m')]) }}">＞</a>
+            </button>
+        </div>
+        @include('activities.month_activities')
     </div>
 @endsection

--- a/resources/views/activities/user_activities.blade.php
+++ b/resources/views/activities/user_activities.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('css')
+    <link rel="stylesheet" href="{{ asset('css/activities/user_activities.css') }}">
+@endsection
+
+@section('content')
+    <div class="activities__content">
+        <h2 class="mt-2">ラ活の記録</h2>
+        <div class="activity-card"></div>
+        @include('activities.activities', ['activities' => $activities])
+    </div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -24,15 +24,25 @@
                     <div class="rounded-circle overflow-hidden mx-auto" style="max-width: 100%; width: 90%; aspect-ratio: 1 / 1;">
                         <img src="{{ $user->image ? asset('storage/' . $user->image) : Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像" class="w-100 h-100" style="object-fit: cover;">
                     </div>
-                        @if (Auth::id() === $user->id)
-                            <div class="custom-edit-btn">
-                                <a href="{{ route('user.edit', $user->id) }}">ユーザ情報の編集</a>
-                            </div>
-                        @endif
+                    @if (Auth::id() === $user->id)
+                        <div class="custom-edit-btn">
+                            <a href="{{ route('user.edit', $user->id) }}">ユーザ情報の編集</a>
+                        </div>
+                    @endif
                 </div>
             </div>
             <div class="mt-2">
                 @include('follow.follow_button', ['user' => $user])
+            </div>
+            <div class="mt-2">
+                <div class="activity-card">
+                    <p class="activity__heading">ラ活の記録</p>
+                    <div class="activity__count">
+                        <p class="activity__count-total">トータル<span>10</span>杯</p>
+                        <p class="activity__count-month">今月<span>2</span>杯</p>
+                    </div>
+                    <a class="activity__link" href="{{ route('user.activities', $user->id) }}">記録を見る <i class="fas fa-arrow-circle-right"></i></a>
+                </div>
             </div>
             <div class="mt-2">
                 @if (Auth::id() === $user->id)

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -38,8 +38,8 @@
                 <div class="activity-card">
                     <p class="activity__heading">ラ活の記録</p>
                     <div class="activity__count">
-                        <p class="activity__count-total">トータル<span>10</span>杯</p>
-                        <p class="activity__count-month">今月<span>2</span>杯</p>
+                        <p class="activity__count-total">トータル<span>{{ $countActivities }}</span>杯</p>
+                        <p class="activity__count-month">今月<span>{{ $countActivitiesThisMonth }}</span>杯</p>
                     </div>
                     <a class="activity__link" href="{{ route('user.activities', $user->id) }}">記録を見る <i class="fas fa-arrow-circle-right"></i></a>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -100,12 +100,14 @@ Route::group(['middleware' => 'auth'], function(){
     // 活動記録関係
     Route::prefix('activity')->group(function(){
         // 活動記録の新規登録ページ
-        Route::get('', 'ActivitiesController@create')->name('activity.create');
+        Route::get('create', 'ActivitiesController@create')->name('activity.create');
         // 活動記録の新規登録処理
         Route::post('', 'ActivitiesController@store')->name('activity.store');
         // 活動記録の編集ページ
-        Route::get('edit/{id}', 'ActivitiesController@edit')->name('activity.edit');
+        Route::get('{id}/edit', 'ActivitiesController@edit')->name('activity.edit');
         // 活動記録の編集処理
-        Route::put('edit/{id}', 'ActivitiesController@update')->name('activity.update');
+        Route::put('{id}', 'ActivitiesController@update')->name('activity.update');
+        // 活動記録の削除
+        Route::delete('{id}', 'ActivitiesController@destroy')->name('activity.delete');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,8 @@ Route::prefix('users/{id}')->group(function(){
     Route::get('followers', 'UsersController@followers')->name('user.followers');
     // フォロー中の表示
     Route::get('followings', 'UsersController@followings')->name('user.followings');
+    // ユーザーの活動記録一覧ページ
+    Route::get('activities', 'ActivitiesController@userActivities')->name('user.activities');
 });
 
 // 返信ページの表示

--- a/routes/web.php
+++ b/routes/web.php
@@ -103,5 +103,9 @@ Route::group(['middleware' => 'auth'], function(){
         Route::get('', 'ActivitiesController@create')->name('activity.create');
         // 活動記録の新規登録処理
         Route::post('', 'ActivitiesController@store')->name('activity.store');
+        // 活動記録の編集ページ
+        Route::get('edit/{id}', 'ActivitiesController@edit')->name('activity.edit');
+        // 活動記録の編集処理
+        Route::put('edit/{id}', 'ActivitiesController@update')->name('activity.update');
     });
 });


### PR DESCRIPTION
## issue
 - Closes #1371 

## 概要
 - 活動記録の編集・削除機能、マイページでの一覧表示

## 動作確認手順
### 編集機能
 - ログイン後、トップページへアクセスする。
 - ログインユーザーの活動記録の編集ボタンを押下すると、編集ページへ遷移することを確認。  
※ダミーデータは作成していないので、新たなデータを登録する必要があります。
 - 編集ページでフォームに入力後、送信すると内容の編集ができることを確認。
 - Adminerのactivitiesテーブルの該当レコードが更新されていることを確認。

### 削除機能
 - ログインユーザーの活動記録の削除ボタンを押下すると、一覧から削除されることを確認。
 - Adminerのactivitiesテーブルの該当レコードのdeleted_atカラムが更新されていることを確認。

### マイページでの表示
 - ユーザーの詳細ページへアクセスする。（ログイン前でも閲覧可能）
 - 「ラ活の記録」というカードでトータルの総数と今月の数が取得されていることを確認。
 - 「記録を見る」というリンクを押下すると、ユーザーが所有する活動の記録一覧ページへ遷移することを確認。
 -  一覧では6ヶ月単位でページを取得。月別に区切って表示されるようにしました。

## 考慮してほしいこと
 - この後、ユーザーの記録一覧ページから、記録の詳細ページへ遷移し一つ一つ見られるようにする予定です。

## 確認してほしいこと
 - 今回ダミーデータを用意していなかったのですが、用意した方が良いのでしょうか？  
ダミーデータを用意する場合、画像はどのように扱えば良いのか調べてもいくつか方法が出てきてしまって…。storageの中のpublicフォルダはリモートにはプッシュしない方が良いですよね？  
実務現場での一般的なやり方などあるのでしょうか？  
教えていただけるとありがたいです。