### PR TITLE
#1428 リプライ（返信）機能_表示(miyagi)

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Post;
+
+class RepliesController extends Controller
+{
+    // リプライ一覧画面表示
+    public function index($id)
+    {
+        $post = Post::findOrFail($id);
+        $replies = $post->replies()->orderBy('created_at', 'asc')->paginate(10);
+        $data = [
+            'post' => $post,
+            'replies' => $replies,
+        ];
+
+        return view('replies.replies', $data);
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -14,4 +14,10 @@ class Post extends Model
         // Userモデルとのリレーション
         return $this->belongsTo(User::class);
     }
+
+    // Replyモデルとのリレーション
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Reply extends Model
+{
+    use SoftDeletes;
+
+    protected $fillable = [
+        'user_id', 'post_id', 'content',
+    ];
+
+    // Userモデルとのリレーション
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    // Postモデルとのリレーション
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,10 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    // Replyモデルとのリレーション
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
 }

--- a/database/migrations/2025_02_01_154450_create_replies_table.php
+++ b/database/migrations/2025_02_01_154450_create_replies_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replies', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->string('content', 140);
+            $table->timestamps();
+            $table->softDeletes();
+
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replies');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(RepliesTableSeeder::class);
     }
 }

--- a/database/seeds/RepliesTableSeeder.php
+++ b/database/seeds/RepliesTableSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class RepliesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // user_idが1、post_idが1の投稿に対して12件のテストデータ作成
+        for ($i = 1; $i <= 12; $i++) {
+            DB::table('replies')->insert([
+                'user_id' => $i,
+                'post_id' => 1,
+                'content' =>  $i . '番目コメントです！',
+                'created_at' => now()->addSeconds($i * 3),
+            ]);
+        }
+    }
+}

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -31,5 +31,15 @@ class UsersTableSeeder extends Seeder
             'email' => 'test4@test.com',
             'password' => bcrypt('test4')
         ]);
+
+        // ユーザを8人追加
+        for ($i = 5; $i <= 12; $i++) {
+            DB::table('users')->insert([
+                'name' => 'test' . $i,
+                'email' => 'test' . $i . '@test.com',
+                'password' => bcrypt('test' . $i),
+                'created_at' => now(),
+            ]);
+        }
     }
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,0 +1,7 @@
+html {
+    scroll-behavior: smooth;
+}
+
+.reply > a:hover span {
+    color: #007bff;
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,7 @@
         <title>Topic Posts</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link rel="stylesheet" href="{{ asset('/css/styles.css') }}">
     </head>
     <body>
         @include('commons.header')
@@ -18,4 +19,4 @@
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script defer src="https://use.fontawesome.com/releases/v5.7.2/js/all.js"></script>
     </body>
--</html>
+</html>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -12,7 +12,14 @@
             <div class="">
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{ $post->content }}</p>
-                    <p class="text-muted">{{ $post->created_at->format('Y-m-d H:i') }}</p>
+                    <p class="text-muted mb-0">{{ $post->created_at->format('Y-m-d H:i') }}</p>
+                    <hr class="m-0">
+                    <p class="mb-0 reply">
+                        <a class="text-dark text-decoration-none" href="{{ route('reply.index', $post->id) }}" data-toggle="tooltip" title="Reply">
+                            <i class="far fa-comment-dots fa-lg"></i>
+                            <span>{{ $post->replies->count() }}</span>
+                        </a>
+                    </p>
                 </div>
 
             @if (Auth::id() === $post->user_id)

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -1,0 +1,80 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="d-flex flex-column">
+        {{-- 投稿内容 --}}
+        <div class="w-75 m-auto">
+            <div class="mb-3 text-center">
+                <div class="p-2 text-left d-inline-block w-75" style="background-color: #eff7ff">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 65) }}" alt="ユーザのアバター画像">
+                    <p class="mt-3 mb-0 d-inline-block">
+                        <a href="{{ route('user.show', $post->user_id) }}">{{ $post->user->name }}</a>
+                    </p>
+                </div>
+                <div class="p-2 text-left d-inline-block w-75" style="background-color: #eff7ff">
+                    <p class="mb-2">{{ $post->content }}</p>
+                    <p class="text-muted mb-0">{{ $post->created_at }}</p>
+                    <hr class="m-0 mb-1">
+                    <a class="text-dark text-decoration-none" href="#replyList" onclick="scrollReplyList(event)"
+                        data-toggle="tooltip" title="Reply">
+                        <i class="far fa-comment-dots fa-lg"></i><span>&nbsp;{{ $post->replies->count() }}</span>
+                    </a>
+                </div>
+            </div>
+
+            {{-- リプライ表示 --}}
+            <div class="mb-3 text-center">
+                <div id="replyList" class="text-left d-inline-block w-75">
+                    <h4 class="mt-2 mb-2 py-2 pl-2 border-top border-bottom border-dark">
+                        リプライ一覧
+                    </h4>
+                </div>
+            </div>
+            @if ($post->replies->isEmpty())
+                {{-- リプライ数が０件の場合の処理 --}}
+                <div class="mb-3 text-center">
+                    <div id="replyList" class="text-left d-inline-block w-75">
+                        <p class="m-0 d-inline-block">
+                            リプライがありません
+                        </p>
+                    </div>
+                </div>
+            @else
+                {{-- リプライ数が1件以上ある場合の処理 --}}
+                @foreach ($replies as $reply)
+                    <div class="mb-3 text-center">
+                        <div class="text-left d-inline-block w-75 mb-2 pl-2">
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 45) }}"
+                                alt="ユーザのアバター画像">
+                            <p class="mt-3 mb-0 d-inline-block">
+                                <a href="{{ route('user.show', $reply->user_id) }}">{{ $post->user->name }}</a>
+                            </p>
+                        </div>
+                        <div class="text-left d-inline-block w-75 pl-2">
+                            <p class="mb-2">{{ $reply->content }}</p>
+                            <p class="text-muted">{{ $reply->created_at }}</p>
+                        </div>
+                        <hr class="mt-0 mb-0 w-75">
+                    </div>
+                @endforeach
+            @endif
+        </div>
+
+        {{-- ページネーションの表示 --}}
+        <div class="m-auto" style="width: fit-content">
+            {{ $replies->links('pagination::bootstrap-4') }}
+        </div>
+    </div>
+@endsection
+
+<script>
+    function scrollReplyList(event) {
+        event.preventDefault();
+        const replyList = document.getElementById("replyList");
+        const replyListTop = replyList.getBoundingClientRect().top + window.pageYOffset;
+        window.scrollTo({
+            top: replyListTop,
+            behavior: 'smooth'
+        });
+    }
+</script>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -46,34 +46,7 @@
                 <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
             </ul>
-            @foreach ($posts as $post)
-                <ul class="list-unstyled">
-                    <li class="mb-3 text-center">
-                        <div class="text-left d-inline-block w-75 mb-2">
-                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}"
-                                alt="ユーザのアバター画像">
-                            <p class="mt-3 mb-0 d-inline-block">
-                                <a href="{{ route('user.show', $post->user_id) }}">{{ $post->user->name }}</a>
-                            </p>
-                        </div>
-                        <div class="text-left d-inline-block w-75">
-                            <p class="mb-2">{{ $post->content }}</p>
-                            <p class="text-muted">{{ $post->created_at }}</p>
-                        </div>
-                        @if (Auth::id() === $post->user_id)
-                            <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                                <form action="" method="" onsubmit="">
-                                    <button type="submit" class="btn btn-danger">削除</button>
-                                </form>
-                                <a href="{{ route('post.edit', $post->id) }}" class="btn btn-primary">編集する</a>
-                            </div>
-                        @endif
-                    </li>
-                </ul>
-            @endforeach
-            <div class="m-auto" style="width: fit-content">
-                {{ $posts->links('pagination::bootstrap-4') }}
-            </div>
+            @include('posts.posts')
         </div>
     </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,8 +24,11 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
-// ユーザ
+// ユーザ詳細
 Route::get('users/{id}', 'UsersController@show')->name('user.show');
+
+// リプライ一覧
+Route::get('posts/{id}/reply/', 'RepliesController@index')->name('reply.index');
 
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {


### PR DESCRIPTION
## isuue
- #1428 

## 概要
- リプライ（返信）機能の実装（表示のみ）

## 動作確認手順
- 下記コマンドを実行
php artisan migrate:refresh --seed
- 下記URLにアクセス
http://localhost:8080/
- 下記ユーザでログインする
メールアドレス「test1@test.com」　パスワード「test1」
- トップページにてユーザ「test1」の投稿からリプライ数が12件ある
投稿のコメントアイコンを押下
- リプライ一覧画面に遷移して12件のリプライが表示されていることを確認
- ユーザ「test1」を押下してユーザ詳細画面に遷移
- ユーザ詳細画面にて各投稿にコメントアイコンとリプライ数が表示されていることを確認
- ユーザ詳細画面にてリプライ数が0の投稿のコメントアイコンを押下
- 再度リプライ一覧画面が表示され、「リプライがありません」と表示されていることを確認

## 考慮してほしいこと
- 動作確認手順でログイン処理がある理由として
ログアウト状態でユーザ詳細画面へ遷移しようとした時にエラーが表示されるのでエラー回避のためです