### PR TITLE
投稿ランキング表示

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Post;
+
+class RankingController extends Controller
+{
+    public function index()
+    {
+        $rankingPosts = Post::with(['user', 'likes', 'replies']) // 必要な関連も読み込み
+            ->withCount('likes')
+            ->orderBy('likes_count', 'desc')
+            ->take(5)
+            ->get();
+    
+        return view('posts.ranking', compact('rankingPosts'));
+    }
+}

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -10,6 +10,7 @@ class RankingController extends Controller
     {
         $rankingPosts = Post::with(['user', 'likes', 'replies']) // 必要な関連も読み込み
             ->withCount('likes')
+            ->having('likes_count', '>', 0)
             ->orderBy('likes_count', 'desc')
             ->take(5)
             ->get();

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -12,7 +12,6 @@ class RankingController extends Controller
             ->withCount('likes')
             ->having('likes_count', '>', 0)
             ->orderBy('likes_count', 'desc')
-            ->take(5)
             ->get();
     
         return view('posts.ranking', compact('rankingPosts'));

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,6 +16,8 @@
     <script src="{{ mix('js/app.js') }}" defer></script>
     <!-- css -->
     <link rel="stylesheet" href="{{ asset('css/app.css') }}">
+
+    @stack('styles')
 </head>
 
 <body>

--- a/resources/views/posts/post_actions.blade.php
+++ b/resources/views/posts/post_actions.blade.php
@@ -1,0 +1,10 @@
+<div class="d-flex justify-content-between w-75 pb-3 m-auto">
+    @if (Auth::id() === $post->user_id)
+        <form method="POST" action="{{ route('posts.destroy', $post->id) }}">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">削除</button>
+        </form>
+        <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
+    @endif
+</div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -30,16 +30,7 @@
                     </form>
                 </div>
             </div>
-            <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        @if (Auth::id() === $post->user_id)
-                            <form method="POST" action="{{ route('posts.destroy', $post->id) }}">
-                                @csrf
-                                @method('DELETE')
-                                <button type="submit" class="btn btn-danger">削除</button>
-                            </form>
-                        <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
-                        @endif
-            </div>
+            @include('posts.post_actions')
         </li>
     @endforeach
 </ul>

--- a/resources/views/posts/ranking.blade.php
+++ b/resources/views/posts/ranking.blade.php
@@ -7,6 +7,8 @@
         $rank = 0;
         $prevLikes = null;
         $displayRank = 0;
+        $maxDisplayed = 0;
+        $maxToShow = 5;
     @endphp
 
     @push('styles')
@@ -58,74 +60,84 @@
         </style>
     @endpush
 
-    <ul class="list-unstyled">
-        @foreach ($rankingPosts as $post)
-            <li class="mb-3 text-center">
-                @php
-                    $currentLikes = $post->likes->count();
-                    $rank++;
+    @if ($rankingPosts->isEmpty())
+        <p class="text-center text-muted">まだいいねがついた投稿はありません。</p>
+    @else
+        <ul class="list-unstyled">
+            @foreach ($rankingPosts as $post)
+                <li class="mb-3 text-center">
+                    @php
+                        $currentLikes = $post->likes->count();
+                        $rank++;
 
-                    // いいね数が前と違えば表示順位を更新
-                    if ($currentLikes !== $prevLikes) {
-                        $displayRank = $rank;
-                        $prevLikes = $currentLikes;
-                    }
+                        // いいね数が前と違えば表示順位を更新
+                        if ($currentLikes !== $prevLikes) {
+                            $displayRank = $rank;
+                            $prevLikes = $currentLikes;
+                        }
 
-                    // ランクに応じた色・文字サイズのクラスを設定
-                    if ($displayRank === 1) {
-                        $rankClass = 'text-warning font-weight-bold rank-size-1';
-                        $bgClass = 'bg-gold';
-                    } elseif ($displayRank === 2) {
-                        $rankClass = 'text-secondary font-weight-bold rank-size-2';
-                        $bgClass = 'bg-silver';
-                    } elseif ($displayRank === 3) {
-                        $rankClass = 'text-orange font-weight-bold rank-size-3';
-                        $bgClass = 'bg-bronze';
-                    } else {
-                        $rankClass = 'text-muted rank-size-default';
-                        $bgClass = 'bg-muted';
-                    }
-                @endphp
+                        // 上限を超えたら break
+                        if ($displayRank > $maxToShow) {
+                            break;
+                        }
 
-                <div class="{{ $rankClass }}">🏆 {{ $displayRank }}位（獲得👍 {{ $currentLikes }}）</div>
+                        // ランクに応じた色・文字サイズのクラスを設定
+                        if ($displayRank === 1) {
+                            $rankClass = 'text-warning font-weight-bold rank-size-1';
+                            $bgClass = 'bg-gold';
+                        } elseif ($displayRank === 2) {
+                            $rankClass = 'text-secondary font-weight-bold rank-size-2';
+                            $bgClass = 'bg-silver';
+                        } elseif ($displayRank === 3) {
+                            $rankClass = 'text-orange font-weight-bold rank-size-3';
+                            $bgClass = 'bg-bronze';
+                        } else {
+                            $rankClass = 'text-muted rank-size-default';
+                            $bgClass = 'bg-muted';
+                        }
+                    @endphp
 
-                {{-- 以下、投稿の表示 --}}
-                <div class="{{ $bgClass }} p-3 rounded mb-3">
-                    <div>{{ $post->name }}</div>
-                    <div class="text-left d-inline-block w-75 mb-2">
-                        <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                        <a href="{{ route('user.show', ['id' => $post->user->id]) }}"
-                            style="text-decoration: none; color: blue;">
-                            {{ $post->user->name }}
-                        </a>
-                    </div>
+                    <div class="{{ $rankClass }}">🏆 {{ $displayRank }}位（獲得👍 {{ $currentLikes }}）</div>
 
-                    <div class="text-left d-inline-block w-75">
-                        <p class="mb-2">{{ $post->content }}</p>
-                        @if ($post->image_path)
-                            <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像"
-                                class="img-thumbnail clickable-image" style="width: 200px; cursor: pointer;"
-                                data-image="{{ asset('storage/' . $post->image_path) }}">
-                        @endif
-                        <p class="text-muted">{{ $post->created_at }}</p>
-                        {{-- ここにいいねボタンを追加 --}}
-                        <div class="d-inline-block">
-                            {{-- 💬リプライリンク ← 追加する！ --}}
-                            <a href="{{ route('replies.index', $post->id) }}" class="btn btn-light">
-                                💬 {{ $post->replies->count() }}
+                    {{-- 以下、投稿の表示 --}}
+                    <div class="{{ $bgClass }} p-3 rounded mb-3">
+                        <div>{{ $post->name }}</div>
+                        <div class="text-left d-inline-block w-75 mb-2">
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}"
+                                alt="ユーザのアバター画像">
+                            <a href="{{ route('user.show', ['id' => $post->user->id]) }}"
+                                style="text-decoration: none; color: blue;">
+                                {{ $post->user->name }}
                             </a>
-                            <form method="POST" action="{{ route('posts.like', $post->id) }}" style="display:inline;">
-                                @csrf
-                                <button type="submit" class="btn btn-light"
-                                    @if (Auth::id() === $post->user_id) disabled @endif>
-                                    👍 {{ ($post->likes ?? collect([]))->count() }}
-                                </button>
-                            </form>
+                        </div>
+
+                        <div class="text-left d-inline-block w-75">
+                            <p class="mb-2">{{ $post->content }}</p>
+                            @if ($post->image_path)
+                                <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像"
+                                    class="img-thumbnail clickable-image" style="width: 200px; cursor: pointer;"
+                                    data-image="{{ asset('storage/' . $post->image_path) }}">
+                            @endif
+                            <p class="text-muted">{{ $post->created_at }}</p>
+                            {{-- ここにいいねボタンを追加 --}}
+                            <div class="d-inline-block">
+                                {{-- 💬リプライリンク ← 追加する！ --}}
+                                <a href="{{ route('replies.index', $post->id) }}" class="btn btn-light">
+                                    💬 {{ $post->replies->count() }}
+                                </a>
+                                <form method="POST" action="{{ route('posts.like', $post->id) }}" style="display:inline;">
+                                    @csrf
+                                    <button type="submit" class="btn btn-light"
+                                        @if (Auth::id() === $post->user_id) disabled @endif>
+                                        👍 {{ ($post->likes ?? collect([]))->count() }}
+                                    </button>
+                                </form>
+                            </div>
                         </div>
                     </div>
-                </div>
-                @include('posts.post_actions')
-            </li>
-        @endforeach
-    </ul>
+                    @include('posts.post_actions')
+                </li>
+            @endforeach
+        </ul>
+    @endif
 @endsection

--- a/resources/views/posts/ranking.blade.php
+++ b/resources/views/posts/ranking.blade.php
@@ -1,139 +1,131 @@
 @extends('layouts.app')
 
 @section('content')
+    <h2 class="text-center mb-4">👍 いいねランキング</h2>
 
-<h2 class="text-center mb-4">👍 いいねランキング</h2>
-
-@php
-$rank = 0;
-$prevLikes = null;
-$displayRank = 0;
-@endphp
-
-@push('styles')
-<style>
-  .rank-size-1 {
-    font-size: 1.5rem;
-    /* 1位：大きく */
-  }
-
-  .rank-size-2 {
-    font-size: 1.25rem;
-    /* 2位 */
-  }
-
-  .rank-size-3 {
-    font-size: 1.1rem;
-    /* 3位 */
-  }
-
-  .rank-size-default {
-    font-size: 1rem;
-    /* その他 */
-  }
-
-  .text-orange {
-    color: #cd7f32 !important;
-    /* 銅メダル色 */
-  }
-
-  .bg-gold {
-    background-color: #ffd700;
-    color: #fff;
-  }
-
-  .bg-silver {
-    background-color: #c0c0c0;
-    color: #fff;
-  }
-
-  .bg-bronze {
-    background-color: #cd7f32;
-    color: #fff;
-  }
-
-  .bg-muted {
-    background-color: #f8f9fa;
-    color: #6c757d;
-  }
-</style>
-@endpush
-
-<ul class="list-unstyled">
-  @foreach ($rankingPosts as $post)
-  <li class="mb-3 text-center">
     @php
-    $currentLikes = $post->likes->count();
-    $rank++;
-
-    // いいね数が前と違えば表示順位を更新
-    if ($currentLikes !== $prevLikes) {
-    $displayRank = $rank;
-    $prevLikes = $currentLikes;
-    }
-
-    // ランクに応じた色・文字サイズのクラスを設定
-    if ($displayRank === 1) {
-      $rankClass = 'text-warning font-weight-bold rank-size-1';
-      $bgClass = 'bg-gold';
-      } elseif ($displayRank === 2) {
-      $rankClass = 'text-secondary font-weight-bold rank-size-2';
-      $bgClass = 'bg-silver';
-      } elseif ($displayRank === 3) {
-      $rankClass = 'text-orange font-weight-bold rank-size-3';
-      $bgClass = 'bg-bronze';
-      } else {
-      $rankClass = 'text-muted rank-size-default';
-      $bgClass = 'bg-muted';
-      }
+        $rank = 0;
+        $prevLikes = null;
+        $displayRank = 0;
     @endphp
 
-    <div class="{{ $rankClass }}">🏆 {{ $displayRank }}位（獲得👍 {{ $currentLikes }}）</div>
+    @push('styles')
+        <style>
+            .rank-size-1 {
+                font-size: 1.5rem;
+                /* 1位：大きく */
+            }
 
-    {{-- 以下、投稿の表示 --}}
-    <div class="{{ $bgClass }} p-3 rounded mb-3">
-      <div>{{ $post->name }}</div>
-      <div class="text-left d-inline-block w-75 mb-2">
-        <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-        <a href="{{ route('user.show', ['id' => $post->user->id]) }}" style="text-decoration: none; color: blue;">
-          {{ $post->user->name }}
-        </a>
-      </div>
+            .rank-size-2 {
+                font-size: 1.25rem;
+                /* 2位 */
+            }
 
-      <div class="text-left d-inline-block w-75">
-        <p class="mb-2">{{ $post->content }}</p>
-        @if($post->image_path)
-        <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像" class="img-thumbnail clickable-image" style="width: 200px; cursor: pointer;" data-image="{{ asset('storage/' .$post->image_path) }}">
-        @endif
-        <p class="text-muted">{{ $post->created_at }}</p>
-        {{-- ここにいいねボタンを追加 --}}
-        <div class="d-inline-block">
-          {{-- 💬リプライリンク ← 追加する！ --}}
-          <a href="{{ route('replies.index', $post->id) }}" class="btn btn-light">
-            💬 {{ $post->replies->count() }}
-          </a>
-          <form method="POST" action="{{ route('posts.like', $post->id) }}" style="display:inline;">
-            @csrf
-            <button type="submit" class="btn btn-light"
-              @if (Auth::id()===$post->user_id) disabled @endif>
-              👍 {{ ($post->likes ?? collect([]))->count() }}
-            </button>
-          </form>
-        </div>
-      </div>
-    </div>
-    <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-      @if (Auth::id() === $post->user_id)
-      <form method="POST" action="{{ route('posts.destroy', $post->id) }}">
-        @csrf
-        @method('DELETE')
-        <button type="submit" class="btn btn-danger">削除</button>
-      </form>
-      <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
-      @endif
-    </div>
-  </li>
-  @endforeach
-</ul>
+            .rank-size-3 {
+                font-size: 1.1rem;
+                /* 3位 */
+            }
 
+            .rank-size-default {
+                font-size: 1rem;
+                /* その他 */
+            }
+
+            .text-orange {
+                color: #cd7f32 !important;
+                /* 銅メダル色 */
+            }
+
+            .bg-gold {
+                background-color: #ffd700;
+                color: #fff;
+            }
+
+            .bg-silver {
+                background-color: #c0c0c0;
+                color: #fff;
+            }
+
+            .bg-bronze {
+                background-color: #cd7f32;
+                color: #fff;
+            }
+
+            .bg-muted {
+                background-color: #f8f9fa;
+                color: #6c757d;
+            }
+        </style>
+    @endpush
+
+    <ul class="list-unstyled">
+        @foreach ($rankingPosts as $post)
+            <li class="mb-3 text-center">
+                @php
+                    $currentLikes = $post->likes->count();
+                    $rank++;
+
+                    // いいね数が前と違えば表示順位を更新
+                    if ($currentLikes !== $prevLikes) {
+                        $displayRank = $rank;
+                        $prevLikes = $currentLikes;
+                    }
+
+                    // ランクに応じた色・文字サイズのクラスを設定
+                    if ($displayRank === 1) {
+                        $rankClass = 'text-warning font-weight-bold rank-size-1';
+                        $bgClass = 'bg-gold';
+                    } elseif ($displayRank === 2) {
+                        $rankClass = 'text-secondary font-weight-bold rank-size-2';
+                        $bgClass = 'bg-silver';
+                    } elseif ($displayRank === 3) {
+                        $rankClass = 'text-orange font-weight-bold rank-size-3';
+                        $bgClass = 'bg-bronze';
+                    } else {
+                        $rankClass = 'text-muted rank-size-default';
+                        $bgClass = 'bg-muted';
+                    }
+                @endphp
+
+                <div class="{{ $rankClass }}">🏆 {{ $displayRank }}位（獲得👍 {{ $currentLikes }}）</div>
+
+                {{-- 以下、投稿の表示 --}}
+                <div class="{{ $bgClass }} p-3 rounded mb-3">
+                    <div>{{ $post->name }}</div>
+                    <div class="text-left d-inline-block w-75 mb-2">
+                        <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                        <a href="{{ route('user.show', ['id' => $post->user->id]) }}"
+                            style="text-decoration: none; color: blue;">
+                            {{ $post->user->name }}
+                        </a>
+                    </div>
+
+                    <div class="text-left d-inline-block w-75">
+                        <p class="mb-2">{{ $post->content }}</p>
+                        @if ($post->image_path)
+                            <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像"
+                                class="img-thumbnail clickable-image" style="width: 200px; cursor: pointer;"
+                                data-image="{{ asset('storage/' . $post->image_path) }}">
+                        @endif
+                        <p class="text-muted">{{ $post->created_at }}</p>
+                        {{-- ここにいいねボタンを追加 --}}
+                        <div class="d-inline-block">
+                            {{-- 💬リプライリンク ← 追加する！ --}}
+                            <a href="{{ route('replies.index', $post->id) }}" class="btn btn-light">
+                                💬 {{ $post->replies->count() }}
+                            </a>
+                            <form method="POST" action="{{ route('posts.like', $post->id) }}" style="display:inline;">
+                                @csrf
+                                <button type="submit" class="btn btn-light"
+                                    @if (Auth::id() === $post->user_id) disabled @endif>
+                                    👍 {{ ($post->likes ?? collect([]))->count() }}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                @include('posts.post_actions')
+            </li>
+        @endforeach
+    </ul>
 @endsection

--- a/resources/views/posts/ranking.blade.php
+++ b/resources/views/posts/ranking.blade.php
@@ -1,0 +1,139 @@
+@extends('layouts.app')
+
+@section('content')
+
+<h2 class="text-center mb-4">👍 いいねランキング</h2>
+
+@php
+$rank = 0;
+$prevLikes = null;
+$displayRank = 0;
+@endphp
+
+@push('styles')
+<style>
+  .rank-size-1 {
+    font-size: 1.5rem;
+    /* 1位：大きく */
+  }
+
+  .rank-size-2 {
+    font-size: 1.25rem;
+    /* 2位 */
+  }
+
+  .rank-size-3 {
+    font-size: 1.1rem;
+    /* 3位 */
+  }
+
+  .rank-size-default {
+    font-size: 1rem;
+    /* その他 */
+  }
+
+  .text-orange {
+    color: #cd7f32 !important;
+    /* 銅メダル色 */
+  }
+
+  .bg-gold {
+    background-color: #ffd700;
+    color: #fff;
+  }
+
+  .bg-silver {
+    background-color: #c0c0c0;
+    color: #fff;
+  }
+
+  .bg-bronze {
+    background-color: #cd7f32;
+    color: #fff;
+  }
+
+  .bg-muted {
+    background-color: #f8f9fa;
+    color: #6c757d;
+  }
+</style>
+@endpush
+
+<ul class="list-unstyled">
+  @foreach ($rankingPosts as $post)
+  <li class="mb-3 text-center">
+    @php
+    $currentLikes = $post->likes->count();
+    $rank++;
+
+    // いいね数が前と違えば表示順位を更新
+    if ($currentLikes !== $prevLikes) {
+    $displayRank = $rank;
+    $prevLikes = $currentLikes;
+    }
+
+    // ランクに応じた色・文字サイズのクラスを設定
+    if ($displayRank === 1) {
+      $rankClass = 'text-warning font-weight-bold rank-size-1';
+      $bgClass = 'bg-gold';
+      } elseif ($displayRank === 2) {
+      $rankClass = 'text-secondary font-weight-bold rank-size-2';
+      $bgClass = 'bg-silver';
+      } elseif ($displayRank === 3) {
+      $rankClass = 'text-orange font-weight-bold rank-size-3';
+      $bgClass = 'bg-bronze';
+      } else {
+      $rankClass = 'text-muted rank-size-default';
+      $bgClass = 'bg-muted';
+      }
+    @endphp
+
+    <div class="{{ $rankClass }}">🏆 {{ $displayRank }}位（獲得👍 {{ $currentLikes }}）</div>
+
+    {{-- 以下、投稿の表示 --}}
+    <div class="{{ $bgClass }} p-3 rounded mb-3">
+      <div>{{ $post->name }}</div>
+      <div class="text-left d-inline-block w-75 mb-2">
+        <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+        <a href="{{ route('user.show', ['id' => $post->user->id]) }}" style="text-decoration: none; color: blue;">
+          {{ $post->user->name }}
+        </a>
+      </div>
+
+      <div class="text-left d-inline-block w-75">
+        <p class="mb-2">{{ $post->content }}</p>
+        @if($post->image_path)
+        <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像" class="img-thumbnail clickable-image" style="width: 200px; cursor: pointer;" data-image="{{ asset('storage/' .$post->image_path) }}">
+        @endif
+        <p class="text-muted">{{ $post->created_at }}</p>
+        {{-- ここにいいねボタンを追加 --}}
+        <div class="d-inline-block">
+          {{-- 💬リプライリンク ← 追加する！ --}}
+          <a href="{{ route('replies.index', $post->id) }}" class="btn btn-light">
+            💬 {{ $post->replies->count() }}
+          </a>
+          <form method="POST" action="{{ route('posts.like', $post->id) }}" style="display:inline;">
+            @csrf
+            <button type="submit" class="btn btn-light"
+              @if (Auth::id()===$post->user_id) disabled @endif>
+              👍 {{ ($post->likes ?? collect([]))->count() }}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+    <div class="d-flex justify-content-between w-75 pb-3 m-auto">
+      @if (Auth::id() === $post->user_id)
+      <form method="POST" action="{{ route('posts.destroy', $post->id) }}">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="btn btn-danger">削除</button>
+      </form>
+      <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
+      @endif
+    </div>
+  </li>
+  @endforeach
+</ul>
+
+@endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -14,5 +14,8 @@
             @if(auth()->check())
                 @include('posts.add_post')
             @endif
+        <div class="text-center mb-4">
+        <a href="{{ route('ranking.index') }}" class="btn btn-warning">👍 いいねランキングを見る</a>
+        </div>
     @include('posts.posts', ['posts' => $posts])
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -14,7 +14,7 @@
             @if(auth()->check())
                 @include('posts.add_post')
             @endif
-        <div class="text-center mb-4">
+        <div class="mb-4 d-flex justify-content-end">
         <a href="{{ route('ranking.index') }}" class="btn btn-warning">👍 いいねランキングを見る</a>
         </div>
     @include('posts.posts', ['posts' => $posts])

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', 'PostsController@index');
 Route::get('/posts/search', 'PostsController@search')->name('posts.search');//検索機能をログインなしで
 Route::get('/posts/{post}/replies', 'RepliesController@index')->name('replies.index');//リプライ一覧
+Route::get('/posts/ranking', 'RankingController@index')->name('ranking.index');//ランキング表示
 
 
 // ログイン必須のルーティング


### PR DESCRIPTION
## issue
- Closes #1481 

## 概要
- いいねランキング

## 動作確認手順
- http://localhost:8080/ トップページの投稿一覧の頭にランキングページへの導線を挿入
- ランキングは誰でも見れるよう仕様(ログイン判定なし)
- http://localhost:8080/posts/ranking にて5つ、いいね多い順に投稿を表示。
- いいね同数の場合は順位も一緒になるよう調整
- また、1位～3位は色と文字サイズを変更、背景色もつけてランキング感を出した

## 考慮してほしいこと
ランキングへの導線がうまくいっているか確認いただけると幸いです。
投稿単体の表示はposts.blade.phpと全く一緒にしています。

## 確認してほしいこと
今回CSSも調べて結構触ったので、記述的に問題ないか確認いただけるとありがたいです！
※ranking.blade.php内の記述がかなり増えてしまっている