### PR TITLE
ユーザ編集画面・更新（シオカワユタカ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use App\Http\Requests\UserUpdateRequest; //修正
+use Illuminate\Support\Facades\Auth; // エラーの為追加
 use Illuminate\Http\Request;
 
 class UsersController extends Controller
@@ -15,24 +17,23 @@ class UsersController extends Controller
         return view('users.detail', compact('user', 'posts'));
     }
 
-    // ユーザ情報編集フォームを表示
+    // 編集フォーム表示
     public function edit($id)
-    {
-        $user = User::findOrFail($id);
-        return view('users.edit', compact('user'));
+{
+    // 自分以外エラー
+    if (Auth::id() != $id) {
+        abort(403, 'このページへのアクセス権限がありません');
     }
 
-    // ユーザ情報を更新
-    public function update(Request $request, $id)
+    $user = User::findOrFail($id);
+    return view('users.edit', compact('user'));
+}
+
+
+    // 更新
+    public function update(UserUpdateRequest $request, $id) 
     {
         $user = User::findOrFail($id);
-
-        // バリデーション → パスワード必須
-        $request->validate([
-            'name' => 'required|max:50',
-            'email' => 'required|email',
-            'password' => 'required|min:6|confirmed', 
-        ]);
 
         // 入力値を保存
         $user->name = $request->input('name');
@@ -41,17 +42,7 @@ class UsersController extends Controller
 
         $user->save();
 
-        // 更新後、ユーザ詳細ページへリダイレクト
+        // 更新後詳細ページ
         return redirect()->route('user.show', ['id' => $user->id]);
     }
-
-    // ユーザを削除（退会処理）
-    public function destroy($id)
-    {
-        $user = User::findOrFail($id);
-        $user->delete();
-
-        return redirect('/')->with('success', '退会処理が完了しました。');
-    }
 }
-

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,14 +3,55 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use Illuminate\Http\Request;
 
 class UsersController extends Controller
 {
+    // ユーザ詳細表示
     public function show($id)
     {
         $user = User::findOrFail($id);
-        $posts = $user->posts()->orderBy('id','desc')->paginate(6);
+        $posts = $user->posts()->orderBy('id', 'desc')->paginate(6);
+        return view('users.detail', compact('user', 'posts'));
+    }
 
-        return view('users.detail',compact('user','posts'));
+    // ユーザ情報編集フォームを表示
+    public function edit($id)
+    {
+        $user = User::findOrFail($id);
+        return view('users.edit', compact('user'));
+    }
+
+    // ユーザ情報を更新
+    public function update(Request $request, $id)
+    {
+        $user = User::findOrFail($id);
+
+        // バリデーション → パスワード必須
+        $request->validate([
+            'name' => 'required|max:50',
+            'email' => 'required|email',
+            'password' => 'required|min:6|confirmed', 
+        ]);
+
+        // 入力値を保存
+        $user->name = $request->input('name');
+        $user->email = $request->input('email');
+        $user->password = bcrypt($request->input('password'));
+
+        $user->save();
+
+        // 更新後、ユーザ詳細ページへリダイレクト
+        return redirect()->route('user.show', ['id' => $user->id]);
+    }
+
+    // ユーザを削除（退会処理）
+    public function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        $user->delete();
+
+        return redirect('/')->with('success', '退会処理が完了しました。');
     }
 }
+

--- a/app/Http/Requests/UserUpdateRequest.php
+++ b/app/Http/Requests/UserUpdateRequest.php
@@ -16,7 +16,7 @@ class UserUpdateRequest extends FormRequest
     {
         return [
             'name' => 'required|max:50',
-            'email' => 'required|email',
+            'email' => 'required|email|max:255',
             'password' => 'required|min:6|confirmed',
         ];
     }

--- a/app/Http/Requests/UserUpdateRequest.php
+++ b/app/Http/Requests/UserUpdateRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserUpdateRequest extends FormRequest
+{
+    public function authorize()
+    {
+        
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'name' => 'required|max:50',
+            'email' => 'required|email',
+            'password' => 'required|min:6|confirmed',
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "fideloper/proxy": "^4.4",
         "laravel/framework": "^6.20.26",
         "laravel/tinker": "^2.5",
-        "thomaswelton/laravel-gravatar": "~1.0"
+        "thomaswelton/laravel-gravatar": "^1.3"
     },
     "require-dev": {
         "facade/ignition": "^1.16.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2be5b46626a338c96827315da91b750c",
+    "content-hash": "ed0a0136aeded502d0b4d0b0d25fdd2b",
     "packages": [
         {
             "name": "carbonphp/carbon-doctrine-types",

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -2,27 +2,32 @@
     @foreach ($posts as $post)
         <li class="mb-3 text-center">
             <div>{{ $post->name }}</div>
-                <div class="text-left d-inline-block w-75 mb-2">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                    <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $post->user->name }}</a></p>
-                </div>
-            <div class="">
-                <div class="text-left d-inline-block w-75">
-                    <p class="mb-2">{{ $post->content }}</p>
-                    <p class="text-muted">{{ $post->created_at }}</p>
-                </div>
-                    <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        @if (Auth::id() === $post->user_id)
-                            <form method="" action="">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-danger">削除</button>
-                            </form>
-                        <a href="" class="btn btn-primary">編集する</a>
-                        @endif
-                    </div>
+            <div class="text-left d-inline-block w-75 mb-2">
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                
+                <!-- ユーザー詳細ページへのリンク -->
+                <a href="/users/{{ $post->user->id }}" style="text-decoration: none; color: blue;">
+                    {{ $post->user->name }}
+                </a>
+            </div>
+
+            <div class="text-left d-inline-block w-75">
+                <p class="mb-2">{{ $post->content }}</p>
+                <p class="text-muted">{{ $post->created_at }}</p>
+            </div>
+
+            <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                @if (Auth::id() === $post->user_id)
+                    <form method="POST" action="{{ route('posts.destroy', ['post' => $post->id]) }}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger">削除</button>
+                    </form>
+                    <a href="{{ route('posts.edit', ['post' => $post->id]) }}" class="btn btn-primary">編集する</a>
+                @endif
             </div>
         </li>
     @endforeach
 </ul>
+
 <div class="m-auto" style="width: fit-content">{{ $posts->links() }}</div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -14,6 +14,16 @@
                 <p class="mb-2">{{ $post->content }}</p>
                 <p class="text-muted">{{ $post->created_at }}</p>
             </div>
+            <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+                        @if (Auth::id() === $post->user_id)
+                            <form method="" action="">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-danger">削除</button>
+                            </form>
+                        <a href="" class="btn btn-primary">編集する</a>
+                        @endif
+             </div>
         </li>
     @endforeach
 </ul>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -4,9 +4,8 @@
             <div>{{ $post->name }}</div>
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                
-                <!-- ユーザー詳細ページへのリンク -->
-                <a href="/users/{{ $post->user->id }}" style="text-decoration: none; color: blue;">
+    
+                <a href="{{ route('user.show', ['id' => $post->user->id]) }}"style="text-decoration: none; color: blue;">
                     {{ $post->user->name }}
                 </a>
             </div>
@@ -14,17 +13,6 @@
             <div class="text-left d-inline-block w-75">
                 <p class="mb-2">{{ $post->content }}</p>
                 <p class="text-muted">{{ $post->created_at }}</p>
-            </div>
-
-            <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                @if (Auth::id() === $post->user_id)
-                    <form method="POST" action="{{ route('posts.destroy', ['post' => $post->id]) }}">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit" class="btn btn-danger">削除</button>
-                    </form>
-                    <a href="{{ route('posts.edit', ['post' => $post->id]) }}" class="btn btn-primary">編集する</a>
-                @endif
             </div>
         </li>
     @endforeach

--- a/resources/views/users/detail.blade.php
+++ b/resources/views/users/detail.blade.php
@@ -4,19 +4,53 @@
 <main class="row mt-5">
     <section class="user-card col-md-4">
         <div class="card text-bg-light mb-3 bg-info">
-            <div class="card-header fs-auto pb-3">
+            <div class="card-header fs-auto pb-3 text-white">
                 <h3>{{ $user->name }}</h3>
             </div>
             <div class="card-body">
-             <div class="d-flex justify-content-center mb-3">
-             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 150) }}" alt="ユーザのアバター画像">
-            </div>
-            <div class="d-flex justify-content-center">
-            <a href="{{ route('users.edit', ['user' => $user->id]) }}" class="btn btn-primary">ユーザ情報の編集</a>
+                <div class="d-flex justify-content-center mb-3">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 150) }}" alt="ユーザのアバター画像">
+                </div>
+
+                @if(Auth::id() === $user->id)
+                <div class="d-flex justify-content-center">
+                    <a href="{{ route('users.edit', ['user' => $user->id]) }}" class="btn btn-primary">ユーザ情報の編集</a>
+                </div>
+                @endif
             </div>
         </div>
 
+        <!-- 以下退会ボタン -->
+        @if(Auth::id() === $user->id)
+        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#exampleModal">退会する</button>
+        @endif
+
+        <!-- Modal -->
+        <div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">最終確認</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        本当に退会しますか？
+                    </div>
+                    <div class="modal-footer">
+                        <form action="{{ route('users.destroy', ['user'=>$user->id]) }}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger">退会する</button>
+                        </form>
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">キャンセル</button>
+                    </div>
+                </div>
+            </div>
         </div>
+        <!-- ここまで退会処理ボタン -->
+
     </section>
 
     <section class="col-md-8">
@@ -35,29 +69,11 @@
                 </ul>
             </div>
             <div class="card-body">
-                <!-- user post作成後 extends -->
-                <!-- 応急処置として対象ユーザの投稿(post)を表示する処理を実施 -->
-                @if($posts->count() > 0)
-                @foreach($posts as $post)
-                <div class="post mb-4 mx-4">
-                    <div class="d-flex justify-content-start align-items-center">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="ユーザのアバター画像">
-                    <a class="mx-2" href="">{{ $user->name }}</a>
-                    </div>
-                    <p class="card-text d-flex justify-content-start">{{ $post->content }}</p>
-                    <small class="text-muted d-flex justify-content-start">投稿日: {{ $post->created_at->format('Y-m-d H:i:s') }}</small>
-                </div>
-                @endforeach
-
-                <div class="d-flex justify-content-center">
-                    {{ $posts->links() }}
-                </div>
-                @else
-                <p>投稿はまだありません。</p>
-                @endif
+                @include('posts.posts', ['posts' => $posts])
             </div>
         </div>
     </section>
 </main>
 
 @endsection
+

--- a/resources/views/users/detail.blade.php
+++ b/resources/views/users/detail.blade.php
@@ -40,7 +40,7 @@
                         本当に退会しますか？
                     </div>
                     <div class="modal-footer">
-                        <form action="{{ route('users.destroy', ['user'=>$user->id]) }}" method="POST">
+                        <form action="{{ route('users.destroy', ['id'=>$user->id]) }}" method="POST">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">退会する</button>

--- a/resources/views/users/detail.blade.php
+++ b/resources/views/users/detail.blade.php
@@ -8,13 +8,14 @@
                 <h3>{{ $user->name }}</h3>
             </div>
             <div class="card-body">
-                <div class="d-flex justify-content-center mb-3">
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 150) }}" alt="ユーザのアバター画像">
-                </div>
-                <div class="d-flex justify-content-center">
-                    <button type="button" class="btn btn-primary ">ユーザ情報の編集</button>
-                </div>
+             <div class="d-flex justify-content-center mb-3">
+             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 150) }}" alt="ユーザのアバター画像">
             </div>
+            <div class="d-flex justify-content-center">
+            <a href="{{ route('users.edit', ['user' => $user->id]) }}" class="btn btn-primary">ユーザ情報の編集</a>
+            </div>
+        </div>
+
         </div>
     </section>
 

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,72 @@
+@extends('layouts.app')
+
+@section('content')
+
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+
+{{-- バリデーションエラー表示 --}}
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
+<form method="POST" action="{{ route('users.update', ['user' => $user->id]) }}">
+    @csrf
+    @method('PUT')
+
+    <input type="hidden" name="id" value="{{ $user->id }}" />
+
+    <div class="form-group">
+        <label for="name">ユーザ名</label>
+        <input class="form-control" value="{{ old('name', $user->name) }}" name="name" id="name"/>
+    </div>
+
+    <div class="form-group">
+        <label for="email">メールアドレス</label>
+        <input class="form-control" value="{{ old('email', $user->email) }}" name="email" id="email"/>
+    </div>
+
+    <div class="form-group">
+        <label for="password">パスワード</label>
+        <input class="form-control" type="password" name="password" id="password"/>
+    </div>
+
+    <div class="form-group">
+        <label for="password_confirmation">パスワードの確認</label>
+        <input class="form-control" type="password" name="password_confirmation" id="password_confirmation"/>
+    </div>
+
+    <div class="d-flex justify-content-between">
+        <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </div>
+</form>
+
+{{-- 退会確認モーダル --}}
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>確認</h4>
+            </div>
+            <div class="modal-body">
+                <label>本当に退会しますか？</label>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <form action="{{ route('users.destroy', ['user' => $user->id]) }}" method="POST">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-danger">退会する</button>
+                </form>
+                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -50,7 +50,7 @@
                 <label>本当に退会しますか？</label>
             </div>
             <div class="modal-footer d-flex justify-content-between">
-                <form action="{{ route('users.destroy', ['user' => $user->id]) }}" method="POST">
+                <form action="{{ route('users.destroy', ['id' => $user->id]) }}" method="POST">
                     @csrf
                     @method('DELETE')
                     <button type="submit" class="btn btn-danger">退会する</button>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -4,16 +4,8 @@
 
 <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
 
-{{-- バリデーションエラー表示 --}}
-@if ($errors->any())
-    <div class="alert alert-danger">
-        <ul class="mb-0">
-            @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
-            @endforeach
-        </ul>
-    </div>
-@endif
+@include('commons.error_messages')
+
 
 <form method="POST" action="{{ route('users.update', ['user' => $user->id]) }}">
     @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,15 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+
 /*
 |--------------------------------------------------------------------------
 | Web Routes
 |--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
 */
 
 Route::get('/', 'PostsController@index');
@@ -25,7 +21,26 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 //ログアウト
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
-//user詳細
+
+// user詳細
 Route::prefix('/users')->group(function(){
     Route::get('/{id}','UsersController@show')->name('user.show');
 });
+
+// ユーザ詳細画面へ表示
+Route::get('users/{user}', 'UsersController@show')->name('users.show');
+
+// 編集フォームを表示
+Route::get('users/{user}/edit', 'UsersController@edit')->name('users.edit');
+
+// 更新処理
+Route::put('users/{user}', 'UsersController@update')->name('users.update');
+
+// 削除処理（退会用）
+Route::delete('users/{user}', 'UsersController@destroy')->name('users.destroy');
+
+// 投稿削除処理
+Route::delete('posts/{post}', 'PostsController@destroy')->name('posts.destroy');
+
+// 投稿編集画面表示
+Route::get('posts/{post}/edit', 'PostsController@edit')->name('posts.edit');

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,13 +9,22 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', 'PostsController@index');
+
 Route::group(['middleware' => 'auth'], function(){
-    // 以下、ログイン後のみ実行できるルーティングを記述可能
+
+    // 投稿関係
     Route::prefix('/posts')->group(function(){
-        Route::post('/','PostsController@store')->name('post.store'); // 新規登録処理
-        // 以下、その他post関連のルーティングを記述可能
+        Route::post('/','PostsController@store')->name('post.store'); //新規登録
     });
+
+    // ユーザー編集・更新
+    Route::prefix('/users')->group(function(){
+        Route::get('{user}/edit', 'UsersController@edit')->name('users.edit');
+        Route::put('{user}', 'UsersController@update')->name('users.update');
+    });
+
 });
+
 
 // user新規登録処理
 Route::prefix('/signup')->group(function () {
@@ -35,20 +44,16 @@ Route::prefix('/users')->group(function(){
     Route::get('/{id}','UsersController@show')->name('user.show');
 });
 
-// ユーザ詳細画面へ表示
-Route::get('users/{user}', 'UsersController@show')->name('users.show');
-
 // 編集フォームを表示
 Route::get('users/{user}/edit', 'UsersController@edit')->name('users.edit');
 
 // 更新処理
 Route::put('users/{user}', 'UsersController@update')->name('users.update');
 
-// 削除処理（退会用）
+//一旦書く
 Route::delete('users/{user}', 'UsersController@destroy')->name('users.destroy');
 
-// 投稿削除処理
-Route::delete('posts/{post}', 'PostsController@destroy')->name('posts.destroy');
 
-// 投稿編集画面表示
-Route::get('posts/{post}/edit', 'PostsController@edit')->name('posts.edit');
+
+
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,8 @@ Route::group(['middleware' => 'auth'], function(){
     Route::prefix('/users')->group(function(){
         Route::get('{user}/edit', 'UsersController@edit')->name('users.edit');
         Route::put('{user}', 'UsersController@update')->name('users.update');
-        Route::delete('{user}', 'UsersController@destroy')->name('users.destroy');
+        Route::delete('/{id}', 'UsersController@destroy')->name('users.destroy');
+
     });
 
 });


### PR DESCRIPTION
## issues
#117

## 概要
ユーザー編集機能バリデーション・ルートその他修正


## ユーザー情報編集機能の修正
UserUpdateRequest内emailのバリデーションルールにmax:255を追加
routes/web.phpのusers.destroyルートを{user}→{id}に変更し、コントローラの内容と整合性を持たせました
resources/views/posts/posts.blade.phpの投稿削除・編集ボタンを残す

## 動作確認
ユーザー編集・更新が正しく動作
よろしくお願い致します。