### PR TITLE
#1428 リプライ（返信）機能_編集・更新(miyagi)

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -13,7 +13,10 @@ class RepliesController extends Controller
     public function index($id)
     {
         $post = Post::findOrFail($id);
-        $replies = $post->replies()->orderBy('created_at', 'desc')->paginate(10);
+        $replies = $post->replies()
+            ->orderBy('updated_at', 'desc')
+            ->orderBy('created_at', 'desc')
+            ->paginate(10);
         $data = [
             'post' => $post,
             'replies' => $replies,
@@ -40,5 +43,25 @@ class RepliesController extends Controller
             'status' => true,
             'reply_count' => $replyCount,
         ], 200);
+    }
+
+    // リプライ編集・更新
+    public function update(ReplyRequest $request, $reply_id)
+    {
+        $reply = Reply::findOrFail($reply_id);
+        
+        // 編集権限チェック
+        if (\Auth::id() === $reply->user_id) {
+            $reply->content = $request->content;
+            $reply->save();
+            return response()->json([
+                'status' => true,
+            ], 200);
+        } else {
+            return response()->json([
+                'status' => false,
+                'message' => 'このリプライを編集する権限がありません。'
+            ], 403);
+        }
     }
 }

--- a/database/seeds/RepliesTableSeeder.php
+++ b/database/seeds/RepliesTableSeeder.php
@@ -19,6 +19,7 @@ class RepliesTableSeeder extends Seeder
                 'post_id' => 48,
                 'content' =>  $i . '番目コメントです！',
                 'created_at' => Carbon::create(2025, 2, 16, 12, 0, 0)->addSeconds($i * 60),
+                'updated_at' => Carbon::create(2025, 2, 16, 12, 0, 0)->addSeconds($i * 60),
             ]);
         }
     }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -9,3 +9,8 @@ html {
 .hidden {
     display: none !important;
 }
+
+.dropdown-menu {
+    min-width: auto;
+    width: 90px;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,4 +50,6 @@ Route::group(['middleware' => 'auth'], function () {
     });
     // ユーザ退会
     Route::delete('users/{id}', 'UsersController@destroy')->name('user.delete');
+    // リプライ編集・更新
+    Route::put('{id}', 'RepliesController@update')->name('reply.update');
 });


### PR DESCRIPTION
## isuue
- #1428 

## 概要
- リプライ（返信）機能の編集・更新処理の実装

## 動作確認手順
- 下記コマンドを実行
php artisan migrate:refresh --seed
- 下記URLにアクセス
http://localhost:8080/
- 下記ユーザでログイン
メールアドレス「test1@test.com」　パスワード「test1」
- 最新の投稿の本文をクリックし、リプライ一覧画面を表示
- ログイン中のユーザ「test1」のリプライにのみ
「･･･」のアイコンが表示されていることを確認
- 「･･･」のアイコンをクリックし、「編集」ボタンを押下
- 編集用フォームにて任意の編集内容を入力し、「更新」ボタンを押下
- 編集内容が反映され、リプライ一覧の一番上に表示されていることを確認
- 再度「･･･」のアイコンをクリックし、「編集」ボタンを押下
- 編集フォームにて任意の文字列を入力し、「キャンセル」ボタンを押下
- リプライ内容が変更されていないことを確認

## 考慮してほしいこと
- テストデータとしてrepliesテーブルのupdated_atカラムのデータが必要だったため
RepliesTableSeeder.phpのファイルを変更しています
そのため、動作確認手順にて「php artisan migrate:refresh --seed」のコマンドを
実行する必要があります
- 「削除」ボタンは作成のみで未実装です

## 確認して欲しいこと
- RepliesController.phpのupdateメソッドでは
リプライ編集権限のチェックの結果で処理を分けてreturnを記述していますが
そのほかにも、追加の処理とreturnの記述が必要な場合はありますでしょうか？
