### PR TITLE
#125 ユーザ退会機能（芦野）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\User;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Redirect;
 
 class UsersController extends Controller
 {
@@ -16,9 +15,9 @@ class UsersController extends Controller
         return view('users.detail',compact('user','posts'));
     }
 
-    public function destroy()
+    public function destroy($id)
     {
-        $user = Auth::user();
+        $user = User::findOrFail($id);
         $user->delete();
 
         return redirect('/');

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -4,22 +4,30 @@ namespace App\Http\Controllers;
 
 use App\User;
 use Illuminate\Support\Facades\Auth;
-
+use Illuminate\Http\Request;
 class UsersController extends Controller
 {
     public function show($id)
     {
         $user = User::findOrFail($id);
-        $posts = $user->posts()->orderBy('id','desc')->paginate(6);
+        $posts = $user->posts()->orderBy('id', 'desc')->paginate(6);
 
-        return view('users.detail',compact('user','posts'));
+        return view('users.detail', compact('user', 'posts'));
     }
 
-    public function destroy($id)
+    public function destroy($id, Request $request)
     {
         $user = User::findOrFail($id);
+        if(Auth::id() !== $user->id){
+            abort(403,'権限がありません。');
+        }
         $user->delete();
 
-        return redirect('/');
+        Auth::logout();
+
+        $request->session()->invalidate(); // session無効化
+        $request->session()->regenerateToken(); // CSRFトークンをリセット
+
+        return redirect('/'); // 退会後トップページへ
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
 
 class UsersController extends Controller
 {
@@ -12,5 +14,13 @@ class UsersController extends Controller
         $posts = $user->posts()->orderBy('id','desc')->paginate(6);
 
         return view('users.detail',compact('user','posts'));
+    }
+
+    public function destroy()
+    {
+        $user = Auth::user();
+        $user->delete();
+
+        return redirect('/');
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -12,6 +12,8 @@ class User extends Authenticatable
     use Notifiable;
     use SoftDeletes;
 
+    protected $dates = ['deleted_at'];
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/User.php
+++ b/app/User.php
@@ -14,6 +14,16 @@ class User extends Authenticatable
 
     protected $dates = ['deleted_at'];
 
+    // 退会したユーザの投稿削除
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::deleting(function($user){
+            $user->posts()->delete();
+        });
+    }
+
     /**
      * The attributes that are mass assignable.
      *

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -11,7 +11,7 @@
                 @if (Auth::check())
                     <!-- ログイン中（ユーザー名表示 & ログアウトボタン） -->
                     <li class="nav-item">
-                        <a href="" class="nav-link text-light">{{ Auth::user()->name }}</a>
+                        <a href="{{ route('user.show', Auth::user()->id) }}" class="nav-link text-light">{{ Auth::user()->name }}</a>
                     </li>
                     <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
 

--- a/resources/views/users/detail.blade.php
+++ b/resources/views/users/detail.blade.php
@@ -4,21 +4,25 @@
 <main class="row mt-5">
     <section class="user-card col-md-4">
         <div class="card text-bg-light mb-3 bg-info">
-            <div class="card-header fs-auto pb-3">
+            <div class="card-header fs-auto pb-3 text-white">
                 <h3>{{ $user->name }}</h3>
             </div>
             <div class="card-body">
                 <div class="d-flex justify-content-center mb-3">
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 150) }}" alt="ユーザのアバター画像">
                 </div>
+                @if(Auth::id() === $user->id)
                 <div class="d-flex justify-content-center">
                     <button type="button" class="btn btn-primary ">ユーザ情報の編集</button>
                 </div>
+                @endif
             </div>
         </div>
 
         <!-- 以下退会ボタン（仮設置）※ユーザ編集画面実装後移動 -->
+        @if(Auth::id() === $user->id)
         <button type="submit" class="btn btn-danger" data-toggle="modal" data-target="#exampleModal">退会する</button>
+        @endif
 
         <!-- Modal -->
         <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
@@ -64,26 +68,7 @@
                 </ul>
             </div>
             <div class="card-body">
-                <!-- user post作成後 extends -->
-                <!-- 応急処置として対象ユーザの投稿(post)を表示する処理を実施 -->
-                @if($posts->count() > 0)
-                @foreach($posts as $post)
-                <div class="post mb-4 mx-4">
-                    <div class="d-flex justify-content-start align-items-center">
-                        <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="ユーザのアバター画像">
-                        <a class="mx-2" href="">{{ $user->name }}</a>
-                    </div>
-                    <p class="card-text d-flex justify-content-start">{{ $post->content }}</p>
-                    <small class="text-muted d-flex justify-content-start">投稿日: {{ $post->created_at->format('Y-m-d H:i:s') }}</small>
-                </div>
-                @endforeach
-
-                <div class="d-flex justify-content-center">
-                    {{ $posts->links() }}
-                </div>
-                @else
-                <p>投稿はまだありません。</p>
-                @endif
+            @include('posts.posts', ['posts' => $posts])
             </div>
         </div>
     </section>

--- a/resources/views/users/detail.blade.php
+++ b/resources/views/users/detail.blade.php
@@ -9,13 +9,43 @@
             </div>
             <div class="card-body">
                 <div class="d-flex justify-content-center mb-3">
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 150) }}" alt="ユーザのアバター画像">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 150) }}" alt="ユーザのアバター画像">
                 </div>
                 <div class="d-flex justify-content-center">
                     <button type="button" class="btn btn-primary ">ユーザ情報の編集</button>
                 </div>
             </div>
         </div>
+
+        <!-- 以下退会ボタン（仮設置）※ユーザ編集画面実装後移動 -->
+        <button type="submit" class="btn btn-danger" data-toggle="modal" data-target="#exampleModal">退会する</button>
+
+        <!-- Modal -->
+        <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">最終確認</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        本当に退会しますか？
+                    </div>
+                    <div class="modal-footer">
+                        <form action="{{ route('user.destroy', ['id'=>$user->id]) }}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger" data-toggle="modal" data-target="#exampleModal">退会する</button>
+                        </form>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- ここまで退会処理ボタン -->
+
     </section>
 
     <section class="col-md-8">
@@ -40,8 +70,8 @@
                 @foreach($posts as $post)
                 <div class="post mb-4 mx-4">
                     <div class="d-flex justify-content-start align-items-center">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="ユーザのアバター画像">
-                    <a class="mx-2" href="">{{ $user->name }}</a>
+                        <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="ユーザのアバター画像">
+                        <a class="mx-2" href="">{{ $user->name }}</a>
                     </div>
                     <p class="card-text d-flex justify-content-start">{{ $post->content }}</p>
                     <small class="text-muted d-flex justify-content-start">投稿日: {{ $post->created_at->format('Y-m-d H:i:s') }}</small>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', 'PostsController@index');
 Route::group(['middleware' => 'auth'], function(){
     // 以下、ログイン後のみ実行できるルーティングを記述可能
+
     Route::prefix('/posts')->group(function(){
         Route::post('/','PostsController@store')->name('post.store'); // 新規登録処理
         // 以下、その他post関連のルーティングを記述可能
@@ -34,7 +35,6 @@ Route::prefix('/signup')->group(function () {
     Route::get('/', 'Auth\RegisterController@showRegistrationForm')->name('signup'); // 画面表示
     Route::post('/','Auth\RegisterController@register')->name('signup.post'); // 登録処理
 });
-
 
 // ログイン
 Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,12 +22,12 @@ Route::group(['middleware' => 'auth'], function(){
         // 以下、その他post関連のルーティングを記述可能
     });
 
-    Route::prefix('/users')->group(function(){
-        Route::get('/{id}','UsersController@show')->name('user.show');  // ユーザ詳細
-        Route::delete('/{id}','UsersController@destroy')->name('user.destroy'); // ユーザ退会
-        // 以下、その他のUser関連のルーティングを記述可能
-    });
+});
 
+Route::prefix('/users')->group(function(){
+    Route::get('/{id}','UsersController@show')->name('user.show'); // ユーザ詳細
+    Route::delete('/{id}','UsersController@destroy')->name('user.destroy'); // ユーザ退会
+    // 以下、その他のUser関連のルーティングを記述可能
 });
 
 // user新規登録処理

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\UsersController;
 use Illuminate\Support\Facades\Route;
 /*
 |--------------------------------------------------------------------------
@@ -20,9 +21,17 @@ Route::prefix('/signup')->group(function () {
     Route::post('/','Auth\RegisterController@register')->name('signup.post');
 });
 
-Route::middleware('auth')->prefix('/users')->group(function(){
-    // user詳細
-    Route::get('/{id}','UsersController@show')->name('user.show');
-    // user退会
-    Route::delete('/','UsersController@destroy')->name('user.delete');
+
+// ログイン
+Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
+Route::post('login', 'Auth\LoginController@login')->name('login.post');
+//ログアウト
+Route::get('logout', 'Auth\LoginController@logout')->name('logout');
+
+Route::group(['middleware' => 'auth'],function(){
+    // 以下、ログイン後のみ実行できるルーティングを記述可能
+    Route::prefix('/users')->group(function(){
+        Route::get('/{id}','UsersController@show')->name('user.show');  // ユーザ詳細
+        Route::delete('/{id}','UsersController@destroy')->name('user.destroy'); // ユーザ退会
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,9 @@ Route::prefix('/signup')->group(function () {
     Route::post('/','Auth\RegisterController@register')->name('signup.post');
 });
 
-//user詳細
-Route::prefix('/users')->group(function(){
+Route::middleware('auth')->prefix('/users')->group(function(){
+    // user詳細
     Route::get('/{id}','UsersController@show')->name('user.show');
+    // user退会
+    Route::delete('/','UsersController@destroy')->name('user.delete');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,11 @@ Route::get('/', 'PostsController@index');
 Route::group(['middleware' => 'auth'], function(){
     // 以下、ログイン後のみ実行できるルーティングを記述可能
 
+    Route::prefix('/users')->group(function(){
+        Route::delete('/{id}','UsersController@destroy')->name('user.destroy'); // ユーザ退会
+        // 以下、【ログイン後に実行可能な】その他のUser関連のルーティングを記述可能
+    });
+
     Route::prefix('/posts')->group(function(){
         Route::post('/','PostsController@store')->name('post.store'); // 新規登録処理
         // 以下、その他post関連のルーティングを記述可能
@@ -26,8 +31,7 @@ Route::group(['middleware' => 'auth'], function(){
 
 Route::prefix('/users')->group(function(){
     Route::get('/{id}','UsersController@show')->name('user.show'); // ユーザ詳細
-    Route::delete('/{id}','UsersController@destroy')->name('user.destroy'); // ユーザ退会
-    // 以下、その他のUser関連のルーティングを記述可能
+    // 以下、【ログインが不必要な】その他のUser関連のルーティングを記述可能
 });
 
 // user新規登録処理


### PR DESCRIPTION
## issues
#125 ユーザ退会
## 概要
＊ユーザの退会処理
＊応急的にユーザ詳細ページに作成
## 動作確認手順
①http://localhost:8080　でユーザ新規作成orログイン
②ヘッダーのユーザ名をクリックしユーザ詳細ページへ移動（http://localhost:8080/users/{id}）
③アイコン下の【退会する】ボタンをクリック、モーダルで退会確認が表示されるので【退会する】ボタンをクリック
## 作業内容
①route
＊delete(destoryメソッド)　※middlwere=>auth下に作成しログインユーザのみ処理可能
②controller
＊ログインユーザのidと削除対象のidを比較、異なってたら処理を停止、同様であれば削除実行
＊削除後、ログアウト
＊session無効化及びCSRFトークンをreset
＊トップページへリダイレクト
③model
＊【protected $dates = ['deleted_at'];】でusersテーブルの削除時間を追加する仕様を追加
④view
＊ユーザ詳細ページに退会ボタンを作成
＊退会ボタンクリックでモーダル表示
## なぜ処理を行ったか
②controller処理に対し
＊userの認証をAuthでなく$idを使用
　→今後の仕様拡張を考慮し技術選定（管理者権限で削除等）
　→middleware及びfindOrFailを使用し未認証及び存在しないuserをブロック
＊【$request->session()->invalidate();】【$request->session()->regenerateToken();】の使用
　→session攻撃対策(退会後もsessionが使用される可能性)
　→CSRF攻撃対策(退会後も旧トークンが使用可能で不正リクエストが通る可能性)
## 確認していただきたい箇所
③modelの処理に対し
【 protected $dates = ['deleted_at'];】を記載する場所は適正なのか(個人的には認識できればどこでもいいかと感じましたが)確認お願いします。