### PR TITLE
返信機能の画像投稿機能(yuki)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\User;
 use App\Post;
 use App\Http\Requests\PostRequest;
+use Illuminate\Support\Facades\Storage;
 
 class PostsController extends Controller
 {
@@ -13,6 +14,7 @@ class PostsController extends Controller
     {
         $post = Post::findOrFail($id);
         if (\Auth::id() === $post->user_id) {
+            Storage::delete($post->image);
             $post->delete();
         }
         return back();
@@ -66,7 +68,26 @@ class PostsController extends Controller
     public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
+        // 画像の情報を取得
+        $image = $request->file('image');
+
         $post->content = $request->content;
+
+        // 画像をアップロードした場合
+        if($image !== null){
+
+            // DBからアップロードした名前が同じものがあるか検索
+            $imageName = Post::where('image', 'public/images/' . $image->getClientOriginalName())->first();
+
+            // storage/app/public/imagesフォルダに保存される
+            // 同じ画像名が存在する場合は、適当な名前で保存
+            if ($imageName !== null) {
+                $post->image = $image->store('public/images');
+            } else {
+                // 同じ画像名が存在しない場合は、アップロードした画像名で保存
+                $post->image = $image->storeAs('public/images', $image->getClientOriginalName());
+            }
+        }
         $post->save();
         return redirect("/");
     }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -14,6 +14,7 @@ class PostsController extends Controller
     {
         $post = Post::findOrFail($id);
         if (\Auth::id() === $post->user_id) {
+            // 保存されていた画像を削除する
             Storage::delete($post->image);
             $post->delete();
         }
@@ -30,7 +31,7 @@ class PostsController extends Controller
         $post->user_id = $request->user()->id;
 
         // 画像をアップロードした場合
-        if($image !== null){
+        if ($image !== null){
 
             // DBからアップロードした名前が同じものがあるか検索
             $imageName = Post::where('image', 'public/images/' . $image->getClientOriginalName())->first();
@@ -74,7 +75,7 @@ class PostsController extends Controller
         $post->content = $request->content;
 
         // 画像をアップロードした場合
-        if($image !== null){
+        if ($image !== null){
 
             // DBからアップロードした名前が同じものがあるか検索
             $imageName = Post::where('image', 'public/images/' . $image->getClientOriginalName())->first();

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -92,4 +92,17 @@ class PostsController extends Controller
         $post->save();
         return redirect("/");
     }
+
+    // 画像のみ削除
+    public function imageDestroy($id)
+    {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
+            // 保存されていた画像を削除する
+            Storage::delete($post->image);
+            $post->image = null;
+            $post->save();
+        }
+        return back();
+    }
 }

--- a/app/Http/Controllers/ReplyController.php
+++ b/app/Http/Controllers/ReplyController.php
@@ -110,4 +110,17 @@ class ReplyController extends Controller
         }
         return back();
     }
+
+    // 画像のみ削除
+    public function imageDestroy($id)
+    {
+        $reply = Reply::findOrFail($id);
+        if (\Auth::id() === $reply->user_id) {
+            // 保存されていた画像を削除する
+            Storage::delete($reply->image);
+            $reply->image = null;
+            $reply->save();
+        }
+        return back();
+    }
 }

--- a/app/Http/Controllers/ReplyController.php
+++ b/app/Http/Controllers/ReplyController.php
@@ -78,7 +78,7 @@ class ReplyController extends Controller
         $reply->content = $request->content;
 
         // 画像をアップロードした場合
-        if($image !== null){
+        if ($image !== null){
 
             // DBからアップロードした名前が同じものがあるか検索
             $imageName = Reply::where('image', 'public/images/replies' . $image->getClientOriginalName())->first();
@@ -104,6 +104,7 @@ class ReplyController extends Controller
     {
         $reply = Reply::findOrFail($id);
         if (\Auth::id() === $reply->user_id) {
+            // 保存されていた画像を削除する
             Storage::delete($reply->image);
             $reply->delete();
         }

--- a/app/Http/Controllers/ReplyController.php
+++ b/app/Http/Controllers/ReplyController.php
@@ -35,7 +35,7 @@ class ReplyController extends Controller
         $reply->content = $request->content;
 
         // 画像をアップロードした場合
-        if($image !== null){
+        if ($image !== null){
 
             // DBからアップロードした名前が同じものがあるか検索
             $imageName = Reply::where('image', 'public/images/replies/' . $image->getClientOriginalName())->first();

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -26,7 +26,7 @@ class PostRequest extends FormRequest
     {
         return [
             'content' => ['required', 'max:140'],
-            'image' => ['image', 'mimes:jpeg,png,jpg', new PictureRule],
+            'image' => ['image', 'mimes:jpeg,png,jpg', 'max:200', new PictureRule],
         ];
     }
     public function attributes()

--- a/database/migrations/2024_12_23_121958_add_image_replies_table.php
+++ b/database/migrations/2024_12_23_121958_add_image_replies_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddImageRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('replies', function (Blueprint $table) {
+            $table->string('image')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('replies', function (Blueprint $table) {
+            $table->dropColumn('image');
+        });
+    }
+}

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -77,7 +77,7 @@ return [
     ],
     'max' => [
         'numeric' => ':attributeには、:max以下の数字を指定してください。',
-        'file' => ':attributeには、:max KB以下のファイルを指定してください。',
+        'file' => ':attributeには、:maxKB以下のファイルを指定してください。',
         'string' => ':attributeは、:max文字以下にしてください。',
         'array' => ':attributeの項目は、:max個以下にしてください。',
     ],

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -2,12 +2,17 @@
 @section('content')
     <h2 class="mt-5">投稿を編集する</h2>
     @include('commons.error_messages')
-    <form method="POST" action="{{ route('post.update', $post->id) }}">
+    <form method="POST" action="{{ route('post.update', $post->id) }}" enctype="multipart/form-data">
     @csrf
     @method('PUT')
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
         </div>
-        <button type="submit" class="btn btn-primary">更新する</button>
+        <!-- 画像を選択していれば、画像が表示される -->
+        @if ($post->image !== null)
+            <img class="mb-3" src="{{ Storage::url($post->image) }}" alt="画像投稿" style="display: block;">
+        @endif
+        <button type="submit" class="btn btn-primary" class="pt-3">更新する</button>
+        <input class="ml-3" type="file" name="image">
     </form>
 @endsection

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -24,6 +24,14 @@
                                     @method('DELETE')
                                     <button type="submit" class="btn btn-danger ml-2">削除</button>
                                 </form>
+                                <!-- 画像を投稿していれば、ボタンが表示される -->
+                                @if ($post->image !== null)
+                                    <form method="POST" action="{{ route('image.delete', $post->id) }}">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-danger ml-2">画像のみ削除</button>
+                                    </form>
+                                @endif
                             </div>
                         @endif
                     </div>

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -2,12 +2,17 @@
 @section('content')
     <h2 class="mt-5">返信を編集する</h2>
     @include('commons.error_messages')
-    <form method="POST" action="{{ route('reply.update', $reply->id) }}">
+    <form method="POST" action="{{ route('reply.update', $reply->id) }}" enctype="multipart/form-data">
     @csrf
     @method('PUT')
         <div class="form-group">
             <textarea id="reply" class="form-control" name="content" rows="5">{{ old('content', $reply->content) }}</textarea>
         </div>
+        <!-- 画像を選択していれば、画像が表示される -->
+        @if ($reply->image !== null)
+            <img class="mb-3" src="{{ Storage::url($reply->image) }}" alt="画像投稿" style="display: block;">
+        @endif
         <button type="submit" class="btn btn-primary">返信を更新する</button>
+        <input class="ml-3" type="file" name="image">
     </form>
 @endsection

--- a/resources/views/replies/reply.blade.php
+++ b/resources/views/replies/reply.blade.php
@@ -58,7 +58,14 @@
                                     @method('DELETE')
                                     <button type="submit" class="btn btn-danger ml-2">削除</button>
                                 </form>
-                                
+                                    <!-- 画像を投稿していれば、ボタンが表示される -->
+                                    @if ($reply->image !== null)
+                                        <form method="POST" action="{{ route('picture.delete', $reply->id) }}">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-danger ml-2">画像のみ削除</button>
+                                        </form>
+                                    @endif
                             </div>
                         
                         </div>

--- a/resources/views/replies/reply.blade.php
+++ b/resources/views/replies/reply.blade.php
@@ -7,6 +7,10 @@
     </div>
     <div class="text-left d-inline-block w-75">
         <p class="mb-2">{{ $post->content }}</p>
+        <!-- 画像を選択していれば、画像が表示される -->
+        @if ($post->image !== null)
+            <img class="mb-2" src="{{ Storage::url($post->image) }}" alt="画像投稿">
+        @endif
         <p class="text-muted">{{ $post->updated_at }}</p>
     </div>
 </div>
@@ -15,12 +19,13 @@
     </div>
     @if (Auth::check())
     <div class="text-center mb-3">
-        <form method="POST" action="{{ route('post.replies', $post->id) }}" class="d-inline-block w-75">
+        <form method="POST" action="{{ route('post.replies', $post->id) }}" enctype="multipart/form-data" class="d-inline-block w-75">
         @csrf
             <div class="form-group">
-                <textarea class="form-control" name="content" rows="4"></textarea>
+                <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
                 <div class="text-left mt-3">
                     <button type="submit" class="btn btn-primary">返信する({{ $post->replies->count() }})</button>
+                    <input class="ml-3" type="file" name="image">
                 </div>
             </div>
         </form>
@@ -37,6 +42,10 @@
                 <div class="">
                     <div class="text-left d-inline-block w-75">
                         <p class="mb-2">{{ $reply->content }}</p>
+                        <!-- 画像を選択していれば、画像が表示される -->
+                        @if ($reply->image !== null)
+                            <img class="mb-2" src="{{ Storage::url($reply->image) }}" alt="画像投稿">
+                        @endif
                         <p class="text-muted">{{ $reply->updated_at }}</p>
                     </div>
                     <!-- ログインしている場合 -->

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,31 +1,31 @@
 @extends('layouts.app')
 @section('content')
-    <div class="center jumbotron bg-info">
-        <div class="text-center text-white mt-2 pt-1">
-            <h1><i class="fa-brands fa-telegram pr-3 d-inline"></i>Tune Talk</h1>
-            <h3><i class="fa-brands fa-telegram pr-3 d-inline"></i>皆で音楽について語りましょう♫</h3>
-        </div>
+<div class="center jumbotron bg-info">
+    <div class="text-center text-white mt-2 pt-1">
+        <h1><i class="fa-brands fa-telegram pr-3 d-inline"></i>Tune Talk</h1>
+        <h3><i class="fa-brands fa-telegram pr-3 d-inline"></i>皆で音楽について語りましょう♫</h3>
     </div>
-    <h5 class="text-center mb-3">音楽について140字以内で会話しよう！</h5>
-    @if(Auth::check())
-    <div class="w-75 m-auto">
-        @include('commons.error_messages')
-    </div>
-    <div class="text-center mb-3">
-        <form method="POST" action="{{ route('post.store') }}" enctype="multipart/form-data" class="d-inline-block w-75">
+</div>
+<h5 class="text-center mb-3">音楽について140字以内で会話しよう！</h5>
+@if(Auth::check())
+<div class="w-75 m-auto">
+    @include('commons.error_messages')
+</div>
+<div class="text-center mb-3">
+    <form method="POST" action="{{ route('post.store') }}" enctype="multipart/form-data" class="d-inline-block w-75">
         @csrf
-            <div class="form-group">
-                <textarea class="form-control" name="content" rows="4"></textarea>
-                <div class="text-left mt-3">
-                    <button type="submit" class="btn btn-primary">投稿する</button>
-                </div>
-                <input type="file" name="image">
+        <div class="form-group">
+            <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
+            <div class="text-left mt-3">
+                <button type="submit" class="btn btn-primary">投稿する</button>
+                <input class="ml-3" type="file" name="image">
             </div>
-        </form>
-    </div>
-    @endif
-    @include('posts.index',['search' => $search])
-    <div class="mt-4">
-        @include('posts.posts', ['posts' => $posts])
-    </div>
+        </div>
+    </form>
+</div>
+@endif
+@include('posts.index',['search' => $search])
+<div class="mt-4">
+    @include('posts.posts', ['posts' => $posts])
+</div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,8 @@ Route::group(['middleware' => 'auth'], function () {
             Route::put('replies/update', 'ReplyController@update')->name('reply.update');
             // 返信削除
             Route::delete('replies/delete', 'ReplyController@destroy')->name('reply.delete');
+            // 画像のみ削除
+            Route::delete('image/delete', 'PostsController@imageDestroy')->name('image.delete');
         });
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,9 @@ Route::group(['middleware' => 'auth'], function () {
             Route::put('replies/update', 'ReplyController@update')->name('reply.update');
             // 返信削除
             Route::delete('replies/delete', 'ReplyController@destroy')->name('reply.delete');
-            // 画像のみ削除
+            // 画像のみ削除（返信）
+            Route::delete('picture/delete', 'ReplyController@imageDestroy')->name('picture.delete');
+            // 画像のみ削除（トップページ）
             Route::delete('image/delete', 'PostsController@imageDestroy')->name('image.delete');
         });
     });


### PR DESCRIPTION
## issue
- Closes #

## 概要
- 返信機能の画像投稿機能

## 動作確認手順
- 返信機能で画像投稿できることを確認
- 投稿/返信共に編集する際も画像を更新できることを確認
- 投稿/返信共に削除ボタンを押下した時に保存していた画像も削除できることを確認
- 投稿/返信共に200KBより大きい画像であればバリデーションエラーになることを確認

## 考慮して欲しいこと
## 確認して欲しいこと