### PR TITLE
#1428 リプライ（返信）機能_投稿(miyagi)

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -55,6 +55,8 @@ class LoginController extends Controller
             if ($request->has('intended')) {
                 session(['url.intended' => $request->input('intended')]);
             }
+            // ログイン成功時のフラッシュメッセージ
+            session()->flash('success', 'ログインに成功しました');
 
             // intended に保存されているURLがあればそこへリダイレクト、なければデフォルトのページへ
             return redirect()->intended();
@@ -62,13 +64,6 @@ class LoginController extends Controller
 
         // 認証失敗時の処理
         return back()->withErrors(['email' => '認証に失敗しました'])->withInput();
-    }
-
-    // ユーザ認証成功時の処理
-    protected function authenticated(Request $request, $user)
-    {
-        // ログイン成功時のフラッシュメッセージ
-        session()->flash('success', 'ログインに成功しました');
     }
 
     // ログアウト処理

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -40,6 +40,30 @@ class LoginController extends Controller
         $this->middleware('guest')->except('logout');
     }
 
+    // ログイン処理
+    public function login(Request $request)
+    {
+        // バリデーション
+        $this->validate($request, [
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        // 認証処理
+        if (Auth::attempt($request->only('email', 'password'), $request->filled('remember'))) {
+            // intended が送信されていれば、それをセッションに保存
+            if ($request->has('intended')) {
+                session(['url.intended' => $request->input('intended')]);
+            }
+
+            // intended に保存されているURLがあればそこへリダイレクト、なければデフォルトのページへ
+            return redirect()->intended();
+        }
+
+        // 認証失敗時の処理
+        return back()->withErrors(['email' => '認証に失敗しました'])->withInput();
+    }
+
     // ユーザ認証成功時の処理
     protected function authenticated(Request $request, $user)
     {

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ReplyRequest;
 use Illuminate\Http\Request;
 use App\Post;
+use App\Reply;
 
 class RepliesController extends Controller
 {
@@ -18,5 +20,25 @@ class RepliesController extends Controller
         ];
 
         return view('replies.replies', $data);
+    }
+
+    // リプライ投稿
+    public function store(ReplyRequest $request, $post_id)
+    {
+         // リプライを保存
+         $reply = new Reply();
+         $reply->user_id = auth()->id();
+         $reply->post_id = $post_id;
+         $reply->content = $request->content;
+         $reply->save();
+ 
+         // リプライ数をカウント
+         $replyCount = $reply->post->replies->count();
+ 
+         // JSONで返信数を返す
+         return response()->json([
+             'status' => true,
+             'reply_count' => $replyCount,
+         ], 200);
     }
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -13,7 +13,7 @@ class RepliesController extends Controller
     public function index($id)
     {
         $post = Post::findOrFail($id);
-        $replies = $post->replies()->orderBy('created_at', 'asc')->paginate(10);
+        $replies = $post->replies()->orderBy('created_at', 'desc')->paginate(10);
         $data = [
             'post' => $post,
             'replies' => $replies,
@@ -25,20 +25,20 @@ class RepliesController extends Controller
     // リプライ投稿
     public function store(ReplyRequest $request, $post_id)
     {
-         // リプライを保存
-         $reply = new Reply();
-         $reply->user_id = auth()->id();
-         $reply->post_id = $post_id;
-         $reply->content = $request->content;
-         $reply->save();
- 
-         // リプライ数をカウント
-         $replyCount = $reply->post->replies->count();
- 
-         // JSONで返信数を返す
-         return response()->json([
-             'status' => true,
-             'reply_count' => $replyCount,
-         ], 200);
+        // リプライを保存
+        $reply = new Reply();
+        $reply->user_id = auth()->id();
+        $reply->post_id = $post_id;
+        $reply->content = $request->content;
+        $reply->save();
+
+        // リプライ数をカウント
+        $replyCount = $reply->post->replies->count();
+
+        // JSONで返信数を返す
+        return response()->json([
+            'status' => true,
+            'reply_count' => $replyCount,
+        ], 200);
     }
 }

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|max:140|regex:/\S/',
+        ];
+    }
+
+    // バリデーションエラーメッセージ
+    public function messages()
+    {
+        return [
+            'content.required' => '返信内容を入力してください。',
+            'content.max' => '返信内容は140文字以内で入力してください。',
+            'content.regex' => '返信内容には空白や改行のみを入力することはできません。',
+        ];
+    }
+
+    // バリデーションに失敗した時のレスポンス
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(response()->json([
+            'status' => false,
+            'message' => 'バリデーションエラー',
+            'errors' => $validator->errors(),
+        ], 422));
+    }
+}

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
-
+use Carbon\Carbon;
 
 class PostsTableSeeder extends Seeder
 {
@@ -12,21 +12,12 @@ class PostsTableSeeder extends Seeder
      */
     public function run()
     {
-        // 12件の投稿テストデータ（user_id 1～4まで繰り返し）
-        for ($i = 1; $i <= 12; $i++) {
+        // 各user_id 1 ~ 4 に 12件の投稿テストデータ作成（合計48件の投稿テストデータ）
+        for ($i = 1; $i <= 48; $i++) {
             DB::table('posts')->insert([
                 'user_id' => (($i - 1) % 4) + 1, // 1から4までのuser_idを繰り返し
                 'content' =>  $i . '番目のテスト投稿です！',
-                'created_at' => now(),
-            ]);
-        }
-
-        // user_id が 1（test1）のユーザーに10件分のテストデータを追加
-        for ($i = 1; $i <= 10; $i++) {
-            DB::table('posts')->insert([
-                'user_id' => 1,
-                'content' => 'test1のテスト投稿',
-                'created_at' => now(),
+                'created_at' => Carbon::create(2025, 2, 15, 12, 0, 0)->addSeconds($i * 60),
             ]);
         }
     }

--- a/database/seeds/RepliesTableSeeder.php
+++ b/database/seeds/RepliesTableSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Carbon\Carbon;
 
 class RepliesTableSeeder extends Seeder
 {
@@ -11,13 +12,13 @@ class RepliesTableSeeder extends Seeder
      */
     public function run()
     {
-        // user_idが1、post_idが1の投稿に対して12件のテストデータ作成
+        // user_id が 4、post_id が 48 の投稿に対して12件のテストデータ作成
         for ($i = 1; $i <= 12; $i++) {
             DB::table('replies')->insert([
-                'user_id' => $i,
-                'post_id' => 1,
+                'user_id' => (($i - 1) % 4) + 1, // 1から4までのuser_idを繰り返し
+                'post_id' => 48,
                 'content' =>  $i . '番目コメントです！',
-                'created_at' => now()->addSeconds($i * 3),
+                'created_at' => Carbon::create(2025, 2, 16, 12, 0, 0)->addSeconds($i * 60),
             ]);
         }
     }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -5,3 +5,7 @@ html {
 .reply > a:hover span {
     color: #007bff;
 }
+
+.hidden {
+    display: none !important;
+}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -11,9 +11,10 @@
     </div>
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
-        @include('commons.error_messages')
+            @include('commons.error_messages')
             <form method="POST" action="{{ route('login.post') }}">
                 @csrf
+                <input type="hidden" name="intended" id="intended-url" value="">
                 <div class="form-group">
                     <label for="email">メールアドレス</label>
                     <input id="email" type="text" class="form-control" name="email" value="{{ old('email') }}">
@@ -29,3 +30,14 @@
         </div>
     </div>
 @endsection
+
+<script>
+    // ログイン画面遷移前のURLをセッションから取得
+    document.addEventListener("DOMContentLoaded", function() {
+        var previousUrl = sessionStorage.getItem('previousUrl');
+        if (previousUrl) {
+            sessionStorage.removeItem('previousUrl');
+            document.getElementById("intended-url").value = previousUrl;
+        }
+    });
+</script>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,3 +1,7 @@
+{{-- リプライ成功時のアラート --}}
+<div id="reply-alert" class="alert alert-success text-center" style="display: none; position: fixed; top: 50px; left: 50%; transform: translateX(-50%); z-index: 1000;">
+    リプライが追加されました！
+</div>
 @if ($posts->isEmpty())
     <p>投稿がありません</p>
     @else
@@ -60,6 +64,9 @@
 {{-- リプライ投稿処理 --}}
 <script>
     document.addEventListener('DOMContentLoaded', function() {
+        const replyAlert = document.getElementById('reply-alert');
+        console.log(replyAlert);
+
         @foreach($posts as $post)
             const replyButton{{ $post->id }} = document.getElementById('reply-button-{{ $post->id }}');
             const replyForm{{ $post->id }} = document.getElementById('reply-form-{{ $post->id }}');
@@ -114,6 +121,25 @@
                                     replyCount{{ $post->id }}.textContent = data.reply_count;
                                     replyForm{{ $post->id }}.classList.add('hidden');
                                     textarea{{ $post->id }}.value = '';
+
+                                    // アラートを表示
+                                    replyAlert.style.display = 'block';
+                                    replyAlert.style.opacity = '1';
+
+                                    // 3秒後にフェードアウト
+                                    setTimeout(() => {
+                                        var fadeEffect = setInterval(() => {
+                                            if (!replyAlert.style.opacity) {
+                                                replyAlert.style.opacity = '1';
+                                            }
+                                            if (replyAlert.style.opacity > '0') {
+                                                replyAlert.style.opacity -= '0.1';
+                                            } else {
+                                                clearInterval(fadeEffect);
+                                                replyAlert.style.display = 'none';
+                                            }
+                                        }, 100);
+                                    }, 3000);
                                 } else {
                                     // バリデーションエラーメッセージダイアログ
                                     alert(data.errors.content[0]);

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -2,6 +2,10 @@
 
 @section('content')
     <div class="d-flex flex-column">
+        {{-- リプライ成功時のアラート --}}
+        <div id="reply-alert" class="alert alert-success text-center" style="display: none; position: fixed; top: 50px; left: 50%; transform: translateX(-50%); z-index: 1000;">
+            リプライが追加されました！
+        </div>
         {{-- 投稿内容 --}}
         <div class="w-75 m-auto">
             <div class="mb-0 text-center">
@@ -95,6 +99,7 @@
         const textarea{{ $post->id }} = document.getElementById('textarea-{{ $post->id }}');
         const replyCount{{ $post->id }} = document.getElementById('reply-count-{{ $post->id }}');
         var isLoggedIn = {{ Auth::check() ? 'true' : 'false' }};
+        const replyAlert = document.getElementById('reply-alert');
 
         if (isLoggedIn) {
             // キャンセルボタンをクリックしたときテキストエリアを空にする
@@ -125,6 +130,7 @@
                             // リプライ投稿成功
                             replyCount{{ $post->id }}.textContent = data.reply_count;
                             textarea{{ $post->id }}.value = '';
+                            sessionStorage.setItem('showReplyAlert', 'true');
                             location.reload();
                         } else {
                             // バリデーションエラーメッセージダイアログ
@@ -136,6 +142,30 @@
                         alert('リプライの投稿に失敗しました。');
                     });
             });
+        }
+        // sessionStorageがtrueの場合アラート表示処理
+        if (sessionStorage.getItem('showReplyAlert') === 'true') {
+            // アラートを表示
+            replyAlert.style.display = 'block';
+            replyAlert.style.opacity = '1';
+
+            // 3秒後にフェードアウト
+            setTimeout(() => {
+                var fadeEffect = setInterval(() => {
+                    if (!replyAlert.style.opacity) {
+                        replyAlert.style.opacity = '1';
+                    }
+                    if (replyAlert.style.opacity > '0') {
+                        replyAlert.style.opacity -= '0.1';
+                    } else {
+                        clearInterval(fadeEffect);
+                        replyAlert.style.display = 'none';
+                    }
+                }, 100);
+            }, 3000);
+
+            // フラグを削除
+            sessionStorage.removeItem('showReplyAlert');
         }
     });
 

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -4,7 +4,7 @@
     <div class="d-flex flex-column">
         {{-- 投稿内容 --}}
         <div class="w-75 m-auto">
-            <div class="mb-3 text-center">
+            <div class="mb-0 text-center">
                 <div class="p-2 text-left d-inline-block w-75" style="background-color: #eff7ff">
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 65) }}" alt="ユーザのアバター画像">
                     <p class="mt-3 mb-0 d-inline-block">
@@ -17,9 +17,30 @@
                     <hr class="m-0 mb-1">
                     <a class="text-dark text-decoration-none" href="#replyList" onclick="scrollReplyList(event)"
                         data-toggle="tooltip" title="Reply">
-                        <i class="far fa-comment-dots fa-lg"></i><span>&nbsp;{{ $post->replies->count() }}</span>
+                        <i class="far fa-comment-dots fa-lg"></i>
+                        <span id="reply-count-{{ $post->id }}">{{ $post->replies->count() }}</span>
                     </a>
                 </div>
+                {{-- リプライフォームの表示・非表示 --}}
+                @if (Auth::check())
+                    <form method="POST" action="{{ route('reply.store', $post->id) }}" class="mt-2 d-inline-block w-75"
+                        id="reply-form-{{ $post->id }}">
+                        @csrf
+                        <div class="form-group mb-0">
+                            <textarea class="form-control" name="content" rows="2" placeholder="ここに返信内容を入力..."
+                                id="textarea-{{ $post->id }}"></textarea>
+                            <div class="text-right mt-2">
+                                <button type="button" class="btn btn-outline-secondary ml-2"
+                                    id="cancel-button-{{ $post->id }}">キャンセル</button>
+                                <button type="submit" class="btn btn-outline-primary">返信する</button>
+                            </div>
+                        </div>
+                    </form>
+                @else
+                    <div class="mt-2 d-inline-block w-75 text-right">
+                        <button type="button" class="btn btn-primary" onclick="confirmLogin()">返信する</button>
+                    </div>
+                @endif
             </div>
 
             {{-- リプライ表示 --}}
@@ -47,7 +68,7 @@
                             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 45) }}"
                                 alt="ユーザのアバター画像">
                             <p class="mt-3 mb-0 d-inline-block">
-                                <a href="{{ route('user.show', $reply->user_id) }}">{{ $post->user->name }}</a>
+                                <a href="{{ route('user.show', $reply->user_id) }}">{{ $reply->user->name }}</a>
                             </p>
                         </div>
                         <div class="text-left d-inline-block w-75 pl-2">
@@ -68,6 +89,67 @@
 @endsection
 
 <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const replyForm{{ $post->id }} = document.getElementById('reply-form-{{ $post->id }}');
+        const cancelButton{{ $post->id }} = document.getElementById('cancel-button-{{ $post->id }}');
+        const textarea{{ $post->id }} = document.getElementById('textarea-{{ $post->id }}');
+        const replyCount{{ $post->id }} = document.getElementById('reply-count-{{ $post->id }}');
+        var isLoggedIn = {{ Auth::check() ? 'true' : 'false' }};
+
+        if (isLoggedIn) {
+            // キャンセルボタンをクリックしたときテキストエリアを空にする
+            cancelButton{{ $post->id }}.addEventListener('click', function() {
+                textarea{{ $post->id }}.value = '';
+            });
+
+            // 返信ボタンをクリック時の処理
+            replyForm{{ $post->id }}.addEventListener('submit', function(event) {
+                // フォーム送信前のバリデーションチェック
+                event.preventDefault();
+                const content = textarea{{ $post->id }}.value.trim();
+                if (content === '') {
+                    alert('返信内容を入力してください（空白や改行のみは無効です）。');
+                    return;
+                }
+                const formData = new FormData(replyForm{{ $post->id }});
+                fetch(replyForm{{ $post->id }}.action, {
+                        method: 'POST',
+                        body: formData,
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                        }
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.status) {
+                            // リプライ投稿成功
+                            replyCount{{ $post->id }}.textContent = data.reply_count;
+                            textarea{{ $post->id }}.value = '';
+                            location.reload();
+                        } else {
+                            // バリデーションエラーメッセージダイアログ
+                            alert(data.errors.content[0]);
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert('リプライの投稿に失敗しました。');
+                    });
+            });
+        }
+    });
+
+    // 未ログイン時に返信ボタンクリックした時の処理
+    function confirmLogin() {
+        var currentUrl = window.location.href;
+        sessionStorage.setItem('previousUrl', currentUrl);
+        var loginUrl = "{{ route('login') }}";
+        if (confirm("ログインが必要です。ログインページに移動しますか？")) {
+            window.location.href = loginUrl;
+        }
+    }
+
+    // コメントアイコンクリックした時の処理
     function scrollReplyList(event) {
         event.preventDefault();
         const replyList = document.getElementById("replyList");

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -4,7 +4,7 @@
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">
                 <div class="card-header d-flex">
-                    <h3 class="card-title text-light flex-fill">{{ $user->name }}</h3> 
+                    <h3 class="card-title text-light flex-fill">{{ $user->name }}</h3>
                     <div class="flex-fill">
                         @include('follow.follow_btn')
                     </div>
@@ -51,9 +51,6 @@
                 <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
             </ul>
             @include('posts.posts')
-            <div class="m-auto" style="width: fit-content">
-                {{ $posts->links('pagination::bootstrap-4') }}
-            </div>
         </div>
     </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,8 +26,11 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 // ユーザ詳細
 Route::get('users/{id}', 'UsersController@show')->name('user.show');
 
-// リプライ一覧
-Route::get('posts/{id}/reply/', 'RepliesController@index')->name('reply.index');
+// リプライ
+Route::group(['prefix' => 'posts/{id}'], function () {
+    Route::get('', 'RepliesController@index')->name('reply.index');
+    Route::post('reply', 'RepliesController@store')->name('reply.store');
+});
 
 //フォロー一覧
 Route::get('followings', 'FollowController@showFollowings')->name('followings');


### PR DESCRIPTION
## isuue
- #1428 

## 概要
- リプライ（返信）機能の実装（投稿）

## 動作確認手順
- 下記コマンドを実行
php artisan migrate:refresh --seed
- 下記URLにアクセス
http://localhost:8080/
- トップページからリプライを投稿できることを下記手順にて確認する
- コメントアイコンをクリックしリプライフォームを表示
- 任意の内容を入力し「返信する」ボタンを押下
未ログイン時・・・ログインページへ遷移するか確認のダイアログが表示される
ログイン時・・・リプライ内容に問題がない場合はDBに保存され、リプライ数が1つ増加される
- 上記の操作にてリプライした投稿内容の本文を押下し、リプライ一覧画面を表示する
- 上記の操作にて投稿したリプライが表示されていることをリプライ一覧画面にて確認
- 下記2つのページでもリプライを投稿できることを確認
１．リプライ一覧画面
（未ログイン時は「返信する」ボタンを押下し、ログイン後リプライが可能となる）
２．ユーザ詳細画面
（トップページと同じく、ログイン後コメントアイコンをクリックし、リプライフォームにてリプライ投稿する）

## 考慮してほしいこと
- 投稿内容と、リプライ一覧を最新順で確認するため
PostsTableSeeder.phpとRepliesTableSeeder.phpのファイルを変更しました。
そのため、動作確認前に「php artisan migrate:refresh --seed」こちらのコマンド処理が必要です