### PR TITLE
投稿削除の修正 (Shinya)

### DIFF
--- a/resources/views/commons/posts_list.blade.php
+++ b/resources/views/commons/posts_list.blade.php
@@ -23,16 +23,16 @@
                             <div class="card-text">{{ $post->content }}</div>
                             @if (Auth::id() === $post->user_id)
                                 <div>
-                                    <form method="POST" action="" class="d-inline">
+                                    <a href="{{ route('post.edit', $post->id) }}" class="btn btn-link icon-ini icon-blue" title="編集">
+                                        <i class="fas fa-edit"></i>
+                                    </a>
+                                    <form method="POST" action="{{ route('post.delete', $post->id) }}" class="d-inline">
                                         @csrf
                                         @method('DELETE')
                                         <button type="submit" class="btn btn-link icon-ini icon-red" title="削除">
                                             <i class="fas fa-trash"></i>
                                         </button>
                                     </form>
-                                    <a href="{{ route('post.edit', $post->id) }}" class="btn btn-link icon-ini icon-blue" title="編集">
-                                        <i class="fas fa-edit"></i>
-                                    </a>
                                 </div>
                             @endif
                     </div>


### PR DESCRIPTION
## Issue
- Closes #

## 概要
- 投稿削除の修正
	
## 動作確認手順
- 投稿の削除ボタンを押すと、投稿が削除されることを確認。
	
## 考慮して欲しいこと
- View調整時のコンフリクト解消時に誤って、投稿削除のaction内のroutingを削除してしまいましたので、修正いたしました。
- 投稿編集ボタンと削除ボタンの位置を入れ替えました。

## 確認して欲しいこと
