### PR TITLE
【芦野】usersテーブル作成(migration)及びテストコード登録(seeder)

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -3,12 +3,14 @@
 namespace App;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
     use Notifiable;
+    use SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,6 +21,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Seeder;
-
 class DatabaseSeeder extends Seeder
 {
     /**
@@ -11,6 +10,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(UsersTableSeeder::class);
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class UsersTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //usersテーブルにデータを2件登録
+        $users = [];
+
+        for ($i = 0; $i < 2; $i++) {
+            $name = Str::random(6);
+            $users[] = [
+                'name' => $name,
+                'email' => $name . '@sample.com',
+                'password' => Hash::make('password'),
+            ];
+        }
+
+        DB::table('users')->insert($users);
+    }
+}


### PR DESCRIPTION
## 概要
＊users（ユーザ）テーブルのマイグレーションとシーダー作成

## 動作確認手順
--下記コマンドでusersテーブルに2件データ登録
php artisan db:seed
--Adminerでusersテーブルに2件のレコードが保存されることを確認

## 作業内容
①usersテーブル及びその他初期既存テーブル(password_resets)(failed_jobs)テーブル作成
　＊既存のmigration/create_users_table.phpのupにsoftDeletesを追加し【migrate】を実行
②seederでテストレコードの保存
　＊usersテーブルに下記データを2件分登録するseederを作成
　　・name（6文字のランダムな文字列）
　　・email（nameの文字に@sample.comを足した文字列）
　　・password（'password'をHash化して登録）
③UserモデルにSoftDelete追加
　＊app/User.phpにuse SoftDeletesを追加

## なぜこの処理を行ったか
①の作業内容に対し
　＊今後の仕様でuser情報削除があったため
②の作業内容に対し
　＊サンプルレコードのかぶり防止
　＊サンプルレコード登録時の工数削減
　＊for文を使用し、登録数をすぐに変更できます（保守性を考慮）
③の作業内容に対し
　＊①の処理にセットで必要なため

## 確認していただきたい箇所
②の作業内容に対し
　＊passwordの登録内容ですがHashを利用しており、教材ではbcryptを使用していたのでそちらを使用した方がよいか確認です。
　＊理由としては公式ドキュメントで推奨しており、保守性を考慮（laravelがFacadesを使用し管理しているため、今後のバージョンアップ等でも変わらずに対応を期待）
※参考までに下記コード記載（use省略）
```
    public function run()
    {
        //usersテーブルにデータを2件登録
        $users = [];

        for ($i = 0; $i < 2; $i++) {
            $name = Str::random(6);
            $users[] = [
                'name' => $name,
                'email' => $name . '@sample.com',
                'password' => Hash::make('password'),
            ];
        }

        DB::table('users')->insert($users);
    }

```