### PR TITLE
#125 ユーザ退会(miyagi)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -21,4 +21,16 @@ class UsersController extends Controller
 
         return view('users.show', $data);
     }
+
+    // 対象ユーザの退会(削除)とそのユーザが所有している投稿情報を削除
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id) {
+            $user->delete();
+            $user->posts()->delete();
+        }
+
+        return redirect()->route('post_list');
+    }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
+    use SoftDeletes;
+
     public function user()
     {
         // Userモデルとのリレーション

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -11,6 +11,29 @@
                     @if (Auth::id() === $user->id)
                         <div class="mt-3">
                             <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                            {{-- ユーザ退会ボタンあとで削除ここから↓ --}}
+                            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+                            <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+                                <div class="modal-dialog">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h4>確認</h4>
+                                        </div>
+                                        <div class="modal-body">
+                                            <label>本当に退会しますか？</label>
+                                        </div>
+                                        <div class="modal-footer d-flex justify-content-between">
+                                            <form action="{{ route('user.delete', $user->id) }}" method="POST">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-danger">退会する</button>
+                                            </form>
+                                            <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {{-- ユーザ退会ボタンあとで削除ここまで↑ --}}
                         </div>
                     @endif
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,3 +23,9 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ユーザ
 Route::get('users/{id}', 'UsersController@show')->name('user.show');
+
+// ログイン後
+Route::group(['middleware' => 'auth'], function () {
+    // ユーザ退会
+    Route::delete('users/{id}', 'UsersController@destroy')->name('user.delete');
+});


### PR DESCRIPTION
## issue
- Closes #125

## 概要
- ユーザ退会機能の実装

## 動作確認手順
- 下記URLにアクセスしユーザ「test2」でログイン
http://localhost:8080/login
メールアドレス「test2@test.com」　パスワード「test2」
- 投稿一覧からユーザ「test2」を押下しユーザ詳細画面を表示
- 「退会する」ボタンを押下し確認のポップアップが表示されることを確認
- ポップアップの「閉じる」を押下しユーザ詳細画面へ戻ることを確認
- 再度「退会する」ボタンを押下しポップアップを表示させ「退会する」を押下
- トップページに遷移し投稿一覧にてユーザ「test2」の投稿がないことを確認
- Adminerでusersテーブルのユーザ「test2」が論理削除されていることを確認
- Adminerでpostsテーブルのuser_idが2の投稿が論理削除されていることを確認

## 考慮してほしいこと
- トップページにてログイン機能未実装のためURLを直接入力し確認する必要があります
- ユーザ編集・更新画面タスクマージ待ちのため
動作確認として退会ボタンをユーザ詳細画面にて作成しています
- 状況に応じて下記コマンドで動作確認する必要があります
php artisan migrate:fresh --seed
- 投稿内容を論理削除するためにPost.phpに「use SoftDeletes;」を追加しました

## 確認して欲しいこと
- ユーザ退会処理の下記部分にてtrueの場合のみ処理がありますが、
falseになる場合も考慮して何か処理を記述すべきでしょうか？
app/Http/Controllers/UsersController.php
```
if (\Auth::id() === $user->id) {
    $user->delete();
    $user->posts()->delete();
}
```