### PR TITLE
投稿編集画面・更新

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -37,24 +37,25 @@ class PostsController extends Controller
 
         return back();
     }
+
     // 投稿編集画面
     public function edit($id)
     {
         $post = Post::findOrFail($id); //投稿を取得（見つからなければ404エラー）
         if (Auth::id() != $post->user_id) {
             abort(403, 'このページへのアクセス権限がありません');
-    }
+        }
 
-    return view('posts.edit', compact('post'));
+        return view('posts.edit', compact('post'));
     }
 
     //投稿更新処理
     public function update(PostRequest $request, $id)
-{
+    {
     $post = Post::findOrFail($id);
     $post->content = $request->content;
     $post->save(); // 投稿を取得して更新
 
     return redirect('/'); //トップページにリダイレクト
-}
+    }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -42,6 +42,7 @@ class PostsController extends Controller
     public function edit($id)
     {
         $post = Post::findOrFail($id); //投稿を取得（見つからなければ404エラー）
+        
         if (Auth::id() != $post->user_id) {
             abort(403, 'このページへのアクセス権限がありません');
         }
@@ -52,10 +53,10 @@ class PostsController extends Controller
     //投稿更新処理
     public function update(PostRequest $request, $id)
     {
-    $post = Post::findOrFail($id);
-    $post->content = $request->content;
-    $post->save(); // 投稿を取得して更新
+        $post = Post::findOrFail($id);
+        $post->content = $request->content;
+        $post->save(); // 投稿を取得して更新
 
-    return redirect('/'); //トップページにリダイレクト
+        return redirect('/'); //トップページにリダイレクト
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\PostRequest;
 use App\Post;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth; 
 
 class PostsController extends Controller
 {
@@ -36,4 +37,24 @@ class PostsController extends Controller
 
         return back();
     }
+    // 投稿編集画面
+    public function edit($id)
+    {
+        $post = Post::findOrFail($id); //投稿を取得（見つからなければ404エラー）
+        if (Auth::id() != $post->user_id) {
+            abort(403, 'このページへのアクセス権限がありません');
+    }
+
+    return view('posts.edit', compact('post'));
+    }
+
+    //投稿更新処理
+    public function update(PostRequest $request, $id)
+{
+    $post = Post::findOrFail($id);
+    $post->content = $request->content;
+    $post->save(); // 投稿を取得して更新
+
+    return redirect('/'); //トップページにリダイレクト
+}
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -8,6 +8,9 @@
         @method('PUT')
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
+                @error('content')
+                <p class="text-danger">{{ $message }}</p>
+                @enderror
         </div>
         <button type="submit" class="btn btn-primary">更新する</button>
     </form>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -4,8 +4,8 @@
 
 <h2 class="mt-5">投稿を編集する</h2>
     <form method="POST" action="{{ route('posts.update', $post->id) }}">
-    @csrf
-    @method('PUT')
+        @csrf
+        @method('PUT')
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
         </div>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('content')
+
+<h2 class="mt-5">投稿を編集する</h2>
+    <form method="POST" action="{{ route('posts.update', $post->id) }}">
+    @csrf
+    @method('PUT')
+        <div class="form-group">
+            <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </form>
+
+@endsection

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -21,7 +21,7 @@
                                 @method('DELETE')
                                 <button type="submit" class="btn btn-danger">削除</button>
                             </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
                         @endif
              </div>
         </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,8 @@ Route::group(['middleware' => 'auth'], function(){
     Route::prefix('/posts')->group(function(){
         Route::post('/', 'PostsController@store')->name('post.store');
         Route::delete('{id}', 'PostsController@destroy')->name('posts.destroy');
+        Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit'); // 編集画面を表示
+        Route::put('{id}', 'PostsController@update')->name('posts.update'); // 更新処理
     });
 
     // ユーザー編集・更新・削除


### PR DESCRIPTION
## issue
- Closes #123  

## 概要
- 投稿編集画面・更新

## 動作確認手順
- 編集画面の見た目、更新処理が問題ないか
- 投稿編集はログイン後のトップページ投稿からと、マイページの編集画面からどちらでも行えるか

## 考慮してほしいこと
更新完了したら、見本同様トップページにリダイレクトさせるようにしました。

## 確認してほしいこと