### PR TITLE
#115 ユーザ詳細(miyagi)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\User;
+
+class UsersController extends Controller
+{
+    // 対象のユーザ情報とそのユーザが所有している投稿情報を取得し、
+    // ユーザ詳細画面を表示
+    public function show($id)
+    {
+        $user = User::findOrFail($id);
+        $posts = $user->posts()->latest()->paginate(10);
+
+        $data = [
+            'user' => $user,
+            'posts' => $posts,
+        ];
+
+        return view('users.show', $data);
+    }
+}

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -6,16 +6,25 @@ class PostsTableSeeder extends Seeder
 {
     /**
      * Run the database seeds.
-     * 12件の投稿テストデータ作成
      * 
      * @return void
      */
     public function run()
     {
+        // 12件の投稿テストデータ（user_id 1～4まで繰り返し）
         for ($i = 1; $i <= 12; $i++) {
             DB::table('posts')->insert([
                 'user_id' => (($i - 1) % 4) + 1, // 1から4までのuser_idを繰り返し
                 'content' =>  $i . '番目のテスト投稿です！',
+                'created_at' => now(),
+            ]);
+        }
+
+        // user_id が 1（test1）のユーザーに10件分のテストデータを追加
+        for ($i = 1; $i <= 10; $i++) {
+            DB::table('posts')->insert([
+                'user_id' => 1,
+                'content' => 'test1のテスト投稿',
                 'created_at' => now(),
             ]);
         }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -7,7 +7,7 @@
             <div class="text-left d-inline-block w-75 mb-2">
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
 
-                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a></p>
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user_id) }}">{{ $post->user->name }}</a></p>
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -7,7 +7,7 @@
             <div class="text-left d-inline-block w-75 mb-2">
             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
 
-                <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $post->user->name }}</a></p>
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a></p>
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -8,9 +8,11 @@
                 </div>
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像">
-                    <div class="mt-3">
-                        <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
-                    </div>
+                    @if (Auth::id() === $user->id)
+                        <div class="mt-3">
+                            <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                        </div>
+                    @endif
                 </div>
             </div>
         </aside>
@@ -28,7 +30,7 @@
                             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}"
                                 alt="ユーザのアバター画像">
                             <p class="mt-3 mb-0 d-inline-block">
-                                <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>
+                                <a href="{{ route('user.show', $post->user_id) }}">{{ $post->user->name }}</a>
                             </p>
                         </div>
                         <div class="text-left d-inline-block w-75">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.app')
+@section('content')
+    <div class="row">
+        <aside class="col-sm-4 mb-5">
+            <div class="card bg-info">
+                <div class="card-header">
+                    <h3 class="card-title text-light">{{ $user->name }}</h3>
+                </div>
+                <div class="card-body">
+                    <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 400) }}" alt="ユーザのアバター画像">
+                    <div class="mt-3">
+                        <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                    </div>
+                </div>
+            </div>
+        </aside>
+        <div class="col-sm-8">
+            <ul class="nav nav-tabs nav-justified mb-3">
+                <li class="nav-item"><a href="{{ route('user.show', $user->id) }}"
+                        class="nav-link {{ Request::is('users/' . $user->id) ? 'active' : '' }}">タイムライン</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
+            </ul>
+            @foreach ($posts as $post)
+                <ul class="list-unstyled">
+                    <li class="mb-3 text-center">
+                        <div class="text-left d-inline-block w-75 mb-2">
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}"
+                                alt="ユーザのアバター画像">
+                            <p class="mt-3 mb-0 d-inline-block">
+                                <a href="{{ route('user.show', $post->user->id) }}">{{ $post->user->name }}</a>
+                            </p>
+                        </div>
+                        <div class="text-left d-inline-block w-75">
+                            <p class="mb-2">{{ $post->content }}</p>
+                            <p class="text-muted">{{ $post->created_at }}</p>
+                        </div>
+                        @if (Auth::id() === $post->user_id)
+                            <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                                <form action="" method="" onsubmit="">
+                                    <button type="submit" class="btn btn-danger">削除</button>
+                                </form>
+                                <a href="" class="btn btn-primary">編集する</a>
+                            </div>
+                        @endif
+                    </li>
+                </ul>
+            @endforeach
+            <div class="m-auto" style="width: fit-content">
+                {{ $posts->links('pagination::bootstrap-4') }}
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,3 +20,6 @@ Route::get('/', 'PostController@index')->name('post_list');
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
+
+// ユーザ
+Route::get('users/{id}', 'UsersController@show')->name('user.show');


### PR DESCRIPTION
## issue
- Closes #115

## 概要
- ユーザ詳細の実装

## 動作確認手順
- 下記コマンドを実行
php artisan migrate:refresh --seed
- Adminerでpostsテーブルに22件のテストデータが作成されていることを確認
- 下記URLにアクセス
http://localhost:8080/
- ユーザ名(test1)のリンクを押下しユーザ詳細画面が表示されていることを確認
- ユーザ情報の編集ボタンと投稿内容を削除・編集するボタンが表示されていないことを確認
- 下記URLにアクセスしユーザtest1でログイン
http://localhost:8080/login
メールアドレス「[test1@test.com](mailto:test1@test.com)」　パスワード「test1」
- 再度ユーザ名(test1)のリンクを押下しユーザ詳細画面が表示されていることを確認
- ユーザ情報の編集ボタンと投稿内容を削除・編集するボタンが表示されていることを確認


## 考慮してほしいこと
- ユーザ詳細画面にてページネーションを表示させるためにテストデータを追加しました
- 動作確認手順にて「php artisan migrate:refresh --seed」を実行した際に
エラーが出た場合は下記コマンドを実行した後に再度「php artisan migrate:refresh --seed」を
実行する必要があります
composer dump-autoload
- 共通ファイル・ヘッダー・フッター & トップページのタイトル表示のタスクのマージ待ちのため
一部URLを直接入力し確認する必要があります

## 確認して欲しいこと
- 実装中にテストデータを増やして動作確認をしたい場合は
今回のようにseederファイルに追記していく方法で大丈夫でしょうか？
他に違う方法や行うべき方法がありましたら教えてほしいです