### PR TITLE
#168 フラッシュメッセージ(miyagi)

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class LoginController extends Controller
 {
@@ -36,5 +38,24 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    // ユーザ認証成功時の処理
+    protected function authenticated(Request $request, $user)
+    {
+        // ログイン成功時のフラッシュメッセージ
+        session()->flash('success', 'ログインに成功しました');
+    }
+
+    // ログアウト処理
+    public function logout(Request $request)
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        // ログアウト後のフラッシュメッセージ
+        session()->flash('success', 'ログアウトしました');
+
+        return redirect()->route('post.list');
     }
 }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,11 +1,12 @@
 <?php
 
 namespace App\Http\Controllers;
+
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\PostRequest;
 
 use Illuminate\Http\Request;
-use App\Post; 
+use App\Post;
 
 class PostController extends Controller
 {
@@ -43,9 +44,6 @@ class PostController extends Controller
         //セッションからリダイレクト先を取得
         $redirectUrl = session('redirect_to', route('post.list'));
 
-        return redirect($redirectUrl);
-        
+        return redirect($redirectUrl)->with('success', '投稿内容を更新しました');
     }
-
-
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -31,6 +31,6 @@ class UsersController extends Controller
             $user->posts()->delete();
         }
 
-        return redirect()->route('post_list');
+        return redirect()->route('post.list')->with('delete', '退会が完了しました');
     }
 }

--- a/resources/views/components/flash_message.blade.php
+++ b/resources/views/components/flash_message.blade.php
@@ -1,0 +1,20 @@
+@if (session('success') || session('delete'))
+    <div id="flash-message" class="alert text-center {{ session('success') ? 'alert-success' : 'alert-danger' }}">
+        <i class="far fa-check-circle"></i>
+        {{ session('success') ?? session('delete') }}
+    </div>
+@endif
+
+<script>
+    window.onload = function() {
+        const flashMessage = document.getElementById("flash-message");
+        if (flashMessage) {
+            setTimeout(function() {
+                flashMessage.classList.add("fade-out");
+                setTimeout(function() {
+                    flashMessage.style.display = "none";
+                }, 1000);
+            }, 3000);
+        }
+    };
+</script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,6 +9,7 @@
     <body>
         @include('commons.header')
         <div class="container">
+            @include('components.flash_message')
             @yield('content')
         </div>
         @include('commons.footer')


### PR DESCRIPTION
## issue
- Closes #168 

## 概要
- フラッシュメッセージの実装

## 動作確認手順
- 下記URLにアクセスする
http://localhost:8080/
- 下記4つの動作時にフラッシュメッセージが表示される
① ログイン成功時
　 下記ユーザでログインする
　 メールアドレス「test1@test.com」パスワード「test1」
　 「ログイン」ボタンを押下
② 投稿内容を編集時
　 ユーザ「test1」の投稿から「編集する」ボタンを押下し
　 投稿内容編集画面にて任意の投稿内容に編集する
　 編集後「更新する」ボタンを押下
③ ログアウト成功時
　 「ログアウト」ボタンを押下
④ ユーザ退会成功時
　 再度下記のユーザでログインする
　 メールアドレス「test1@test.com」パスワード「test1」
　 ユーザ詳細画面にて「退会する」ボタンを押下

## 考慮してほしいこと
- 状況に応じて下記コマンドで動作確認する必要があります
php artisan migrate:fresh --seed
- 下記処理の動作後にもフラッシュメッセージを表示したいと思いますが
現在マージ待ちのため、マージ後に随時実装していきたいを思います
・新規ユーザ登録
・ユーザ情報を更新
・新規投稿
・投稿内容削除

## 確認して欲しいこと
- セッションにメッセージを保存する際に色々な方法があることが分かりましたが、
今回の実装方法で問題ないでしょうか？
他にベストな方法などありましたら教えて欲しいです