### PR TITLE
#107ユーザ新規登録　追加仕様　確認モーダル作成完了（芦野）

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,3 +1,0 @@
-.nav-tabs .nav-link.active {
-    color: black !important;
-}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19395,6 +19395,16 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
+// ユーザ登録モーダル
+window.registerModal = function () {
+  var name = document.getElementById('name').value;
+  var email = document.getElementById('email').value;
+  var password = document.getElementById('password').value;
+  document.getElementById('confirm-name').innerText = name;
+  document.getElementById('confirm-email').innerText = email;
+  document.getElementById('confirm-password').innerText = password;
+};
+
 /***/ }),
 
 /***/ "./resources/js/bootstrap.js":

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -17,3 +17,14 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     });
 });
+
+// ユーザ登録モーダル
+window.registerModal = function() {
+    const name = document.getElementById('name').value;
+    const email = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
+
+    document.getElementById('confirm-name').innerText = name;
+    document.getElementById('confirm-email').innerText = email;
+    document.getElementById('confirm-password').innerText = password;
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -18,14 +18,14 @@
         @csrf
         <div class="w-100 text-start mt-2">
             <label class="form-label">名前</label> <br>
-            <input type="text" name="name" value="{{old('name')}}" class="form-control col-auto">
+            <input type="text" name="name" id="name" value="{{old('name')}}" class="form-control col-auto">
             @error('name')
             <p class="text-danger">{{ $message }}</p>
             @enderror
         </div>
         <div class="w-100 text-start mt-2">
             <label class="form-label">メールアドレス</label> <br>
-            <input type="text" name="email" value="{{old('email')}}" class="form-control col-auto">
+            <input type="text" name="email" id="email" value="{{old('email')}}" class="form-control col-auto">
             @error('email')
             <p class="text-danger">{{ $message }}</p>
             @enderror
@@ -33,7 +33,7 @@
         <div class="w-100 text-start mt-2">
             <label class="form-label">パスワード</label> <br>
             <div class="d-flex input-group">
-                <input type="password" name="password" value="{{old('password')}}" class="form-control col-auto">
+                <input type="password" name="password" id="password" value="{{old('password')}}" class="form-control col-auto">
                 <button type="button" class="btn btn-outline-secondary" data-toggle="password">
                     <i class="bi bi-eye"></i>
                 </button>
@@ -54,8 +54,35 @@
             <p class="text-danger">{{ $message }}</p>
             @enderror
         </div>
-        <button type="submit" class="btn btn-primary mt-3 align-self-start">新規登録</button>
+        <!-- Button trigger modal -->
+        <button type="button" class="btn btn-primary mt-3 align-self-start" onclick="registerModal()" data-bs-toggle="modal" data-bs-target="#exampleModal">
+            登録する
+        </button>
+
+
+        <!-- Modal -->
+        <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-3" id="exampleModalLabel">ユーザを登録します。</h1>
+                    </div>
+                    <div class="modal-body">
+                        <ul class="list-group">
+                            <li class="list-group-item my-2">名前: <span class="mx-2" id="confirm-name"></span></li>
+                            <li class="list-group-item my-2">メールアドレス: <span class="mx-2" id="confirm-email"></span></li>
+                            <li class="list-group-item my-2">パスワード: <span class="mx-2" id="confirm-password"></span></li>
+                        </ul>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+                        <button type="submit" class="btn btn-primary">登録する</button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </form>
+
 </section>
 
 @endsection


### PR DESCRIPTION
## issue 
#107 ユーザ新規登録　追加仕様
## 実装内容
＊ユーザ新規登録　登録前に確認モーダルを追加
## 動作確認手順
＊ユーザ新規登録処理を実施
　*正常に登録処理ができるか
　*バリデーションが正常に作動するか
## レビューして頂きたい箇所
＊確認画面でpasswordをそのまま表示しているが仕様的にはそのまま実装でいいか
　*確認画面なのでそのまま表示しています。
## 考慮して頂きたい箇所
＊JavaScriptをコンパイルしたところ、直接記載していたcssが読み込ませなくなってしまいました。
ユーザ詳細の【タイムライン、フォロー、フォロワー】アクティブ箇所のテキストを黒にする仕様を組み込んでいましたが読み込めなくなったためコードを削除しまいした。
　仕様に直接関係がない箇所だったのでまた、時間が出来ましたら原因解明をします。