### PR TITLE
Post編集・更新＿ロクハラ

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\PostEditRequest;
 use App\Post;
 
 class PostsController extends Controller
@@ -11,6 +12,30 @@ class PostsController extends Controller
     {
         $posts = Post::orderBy('id', 'desc')->paginate(10);
         return view('welcome', compact('posts'));
+    }
+
+    public function edit($id)
+    {
+        $post = Post::findOrFail($id);
+
+        if(\Auth::id() === $post->user_id){
+            return view('post.edit', compact('post'));
+        }
+        
+        return back()->with('権限がありません🙅');
+    }
+
+    public function update(PostEditRequest $request, $id)
+    {
+        $post = Post::findOrFail($id);
+
+        if(\Auth::id() === $post->user_id){
+            $post->content = $request->content;
+            $post->save();
+            return redirect()->route('home')->with('更新に成功しました✅');
+        }
+
+        return back()->with('権限がありません🙅');
     }
 
 }

--- a/app/Http/Requests/PostEditRequest.php
+++ b/app/Http/Requests/PostEditRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PostEditRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|string|max:140'
+        ];
+    }
+    public function messages(){
+        return [
+            'required' => '更新する内容を記入してください。',
+            'max:140' => '字数は140以内に収めてください。'
+        ];
+    }
+}

--- a/resources/views/post/edit.blade.php
+++ b/resources/views/post/edit.blade.php
@@ -1,0 +1,23 @@
+{{--@extends('')--}}
+{{--@section('content')--}}
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
+<h2 class="mt-5">投稿を編集する</h2>
+<form method="POST" action="{{route('post.update', $post->id)}}">
+    @csrf
+    @method('PUT')
+    <div class="form-group">
+        <textarea id="content" class="form-control" name="content" rows="">{!! old('content', $post->content) !!}</textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">更新する</button>
+</form>
+
+{{--@endsection--}}

--- a/resources/views/post/post.blade.php
+++ b/resources/views/post/post.blade.php
@@ -7,7 +7,7 @@
         </div>
         <div class="">
             <div class="text-left d-inline-block w-75">
-                <p class="mb-2">{{$post->content}}</p>
+                <p class="mb-2">{!! nl2br(e($post->content)) !!}</p>
                 <p class="text-muted">{{$post->created_at->format('Y-m-d H:i:s')}}</p>
             </div>
 
@@ -16,7 +16,7 @@
                 <form method="" action="">
                     <button type="submit" class="btn btn-danger">削除</button>
                 </form>
-                <a href="" class="btn btn-primary">編集する</a>
+                <a href="{{route('post.edit', $post->id)}}" class="btn btn-primary">編集する</a>
             </div>
             @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,11 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', 'PostsController@index');
+Route::get('/', 'PostsController@index')->name('home');
 
-
+Route::group([ 'middleware' => 'auth' ], function(){
+    Route::prefix('post/{id}')->group(function(){
+        Route::get('/edit', 'PostsController@edit')->name('post.edit');
+        Route::put('/update', 'PostsController@update')->name('post.update');
+    });
+});


### PR DESCRIPTION
## PostsController　内容追加
- 現場ではどうしているかわかりませんが、サーバー側制御として再度ユーザー認証を行うような形で対応してます。
```
        if(\Auth::id() === $post->user_id){
            return view('post.edit', compact('post'));
        }

        return back()->with('権限がありません🙅');
```
## PostEditRequest　新規ファイル
- Validationを別ファイルに。
- 条件満たさない項目に対しメッセージを用意。

## post.edit　新規ファイル
- 改行を保存するために`{!! old('content', $post->content) !!}`を使用。

## post.post　内容編集
- 改行を反映するために`{!! nl2br(e($post->content)) !!}`を使用。

## routes/web　内容追加
- 編集後ホームページにダイレクトされるようホームページルートにあだ名を追加。
`Route::get('/', 'PostsController@index')->name('home');`

※動作✅