### PR TITLE
#1428 リプライ（返信）機能_削除(miyagi)

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -64,4 +64,23 @@ class RepliesController extends Controller
             ], 403);
         }
     }
+
+    // リプライ削除
+    public function destroy($reply_id)
+    {
+        $reply = Reply::findOrFail($reply_id);
+
+        // 削除権限チェック
+        if (\Auth::id() === $reply->user_id) {
+            $reply->delete();
+            return response()->json([
+                'status' => true,
+            ], 200);
+        } else {
+            return response()->json([
+                'status' => false,
+                'message' => 'このリプライを削除する権限がありません。'
+            ], 403);
+        }
+    }
 }

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -18,7 +18,7 @@
                         @method('DELETE')
                         <button type="submit" class="btn btn-danger">削除する</button>
                     </form>
-                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">キャンセル</button>
                 </div>
             </div>
         </div>

--- a/resources/views/replies/replies.blade.php
+++ b/resources/views/replies/replies.blade.php
@@ -1,9 +1,31 @@
 @extends('layouts.app')
 
 @section('content')
+    {{-- リプライ削除モーダル --}}
+    <div class="modal fade" id="deleteReplyConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal"
+        aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に削除しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form id="deleteReplyForm" action="" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">削除する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
     <div class="d-flex flex-column">
-        {{-- リプライ成功時のアラート --}}
-        <div id="reply-alert" class="alert alert-success text-center"
+        {{-- リプライアラート --}}
+        <div id="reply-alert" class="alert text-center"
             style="display: none; position: fixed; top: 50px; left: 50%; transform: translateX(-50%); z-index: 1000;">
         </div>
         {{-- 投稿内容 --}}
@@ -86,8 +108,9 @@
                                             <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                                                 <button class="dropdown-item text-center" type="button"
                                                     onclick="btnEditMode({{ $reply->id }})">編集</button>
-                                                <button class="dropdown-item text-center text-danger"
-                                                    type="button">削除</button>
+                                                <button class="dropdown-item text-center text-danger" type="button"
+                                                    data-toggle="modal" data-target="#deleteReplyConfirmModal"
+                                                    onclick="setDeleteModal({{ $reply->id }})">削除</button>
                                             </div>
                                         </div>
                                     </div>
@@ -186,15 +209,20 @@
         }
         // sessionStorageがtrueの場合アラート表示内容の設定
         if (sessionStorage.getItem('showReplyAlert') === 'true') {
-            showAlert("リプライが追加されました！");
+            showAlert("リプライが追加されました！", "alert-success");
             sessionStorage.removeItem('showReplyAlert');
         } else if (sessionStorage.getItem('showEditAlert') === 'true') {
-            showAlert("リプライを編集しました！");
+            showAlert("リプライを編集しました！", "alert-success");
             sessionStorage.removeItem('showEditAlert');
+        } else if (sessionStorage.getItem('showDeleteAlert') === 'true') {
+            showAlert("リプライを削除しました！", "alert-danger");
+            sessionStorage.removeItem('showDeleteAlert');
         }
         // アラートメッセージ表示・非表示処理
-        function showAlert(message) {
+        function showAlert(message, alertClass) {
             replyAlert.innerHTML = message;
+            replyAlert.classList.remove("alert-success", "alert-danger");
+            replyAlert.classList.add(alertClass);
             replyAlert.style.display = 'block';
             replyAlert.style.opacity = '1';
 
@@ -295,6 +323,53 @@
                 });
         });
     }
+
+    // 削除ボタンをクリックした時の処理
+    function setDeleteModal(replyId) {
+        var routeUrl = "{{ route('reply.delete', ':id') }}";
+        routeUrl = routeUrl.replace(':id', replyId);
+        document.getElementById('deleteReplyForm').action = routeUrl;
+    }
+
+    // リプライ削除確認ダイアログの削除するボタンをクリックした時の処理
+    document.addEventListener('DOMContentLoaded', function() {
+        const deleteReplyForm = document.getElementById('deleteReplyForm');
+        if (deleteReplyForm) {
+            deleteReplyForm.addEventListener('submit', function(event) {
+                event.preventDefault();
+
+                const form = this;
+                fetch(form.action, {
+                        method: 'POST',
+                        body: new FormData(form),
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                        }
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.status) {
+                            window.scrollTo({
+                                top: 0,
+                                behavior: 'smooth'
+                            });
+                            sessionStorage.setItem('showDeleteAlert', 'true');
+                            setTimeout(() => {
+                                location.reload();
+                            }, 500);
+                        } else {
+                            if (data.message) {
+                                alert(data.message);
+                            }
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert('リプライの削除に失敗しました。');
+                    });
+            });
+        }
+    });
 
     // コメントアイコンクリックした時の処理
     function scrollReplyList(event) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,5 +51,8 @@ Route::group(['middleware' => 'auth'], function () {
     // ユーザ退会
     Route::delete('users/{id}', 'UsersController@destroy')->name('user.delete');
     // リプライ編集・更新
-    Route::put('{id}', 'RepliesController@update')->name('reply.update');
+    Route::prefix('reply/{id}')->group(function () {
+        Route::put('', 'RepliesController@update')->name('reply.update');
+        Route::delete('', 'RepliesController@destroy')->name('reply.delete');
+    });
 });


### PR DESCRIPTION
## isuue
- Closes #1428 

## 概要
- リプライ（返信）機能_削除処理の実装

## 動作確認手順
- 下記URLにアクセスし、ログインを押下
http://localhost:8080/
- ログイン画面にて下記ユーザでログイン
メールアドレス「test1@test.com」　パスワード「test1」
- 最新の投稿の本文「48番目のテスト投稿です！」をクリックし
リプライ一覧画面を表示
- ログイン中のユーザ「test1」のリプライにのみ
「･･･」のアイコンが表示されていることを確認
- 「･･･」のアイコンをクリックし、「削除」ボタンを押下
- 確認ダイアログが表示されることを確認しキャンセルを押下
- 対象のリプライが削除されていないことを確認
- 再度「･･･」のアイコンをクリックし、「削除」ボタンを押下
- 確認ダイアログにて「削除する」ボタンを押下
- リプライ一覧にて削除したリプライが表示されていないことを確認

## 考慮してほしいこと
- 必要に応じて下記コマンドを実行する必要があります
php artisan migrate:refresh --seed

## 確認して欲しいこと
- 全体MTGにて質問させていただいた件ですが、
リプライ削除確認モーダルの記述位置は「削除」ボタンの下
（@foreach ($replies as $reply) 〜 @endforeachの中）に記述すると
モーダルが表示されないので、ループの外でモーダルを定義しました。
javascriptで$reply->idの値だけを渡すような処理に変更しましたが、
このような処理でも大丈夫でしょうか？
