### PR TITLE
posts（投稿）テーブルのマイグレーションとシーダー作成(yurika)

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Post extends Model
+{
+    use SoftDeletes;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2024_12_29_034432_create_posts_table.php
+++ b/database/migrations/2024_12_29_034432_create_posts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('title',140);//タイトル文字数制限
+            $table->text('content');// 投稿の内容　文字数制限なし
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/migrations/2024_12_29_034432_create_posts_table.php
+++ b/database/migrations/2024_12_29_034432_create_posts_table.php
@@ -17,7 +17,6 @@ class CreatePostsTable extends Migration
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
             $table->string('content', 140);
-            $table->text('content');// 投稿の内容　文字数制限なし
             $table->timestamps();
             $table->softDeletes();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');

--- a/database/migrations/2024_12_29_034432_create_posts_table.php
+++ b/database/migrations/2024_12_29_034432_create_posts_table.php
@@ -16,9 +16,10 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
-            $table->string('title',140);//タイトル文字数制限
             $table->text('content');// 投稿の内容　文字数制限なし
             $table->timestamps();
+            $table->softDeletes();
+            //$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/migrations/2024_12_29_034432_create_posts_table.php
+++ b/database/migrations/2024_12_29_034432_create_posts_table.php
@@ -16,10 +16,11 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('content', 140);
             $table->text('content');// 投稿の内容　文字数制限なし
             $table->timestamps();
             $table->softDeletes();
-            //$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+         $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-         $this->call(PostsTableSeeder::class);
+        //$this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        //$this->call(PostsTableSeeder::class);
+        $this->call(UsersTableSeeder_J::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        for ($i = 1; $i <= 10; $i++) {//ここから追加
+            DB::table('posts')->insert([
+                'user_id' => $i,
+                'content' => 'これは最初の投稿の内容です。',
+                'title'=>'string',
+                'created_at' => now(),
+                'updated_at' => now()
+            ]);
+        }
+    }
+}

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -11,11 +11,10 @@ class PostsTableSeeder extends Seeder
      */
     public function run()
     {
-        for ($i = 1; $i <= 10; $i++) {//ここから追加
+        for ($i = 1; $i <= 11; $i++) {//ここから追加
             DB::table('posts')->insert([
                 'user_id' => $i,
                 'content' => 'これは最初の投稿の内容です。',
-                'title'=>'string',
                 'created_at' => now(),
                 'updated_at' => now()
             ]);

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -11,13 +11,71 @@ class PostsTableSeeder extends Seeder
      */
     public function run()
     {
-        for ($i = 1; $i <= 11; $i++) {//ここから追加
-            DB::table('posts')->insert([
-                'user_id' => $i,
-                'content' => 'これは最初の投稿の内容です。',
-                'created_at' => now(),
-                'updated_at' => now()
-            ]);
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'content' => 'これは1番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 2,
+            'content' => 'これは2番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 3,
+            'content' => 'これは3番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 4,
+            'content' => 'これは4番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 5,
+            'content' => 'これは5番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'content' => 'これは6番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 2,
+            'content' => 'これは7番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 3,
+            'content' => 'これは8番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 4,
+            'content' => 'これは9番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 5,
+            'content' => 'これは10番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('posts')->insert([
+            'user_id' => 1,
+            'content' => 'これは11番目の投稿の内容です。',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
         }
-    }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -77,5 +77,5 @@ class PostsTableSeeder extends Seeder
             'created_at' => now(),
             'updated_at' => now()
         ]);
-        }
+    }
 }


### PR DESCRIPTION
## issue
- Closes #1393

## 概要
- posts（投稿）テーブルのマイグレーションとシーダー作成

##動作確認手順
- 下記コマンドを実行。
php artisan migrate --seed

##考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認する必要あり。
php artisan migrate:fresh --seed

## 確認してほしいこと
- シーダーの下記の箇所について、追加した方が良いものがあれば教えてほしいです。
```
public function run()
    {
        for ($i = 1; $i <= 10; $i++) {//ここから追加
            DB::table('posts')->insert([
                'user_id' => $i,
                'content' => 'これは最初の投稿の内容です。',
                'title'=>'string',
                'created_at' => now(),
                'updated_at' => now()
            ]);
        }
    }
```