### PR TITLE
リプライ機能（表示）を実装：マイグレーションモデルコントローラBlade含む　シオカワユタカ

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -8,7 +8,7 @@ class RepliesController extends Controller
 {
     public function index(Post $post)
     {
-        $replies = $post->replies()->with('user')->latest()->get();
+        $replies = $post->replies()->with('user')->latest()->paginate(10);
         return view('replies.replies_for_post', compact('post', 'replies'));
     }
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Post;
 
-class ReplyController extends Controller
+class RepliesController extends Controller
 {
     public function index(Post $post)
     {

--- a/app/Http/Controllers/ReplyController.php
+++ b/app/Http/Controllers/ReplyController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Post;
+
+class ReplyController extends Controller
+{
+    public function index(Post $post)
+    {
+        $replies = $post->replies()->with('user')->latest()->get();
+        return view('replies.replies_for_post', compact('post', 'replies'));
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -25,6 +25,6 @@ class Post extends Model
     //リプライのリレーションを追加
     public function replies()
     {
-    return $this->hasMany(Reply::class);
+        return $this->hasMany(Reply::class);
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -21,4 +21,10 @@ class Post extends Model
     {
         return $this->hasMany(Like::class);
     }
+
+    //リプライのリレーションを追加
+    public function replies()
+    {
+    return $this->hasMany(Reply::class);
+    }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Reply extends Model
+{
+    //投稿時に必要な項目（Mass Assignment）を許可
+    protected $fillable = ['user_id', 'post_id', 'content'];
+
+    //投稿とのリレーション（1つのリプライは1つの投稿に属する）
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    //ユーザーとのリレーション（1つのリプライは1人のユーザーに属する）
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -61,6 +61,12 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    // リプライとリレーション
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
+
     // フォローリレーション(フォローしているユーザを取得)
     public function following()
     {

--- a/database/migrations/2025_04_08_200258_create_replies_table.php
+++ b/database/migrations/2025_04_08_200258_create_replies_table.php
@@ -13,16 +13,16 @@ class CreateRepliesTable extends Migration
      */
     public function up()
     {
-    Schema::create('replies', function (Blueprint $table) {
-        $table->bigIncrements('id'); 
-        $table->unsignedBigInteger('post_id');
-        $table->unsignedBigInteger('user_id');
-        $table->text('content');
-        $table->timestamps();
+        Schema::create('replies', function (Blueprint $table) {
+            $table->bigIncrements('id'); 
+            $table->unsignedBigInteger('post_id');
+            $table->unsignedBigInteger('user_id');
+            $table->text('content');
+            $table->timestamps();
 
-        $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
-        $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-    });
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
     }
 
     /**
@@ -32,6 +32,6 @@ class CreateRepliesTable extends Migration
      */
     public function down()
     {
-    Schema::dropIfExists('replies');
+        Schema::dropIfExists('replies');
     }
 }

--- a/database/migrations/2025_04_08_200258_create_replies_table.php
+++ b/database/migrations/2025_04_08_200258_create_replies_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+    Schema::create('replies', function (Blueprint $table) {
+        $table->bigIncrements('id'); 
+        $table->unsignedBigInteger('post_id');
+        $table->unsignedBigInteger('user_id');
+        $table->text('content');
+        $table->timestamps();
+
+        $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+        $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+    });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    Schema::dropIfExists('replies');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,7 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(RepliesTableSeeder::class);
+
     }
 }

--- a/database/seeds/RepliesTableSeeder.php
+++ b/database/seeds/RepliesTableSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Reply;
+use App\Post;
+use App\User;
+
+class RepliesTableSeeder extends Seeder
+{
+    public function run()
+    {
+        $posts = Post::all();
+        $users = User::all();
+
+        // 各投稿に3件ずつランダムなユーザーからリプライ
+        foreach ($posts as $post) {
+            for ($i = 0; $i < 15; $i++) {
+                Reply::create([
+                    'post_id' => $post->id,
+                    'user_id' => $users->random()->id,
+                    'content' => 'これはダミーのリプライです。'
+                ]);
+            }
+        }
+    }
+}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -17,6 +17,10 @@
                 <p class="text-muted">{{ $post->created_at }}</p>
                 {{-- ここにいいねボタンを追加 --}}
                 <div class="d-inline-block">
+                {{-- 💬リプライリンク ← 追加する！ --}}
+                <a href="{{ route('replies.index', $post->id) }}" class="btn btn-light">
+                💬 {{ $post->replies->count() }}
+                </a>
                     <form method="POST" action="{{ route('posts.like', $post->id) }}" style="display:inline;">
                         @csrf
                         <button type="submit" class="btn btn-light"

--- a/resources/views/replies/replies_for_post.blade.php
+++ b/resources/views/replies/replies_for_post.blade.php
@@ -22,6 +22,9 @@
                 </div>
             </div>
         @endforeach
+        <div class="mt-3">
+        {{ $replies->links() }}
+        </div>
     @endif
 </div>
 @endsection

--- a/resources/views/replies/replies_for_post.blade.php
+++ b/resources/views/replies/replies_for_post.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h2>「{{ $post->content }}」へのリプライ一覧</h2>
+
+    {{-- 💬ボタン--}}
+    <div class="mb-3">
+        <a href="{{ route('replies.index', $post->id) }}">
+            💬 {{ $post->replies->count() }}
+        </a>
+    </div>
+
+    @if ($replies->isEmpty())
+        <p>まだリプライはありません。</p>
+    @else
+        @foreach ($replies as $reply)
+            <div class="card mb-2">
+                <div class="card-body">
+                    <strong>{{ $reply->user->name }}</strong>：{{ $reply->content }}
+                    <div class="text-muted small">{{ $reply->created_at->format('Y/m/d H:i') }}</div>
+                </div>
+            </div>
+        @endforeach
+    @endif
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Route;
 // トップページ
 Route::get('/', 'PostsController@index');
 Route::get('/posts/search', 'PostsController@search')->name('posts.search');//検索機能をログインなしで
+Route::get('{post}/replies', 'ReplyController@index')->name('replies.index');//リプライ一覧
 
 
 // ログイン必須のルーティング
@@ -26,9 +27,6 @@ Route::group(['middleware' => 'auth'], function(){
         // いいね機能の追加
         Route::post('{id}/like', 'LikeController@like')->name('posts.like'); // いいね
         Route::delete('{id}/unlike', 'LikeController@unlike')->name('posts.unlike'); // いいね解除
-        
-        // リプライ機能の追加
-        Route::get('{post}/replies', [App\Http\Controllers\ReplyController::class, 'index'])->name('replies.index'); // リプライ一覧
     });
 
     // ユーザ関係(ログイン必要)

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,9 @@ Route::group(['middleware' => 'auth'], function(){
         // いいね機能の追加
         Route::post('{id}/like', 'LikeController@like')->name('posts.like'); // いいね
         Route::delete('{id}/unlike', 'LikeController@unlike')->name('posts.unlike'); // いいね解除
+        
+        // リプライ機能の追加
+        Route::get('{post}/replies', [App\Http\Controllers\ReplyController::class, 'index'])->name('replies.index'); // リプライ一覧
     });
 
     // ユーザ関係(ログイン必要)

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Route;
 // トップページ
 Route::get('/', 'PostsController@index');
 Route::get('/posts/search', 'PostsController@search')->name('posts.search');//検索機能をログインなしで
-Route::get('{post}/replies', 'ReplyController@index')->name('replies.index');//リプライ一覧
+Route::get('/posts/{post}/replies', 'RepliesController@index')->name('replies.index');//リプライ一覧
 
 
 // ログイン必須のルーティング


### PR DESCRIPTION
## 概要
投稿に対するリプライ一覧表示にページネーション機能を追加しました。  
あわせて動作確認用にリプライのシーダーも作成し、リプライ表示のテストをしやすくしました。

---

## 実装内容

- `RepliesController@index`
  - `paginate(10)` を使用し、1ページあたり10件のリプライを表示するように変更
- `resources/views/replies/replies_for_post.blade.php`
  - `{{ $replies->links() }}` を追加し、ページナビゲーションを表示
- `RepliesTableSeeder` を新規作成
  - 全投稿に対して、ランダムなユーザーから15件のリプライを付与
  - `DatabaseSeeder.php` に登録し、`php artisan db:seed` で実行可能
- `php artisan migrate:refresh --seed` にて動作確認済み

---

## 動作確認手順

1. `php artisan migrate:refresh --seed` を実行
2. ブラウザで `http://localhost:8080/posts/1/replies` にアクセス
3. 1ページ目に10件のリプライが表示されていることを確認
4. ページ下部にページネーションが表示され、`?page=2` で残りの5件が表示されることを確認
