### PR TITLE
#127 フォロー機能（街）

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -6,17 +6,17 @@ use Illuminate\Http\Request;
 
 class FollowController extends Controller
 {
-    public function store(Request $request, $postId)
+    public function store(Request $request, $id)
     {
         $user = $request->user();
-        $user->follow($postId);
+        $user->follow($id);
         return back();
     }
 
-    public function delete(Request $request, $postId)
+    public function delete(Request $request, $id)
     {
         $user = $request->user();
-        $user->unfollow($postId);
+        $user->unfollow($id);
         return back();
     }
 }

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -6,5 +6,17 @@ use Illuminate\Http\Request;
 
 class FollowController extends Controller
 {
-    //
+    public function store(Request $request, $postId)
+    {
+        $user = $request->user();
+        $user->follow($postId);
+        return back();
+    }
+
+    public function delete(Request $request, $postId)
+    {
+        $user = $request->user();
+        $user->unfollow($postId);
+        return back();
+    }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -13,7 +13,6 @@ class PostsController extends Controller
     public function index()
     {
         $posts = Post::orderBy('id','desc')->paginate(10);
-        $users = User::all(); //全ユーザを取得
         $data = [ //現状、viewに渡す変数は１個。だが、今後の拡張性を考えて、配列で書いておく。
             'posts' => $posts, //index.bladeで、$postsと書いて使う。この中身は、ここで定義してある$posts。
         ];

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -34,7 +34,7 @@ class PostsController extends Controller
         
         $post = Post::findOrFail($id); //idに該当する投稿データを取得。見つからなければ404エラーを返す
         $data = [
-            'post' => $post,
+            'post' => $post, //idに該当する投稿データをこれに格納
         ];
         return view('posts.edit_post_form', $data); //posts.editビューを表示
     }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -34,13 +34,16 @@ class PostsController extends Controller
         return back(); //投稿ボタンを押した後、投稿フォームに戻る
     }
 
-    public function edit($id){ //編集ボタンを押した投稿データの、idを取得
-        
-        $post = Post::findOrFail($id); //idに該当する投稿データを取得。見つからなければ404エラーを返す
-        $data = [
-            'post' => $post, //idに該当する投稿データを
-        ];
-        return view('posts.edit_post_form', $data); //posts.editビューを表示
+    public function edit($id) //編集ボタンを押した投稿データの、idを取得
+    { 
+        $post = Post::findOrFail($id); //選択した投稿に該当する、投稿データを取得。
+        if (\Auth::id() === $post->user_id) { //自分の投稿以外は編集できないようにする。そのために、ログインユーザのidと、投稿データのidが一致しない場合はエラーを出す。
+            $data = [
+                'post' => $post,
+            ];
+            return view('posts.edit_post_form', $data); //posts.editビューを表示
+        } 
+        abort(404); //404エラーを返す。
     }
 
     public function update(PostRequest $request, $id)

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -13,10 +13,11 @@ class PostsController extends Controller
     public function index()
     {
         $posts = Post::orderBy('id','desc')->paginate(10);
-
-        return view('posts.index',[
-            'posts' => $posts,
-        ]);
+        $users = User::all(); //全ユーザを取得
+        $data = [ //現状、viewに渡す変数は１個。だが、今後の拡張性を考えて、配列で書いておく。
+            'posts' => $posts, //index.bladeで、$postsと書いて使う。この中身は、ここで定義してある$posts。
+        ];
+        return view('posts.index', $data); //posts.indexビューを表示
     }
 
     /**

--- a/app/Post.php
+++ b/app/Post.php
@@ -15,7 +15,7 @@ class Post extends Model
         return $this->belongsTo(User::class);
     }
 
-    public function favoriteUsers()
+    public function followUsers()
     {
         return $this->belongsToMany(User::class, 'follows', 'post_id', 'user_id')->withTimestamps();
     }

--- a/app/Post.php
+++ b/app/Post.php
@@ -14,4 +14,9 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function favoriteUsers()
+    {
+        return $this->belongsToMany(User::class, 'follows', 'post_id', 'user_id')->withTimestamps();
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -62,23 +62,25 @@ class User extends Authenticatable
         // すでにフォローしている場合は何もしない
         $exists = $this->isFollow($id);
         if ($exists) {
-            return;
+            return false;
         } else {
         // フォローしていない場合は、フォローを追加
         $this->follows()->attach($id);
+            return true;
         }
     }
 
     // フォローを解除するメソッド
     public function unfollow($id)
     {
-        // フォローしていない場合は何もしない
+        // フォローしている場合は、フォローを解除
         $exists = $this->isFollow($id);
         if ($exists) {
             $this->follows()->detach($id);
+            return true;
         } else {
-        // フォローしている場合は、フォローを解除
-            return;
+        // フォローしていない場合は何もしない
+            return false;
         }
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -51,34 +51,34 @@ class User extends Authenticatable
     }
 
     // ユーザがフォローしているか判定するメソッド
-    public function isFollow($postId)
+    public function isFollow($id)
     {
-        return $this->follows()->where('post_id', $postId)->exists();
+        return $this->follows()->where('post_id', $id)->exists();
     }
 
     // フォロー状態を作るメソッド
-    public function follow($postId)
+    public function follow($id)
     {
         // すでにフォローしている場合は何もしない
-        $exists = $this->isFollow($postId);
+        $exists = $this->isFollow($id);
         if ($exists) {
             return;
         } else {
         // フォローしていない場合は、フォローを追加
-        $this->follows()->attach($postId);
+        $this->follows()->attach($id);
         }
     }
 
     // フォローを解除するメソッド
-    public function unfollow($postId)
+    public function unfollow($id)
     {
         // フォローしていない場合は何もしない
-        $exists = $this->isFollow($postId);
+        $exists = $this->isFollow($id);
         if ($exists) {
             return;
         } else {
         // フォローしている場合は、フォローを解除
-        $this->follows()->detach($postId);
+        $this->follows()->detach($id);
         }
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -43,4 +43,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public function follows()
+    {
+        return $this->belongsToMany(Post::class, 'favorites', 'user_id', 'post_id')->withTimestamps();
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -47,7 +47,7 @@ class User extends Authenticatable
     // ユーザがフォローしている投稿を取得するメソッド 
     public function follows()
     {
-        return $this->belongsToMany(Post::class, 'favorites', 'user_id', 'post_id')->withTimestamps();
+        return $this->belongsToMany(Post::class, 'follows', 'user_id', 'post_id')->withTimestamps();
     }
 
     // ユーザがフォローしているか判定するメソッド
@@ -75,10 +75,10 @@ class User extends Authenticatable
         // フォローしていない場合は何もしない
         $exists = $this->isFollow($id);
         if ($exists) {
-            return;
+            $this->follows()->detach($id);
         } else {
         // フォローしている場合は、フォローを解除
-        $this->follows()->detach($id);
+            return;
         }
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -44,8 +44,41 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    // ユーザがフォローしている投稿を取得するメソッド 
     public function follows()
     {
         return $this->belongsToMany(Post::class, 'favorites', 'user_id', 'post_id')->withTimestamps();
+    }
+
+    // ユーザがフォローしているか判定するメソッド
+    public function isFollow($postId)
+    {
+        return $this->follows()->where('post_id', $postId)->exists();
+    }
+
+    // フォロー状態を作るメソッド
+    public function follow($postId)
+    {
+        // すでにフォローしている場合は何もしない
+        $exists = $this->isFollow($postId);
+        if ($exists) {
+            return;
+        } else {
+        // フォローしていない場合は、フォローを追加
+        $this->follows()->attach($postId);
+        }
+    }
+
+    // フォローを解除するメソッド
+    public function unfollow($postId)
+    {
+        // フォローしていない場合は何もしない
+        $exists = $this->isFollow($postId);
+        if ($exists) {
+            return;
+        } else {
+        // フォローしている場合は、フォローを解除
+        $this->follows()->detach($postId);
+        }
     }
 }

--- a/database/migrations/2025_04_09_072335_create_follows_table.php
+++ b/database/migrations/2025_04_09_072335_create_follows_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}

--- a/database/migrations/2025_04_09_072335_create_follows_table.php
+++ b/database/migrations/2025_04_09_072335_create_follows_table.php
@@ -15,7 +15,13 @@ class CreateFollowsTable extends Migration
     {
         Schema::create('follows', function (Blueprint $table) {
             $table->bigIncrements('id');
+            $table->bigIncrements('user_id');
+            $table->bigIncrements('post_id');
             $table->timestamps();
+            // 外部キー制約を追加
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->unique(['user_id','post_id']);
         });
     }
 

--- a/database/migrations/2025_04_09_072335_create_follows_table.php
+++ b/database/migrations/2025_04_09_072335_create_follows_table.php
@@ -15,8 +15,8 @@ class CreateFollowsTable extends Migration
     {
         Schema::create('follows', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigIncrements('user_id');
-            $table->bigIncrements('post_id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('post_id')->unsigned()->index();
             $table->timestamps();
             // 外部キー制約を追加
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -1,23 +1,41 @@
-<head>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-</head>
-@php
-    $exists = Auth::user()->isFollow($post->id);
-@endphp
+@if (Auth::id()!== $post->user_id)
+    @php
+        $exists = Auth::check() ? Auth::user()->isFollow($post->id) : false;
+        $countFollowUsers = $post->followUsers()->count();
+    @endphp
 
-@if ($exists)
-    <form method="POST" action="{{ route('follow.delete', $post->id) }}">
-        @csrf
-        @method('DELETE')
-        <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
-            <i class="fa-regular fa-thumbs-up mb-3"></i>
-        </button>
-    </form>
-@else
-    <form method="POST" action="{{ route('follow.store', $post->id) }}">
-        @csrf
-        <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
-            <i class="fa-solid fa-thumbs-up mb-3"></i>
-        </button>
-    </form>
+    @if ($exists)
+        <form method="POST" action="{{ route('follow.delete', $post->id) }}">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
+                <i class="fa-regular fa-thumbs-up mb-3 mr-1"></i>{{$countFollowUsers}}
+            </button>
+        </form>
+    @else
+        <form method="POST" action="{{ route('follow.store', $post->id) }}">
+            @csrf
+            <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
+                <i class="fa-solid fa-thumbs-up mb-3 mr-1"></i>{{$countFollowUsers}}
+            </button>
+        </form>
+    @endif
+
+    <script>
+        // スクロール位置を記録
+        document.querySelectorAll('form').forEach(form => {
+            form.addEventListener('submit', function () {
+                sessionStorage.setItem('scrollPosition', window.scrollY);
+            });
+        });
+    
+        // ページロード後に元の位置へスクロール
+        window.addEventListener('load', function () {
+            const scrollY = sessionStorage.getItem('scrollPosition');
+            if (scrollY !== null) {
+                window.scrollTo(0, parseInt(scrollY));
+                sessionStorage.removeItem('scrollPosition'); // 1回だけ使う
+            }
+        });
+    </script>
 @endif

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -2,7 +2,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
 </head>
 @php
-    $exists = $post->user->isFollow($post->id);
+    $exists = Auth::user()->isFollow($post->id);
 @endphp
 
 @if ($exists)

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -9,14 +9,14 @@
             @csrf
             @method('DELETE')
             <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
-                <i class="fa-regular fa-thumbs-up mb-3 mr-1"></i>{{$countFollowUsers}}
+                <i class="fa-solid fa-thumbs-up mb-3 mr-1"></i>{{$countFollowUsers}}
             </button>
         </form>
     @else
         <form method="POST" action="{{ route('follow.store', $post->id) }}">
             @csrf
             <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
-                <i class="fa-solid fa-thumbs-up mb-3 mr-1"></i>{{$countFollowUsers}}
+                <i class="fa-regular fa-thumbs-up mb-3 mr-1"></i>{{$countFollowUsers}}
             </button>
         </form>
     @endif

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -1,14 +1,23 @@
+<head>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
+</head>
 @php
-    //$exists = $user()->isFollow($id);
+    $exists = $post->user->isFollow($post->id);
 @endphp
 
-<form method="POST" action="{{ route('follow.store', $post->id) }}">
-    @csrf
-    <button type="submit" class="btn btn-primary">
-        @if ($exists)
-            フォロー中
-        @else
-            フォローする
-        @endif
-    </button>
-</form>
+@if ($exists)
+    <form method="POST" action="{{ route('follow.delete', $post->id) }}">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
+            <i class="fa-regular fa-thumbs-up mb-3"></i>
+        </button>
+    </form>
+@else
+    <form method="POST" action="{{ route('follow.store', $post->id) }}">
+        @csrf
+        <button type="submit" class="btn btn-link p-0 border-0 bg-transparent">
+            <i class="fa-solid fa-thumbs-up mb-3"></i>
+        </button>
+    </form>
+@endif

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -1,11 +1,11 @@
 @php
-    $postId = post()->post_id;
+    $exists = $user()->isFollow($id);
 @endphp
 
-<form method="POST" action="{{ route('follow.store', $postId) }}">
+<form method="POST" action="{{ route('follow.store', $post->id) }}">
     @csrf
     <button type="submit" class="btn btn-primary">
-        @if ($isFollow($postId))
+        @if ($exists)
             フォロー中
         @else
             フォローする

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -1,0 +1,14 @@
+@php
+    $postId = post()->post_id;
+@endphp
+
+<form method="POST" action="{{ route('follow.store', $postId) }}">
+    @csrf
+    <button type="submit" class="btn btn-primary">
+        @if ($isFollow($postId))
+            フォロー中
+        @else
+            フォローする
+        @endif
+    </button>
+</form>

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -1,9 +1,9 @@
-@if (Auth::id()!== $post->user_id)
-    @php
-        $exists = Auth::check() ? Auth::user()->isFollow($post->id) : false;
-        $countFollowUsers = $post->followUsers()->count();
-    @endphp
+@php
+    $exists = Auth::check() ? Auth::user()->isFollow($post->id) : false;
+    $countFollowUsers = $post->followUsers()->count();
+@endphp
 
+@if (Auth::id()!== $post->user_id)
     @if ($exists)
         <form method="POST" action="{{ route('follow.delete', $post->id) }}">
             @csrf
@@ -28,7 +28,7 @@
                 sessionStorage.setItem('scrollPosition', window.scrollY);
             });
         });
-    
+
         // ページロード後に元の位置へスクロール
         window.addEventListener('load', function () {
             const scrollY = sessionStorage.getItem('scrollPosition');
@@ -38,4 +38,9 @@
             }
         });
     </script>
+
+@else
+    <span class="badge badge-info mb-4">
+        フォロー数：{{ $countFollowUsers}}
+    </span>
 @endif

--- a/resources/views/follow_button.blade.php
+++ b/resources/views/follow_button.blade.php
@@ -1,5 +1,5 @@
 @php
-    $exists = $user()->isFollow($id);
+    //$exists = $user()->isFollow($id);
 @endphp
 
 <form method="POST" action="{{ route('follow.store', $post->id) }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
         <link rel="stylesheet" href="{{ asset('css/styles.css') }}"> {{-- 様々なファイルの表示を、追加訂正するためのCSS --}}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
     </head>
     <body>
         @include('commons.header')

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -13,10 +13,8 @@
     {{-- ログインしていると、投稿フォームが表示される。してないと表示されない。 --}}
     @if (Auth::check())
         @include('posts.new_post_form')
-        @include('follow_button')
     @endif
 
     {{-- 投稿一覧 --}}
     @include ('posts.post', ['posts' => $posts])
-
 @endsection

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -13,5 +13,6 @@
     {{-- ログインしていると、投稿フォームが表示される。してないと表示されない。 --}}
     @if (Auth::check())
         @include('posts.new_post_form')
+        @include('follow_button')
     @endif
 @endsection

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -9,6 +9,7 @@
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{$post->content}}</p>
                     <p class="text-muted">{{$post->created_at}}</p>
+                    @include('follow_button', ['post' => $post]) {{-- フォローボタン --}}
                 </div>
                 @if (Auth::id() === $post->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,7 +33,7 @@ Route::group(['middleware' => 'auth'], function () {
 
     //フォロー
     Route::post('follow/{id}', 'FollowsController@store')->name('follow.store');
-    Route::delete('unfollow/{id}', 'FollowsController@destroy')->name('follow.destroy');
+    Route::delete('unfollow/{id}', 'FollowsController@delete')->name('follow.delete');
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,15 +31,17 @@ Route::group(['middleware' => 'auth'], function () {
     //新規投稿
     Route::post('post', 'PostsController@store')->name('post.store');
 
-    //フォロー
-    Route::post('follow/{id}', 'FollowsController@store')->name('follow.store');
-    Route::delete('unfollow/{id}', 'FollowsController@delete')->name('follow.delete');
+    //ユーザの編集
     Route::prefix('users')->group(function () {
         //ユーザ情報の編集
         Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
         //ユーザ削除
         Route::delete('{id}', 'UsersController@delete')->name('users.delete');
     });
+
+    //フォロー
+    Route::post('follow/{id}', 'FollowsController@store')->name('follow.store');
+    Route::delete('unfollow/{id}', 'FollowsController@delete')->name('follow.delete');
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,8 +46,8 @@ Route::group(['middleware' => 'auth'], function () {
     });
 
     //フォロー
-    Route::post('follow/{id}', 'FollowsController@store')->name('follow.store');
-    Route::delete('unfollow/{id}', 'FollowsController@delete')->name('follow.delete');
+    Route::post('follow/{id}', 'FollowController@store')->name('follow.store');
+    Route::delete('unfollow/{id}', 'FollowController@delete')->name('follow.delete');
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,10 @@ Route::get('users/{id}', 'UsersController@show')->name('users.show');
 Route::group(['middleware' => 'auth'], function () {
     //新規投稿
     Route::post('post', 'PostsController@store')->name('post.store');
+
+    //フォロー
+    Route::post('follow/{id}', 'FollowsController@store')->name('follow.store');
+    Route::delete('unfollow/{id}', 'FollowsController@destroy')->name('follow.destroy');
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,12 +30,6 @@ Route::get('users/{id}', 'UsersController@show')->name('users.show');
 Route::group(['middleware' => 'auth'], function () {
     //新規投稿
     Route::post('post', 'PostsController@store')->name('post.store');
-    //投稿編集
-    Route::prefix('posts')->group(function () {
-        Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit');
-        Route::put('{id}', 'PostsController@update')->name('posts.update'); //{id}/updateと書いてしまうと、このurlにgetリクエストを行ってしまう。updateは更新メソッドなのでgetではない。よって/updateは書いてはいけない。
-    }); 
-    
 });
 
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,6 @@ Route::group(['middleware' => 'auth'], function () {
     //新規投稿
     Route::post('post', 'PostsController@store')->name('post.store');
 
-    //ユーザの編集
     //投稿編集
     Route::prefix('posts')->group(function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit');


### PR DESCRIPTION
## issue #127 

## 概要
　投稿とフォローしたユーザを結びつける中間テーブルの作成、中間テーブルのレコードをもとにフォロー数の表示、フォローする/解除

## 行ったとこと
・各投稿にフォローボタンの表示（自分の投稿以外　@if (Auth::id()!== $post->user_id)）
・フォローボタンを押すと、その投稿をフォローしているレコードが、中間テーブルに作られる（store, followメソッドでフォローがつく）
・既に押したフォローボタンをもう一回押すと、その投稿のフォローが中間テーブルから削除される（delete, unfollowメソッドで、フォローが削除される）
・押してないボタンは、色塗り表示。ログインユーザが押したボタンは白抜き表示（isFollowメソッドで判定）。
・ボタンの横に、フォロー数を表示（$post->followUsers()->count()でカウント）
・画面下方の投稿のフォローボタンを押した後、そこ付近に画面のスクロールが保たれるJSを記述（follow_button.blade.php）

##動作確認
下記のようにご確認お願い致します。

（１）ログインしてない時も、フォローボタン・フォロー数を表示されてることを確認。
![image](https://github.com/user-attachments/assets/9e074fce-c678-41e7-9bb0-077b727bfeda)
（２）ログインしてない状態で、フォローボタンを押すと、ログイン画面に遷移する。
（３）適当なユーザでログイン後、フォローボタンを押す。ボタンが色塗り→白抜きにかわる。かつ、ボタン横のフォロー数が１増えることを確認。ログアウト後も、この投稿のフォロー数が表示されてることを確認。ログイン状態で、もう一回フォローボタンを押すと、色塗りにかわり、フォロー数が１減ることを確認。
<img width="530" alt="image" src="https://github.com/user-attachments/assets/f975c8d4-5b3b-469f-a328-18a179ac5cb2" />
![image](https://github.com/user-attachments/assets/8ec43277-f410-4c26-83f6-e93ece63b27d)
（４）ログアウトして、違うユーザで再度ログインする。（３）と同じ投稿のフォローボタンを押すと、さらにフォロー数が１増えることを確認。
![image](https://github.com/user-attachments/assets/4d1cabf5-4833-4223-9675-9308119b6c34)
（５）ログインユーザの投稿にも、フォロー数が表示されてることを確認
![image](https://github.com/user-attachments/assets/c9fd7541-7f36-4d23-9439-ddeddba8b92a)





