### PR TITLE
投稿削除機能追加(シオカワユタカ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -26,4 +26,14 @@ class PostsController extends Controller
 
         return redirect('/');
     }
+    public function destroy($id)
+    {
+        $post = Post::findOrFail($id);
+
+        if (auth()->id() === $post->user_id) {
+            $post->delete();
+        }
+
+        return back();
+    }
 }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -16,7 +16,7 @@
             </div>
             <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                         @if (Auth::id() === $post->user_id)
-                            <form method="" action="">
+                            <form method="POST" action="{{ route('posts.destroy', $post->id) }}">
                                 @csrf
                                 @method('DELETE')
                                 <button type="submit" class="btn btn-danger">削除</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ Route::group(['middleware' => 'auth'], function(){
     // 投稿関係
     Route::prefix('/posts')->group(function(){
         Route::post('/', 'PostsController@store')->name('post.store');
-        Route::delete('posts/{id}', 'PostsController@destroy')->name('posts.destroy');
+        Route::delete('{id}', 'PostsController@destroy')->name('posts.destroy');
     });
 
     // ユーザー編集・更新・削除

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ Route::group(['middleware' => 'auth'], function(){
     // 投稿関係
     Route::prefix('/posts')->group(function(){
         Route::post('/', 'PostsController@store')->name('post.store');
+        Route::delete('posts/{id}', 'PostsController@destroy')->name('posts.destroy');
     });
 
     // ユーザー編集・更新・削除


### PR DESCRIPTION
## isuue
#121 

## 概要
ユーザーが自身の投稿を削除できる機能の修正を行いました。

## 実装内容
Route::delete('posts/{id}', 'PostsController@destroy')->name('posts.destroy');から
Route::delete('{id}', 'PostsController@destroy')->name('posts.destroy');へ重複している場所を削除

## 対応ブランチ
feature/shiokawayutaka/post_delete

ご確認お願い致します。