### PR TITLE
#1491 タグ機能（街）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -28,22 +28,59 @@ class PostsController extends Controller
      */
     public function store(PostRequest $request)
     {
+        // 投稿の保存処理*******************************************************************************************************************
         $post = new Post(); //Postモデルのインスタンスを作成＝postsテーブルに、新規レコードを作成
         $post->content = $request->content; //投稿内容をpostテーブルのcontentカラムに代入
         $post->user_id = $request->user()->id; //ログインユーザのidを、postテーブルのuser_idカラムに代入。user・postテーブルのリレーションを作る必要。ログインしてないと、user()はnullを返すから注意！
         $post->save(); //postテーブルに保存
+        //*******************************************************************************************************************
 
-        // タグを保存
-        $tagNames = explode(',', $request->input('tags'));
-        $tagIds = [];
-        foreach ($tagNames as $name) {
-            $cleaned = trim(preg_replace('/^[#＃]/u', '', $name));
-            if ($cleaned === '') continue;
-            $tag = Tag::firstOrCreate(['name' => $cleaned]);
-            $tagIds[] = $tag->id;
+        // タグの保存処理*******************************************************************************************************************
+        // タグ処理開始
+        $tagNamesRaw = explode(',', $request->input('tags', ''));
+        
+        // ① 前処理（trimのみ）→ 重複・空白除去
+        $cleanedNames = collect($tagNamesRaw)
+            ->map('trim')        // 前後の空白除去
+            ->filter()           // 空文字除去
+            ->unique()
+            ->values();          // インデックス再構成
+
+        if ($cleanedNames->isEmpty()) {
+            return back();
         }
-        $post->tags()->sync($tagIds); // 投稿とタグを関連付け
-        return back(); //投稿ボタンを押した後、投稿フォームに戻る
+
+        // ②既存のタグを一括取得（1回のSELECT）
+        $existingTags = Tag::whereIn('name', $cleanedNames)->get();
+
+        // ③既存名の一覧
+        $existingNames = $existingTags->pluck('name');
+
+        // ④DBに存在しない新規タグ名のみ抽出
+        $newTagNames = $cleanedNames->diff($existingNames);
+
+        // ⑤新規タグを一括でINSERT（1回のINSERT）
+        $insertData = $newTagNames->map(function ($name) {
+            return [
+                'name' => $name,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+        });
+
+        if ($insertData->isNotEmpty()) {
+            Tag::insert($insertData->all());
+        }
+
+        // ⑥再度全タグを取得して、関連付け用のIDリストを作る（最終的に1回のSELECT）
+        $allTags = Tag::whereIn('name', $cleanedNames)->get();
+        $tagIds = $allTags->pluck('id');
+
+        // ⑦中間テーブルへの関連付け（1回のsync）
+        $post->tags()->sync($tagIds);
+
+        return back();
+        //*******************************************************************************************************************
     }
 
     public function edit($id) //編集ボタンを押した投稿データの、idを取得

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Http\Requests\PostRequest;
 use App\User;
 use App\Post;
+use App\Tag;
 
 class PostsController extends Controller
 {
@@ -31,6 +32,18 @@ class PostsController extends Controller
         $post->content = $request->content; //投稿内容をpostテーブルのcontentカラムに代入
         $post->user_id = $request->user()->id; //ログインユーザのidを、postテーブルのuser_idカラムに代入。user・postテーブルのリレーションを作る必要。ログインしてないと、user()はnullを返すから注意！
         $post->save(); //postテーブルに保存
+
+        // タグを保存
+        $tagNames = explode(',', $request->input('tags'));
+        $tagIds = [];
+        foreach ($tagNames as $name) {
+            $cleaned = trim(preg_replace('/^[#＃]/u', '', $name));
+            if ($cleaned === '') continue;
+            $tag = Tag::firstOrCreate(['name' => $cleaned]);
+            $tagIds[] = $tag->id;
+        }
+        $post->tags()->sync($tagIds); // 投稿とタグを関連付け
+
         return back(); //投稿ボタンを押した後、投稿フォームに戻る
     }
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -43,7 +43,6 @@ class PostsController extends Controller
             $tagIds[] = $tag->id;
         }
         $post->tags()->sync($tagIds); // 投稿とタグを関連付け
-
         return back(); //投稿ボタンを押した後、投稿フォームに戻る
     }
 

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -6,7 +6,7 @@ use App\Tag;
 
 class TagController extends Controller
 {   
-    //タグボタンを押したら、そのタグが含まれる投稿を表示する
+    //タグボタンを押したら、そのタグが含まれる投稿を一覧表示する
     public function show($id)
     {
         $tag = Tag::findOrFail($id);

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Tag;
+
+class TagController extends Controller
+{
+    public function show($id)
+    {
+        $tag = Tag::findOrFail($id);
+        $posts = $tag->posts()->latest()->paginate(10);
+
+        return view('tags.show', [
+            'tag' => $tag,
+            'posts' => $posts,
+        ]);
+    }
+}

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -5,7 +5,8 @@ namespace App\Http\Controllers;
 use App\Tag;
 
 class TagController extends Controller
-{
+{   
+    //タグボタンを押したら、そのタグが含まれる投稿を表示する
     public function show($id)
     {
         $tag = Tag::findOrFail($id);

--- a/app/Post.php
+++ b/app/Post.php
@@ -19,4 +19,9 @@ class Post extends Model
     {
         return $this->belongsToMany(User::class, 'follows', 'post_id', 'user_id')->withTimestamps();
     }
+
+    public function tags()
+{
+    return $this->belongsToMany(Tag::class);
+}
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -21,7 +21,7 @@ class Post extends Model
     }
 
     public function tags()
-{
-    return $this->belongsToMany(Tag::class);
-}
+    {
+        return $this->belongsToMany(Tag::class);
+    }
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = ['name'];
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class);
+    }
+}
+

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Post;
+use Faker\Generator as Faker;
+
+$factory->define(Post::class, function (Faker $faker) {
+    return [
+        'user_id' => function () {
+            return \App\User::inRandomOrder()->first()->id;
+        },
+        'content' => $faker->realText(100),
+    ];
+});

--- a/database/migrations/2025_04_22_205322_create_tags_table.php
+++ b/database/migrations/2025_04_22_205322_create_tags_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id'); 
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}
+

--- a/database/migrations/2025_04_22_205427_create_post_tag_table.php
+++ b/database/migrations/2025_04_22_205427_create_post_tag_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostTagTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->unsignedBigInteger('post_id');
+            $table->unsignedBigInteger('tag_id');
+
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
+
+            $table->primary(['post_id', 'tag_id']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('post_tag');
+    }
+}
+

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+        $this->call(TagsTableSeeder::class);
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
     }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,61 +1,17 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
-
+use App\Post;
+use App\Tag;
 
 class PostsTableSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
     public function run()
     {
-        DB::table('posts')->insert([
-            'user_id' => 1,
-            'content' => 'test1'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 2,
-            'content' => 'test2'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 3,
-            'content' => 'test3'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 4,
-            'content' => 'test4'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 5,
-            'content' => 'test5'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 6,
-            'content' => 'test6'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 7,
-            'content' => 'test7'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 8,
-            'content' => 'test8'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 9,
-            'content' => 'test9'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 10,
-            'content' => 'test10'
-        ]);
-        DB::table('posts')->insert([
-            'user_id' => 10,
-            'content' => 'test11'
-        ]);
+        factory(Post::class, 100)->create()->each(function ($post) {
+            // ランダムに1〜3個のタグを付ける
+            $tagIds = Tag::inRandomOrder()->take(rand(1, 3))->pluck('id');
+            $post->tags()->sync($tagIds);
+        });
     }
 }

--- a/database/seeds/TagsTableSeeder.php
+++ b/database/seeds/TagsTableSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Tag;
+
+class TagsTableSeeder extends Seeder
+{
+    public function run()
+    {
+        $tags = [
+            "C", "C+", "C++", "C#", "Django", "Eclips", "Flutter", "Go", "java",
+            "laravel", "php", "rust", "ruby", "rails", "react", "swift", "typescrypt", "vue"
+        ];
+
+        foreach ($tags as $tagName) {
+            Tag::firstOrCreate(['name' => $tagName]);
+        }
+    }
+}
+

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -12,6 +12,6 @@ class UsersTableSeeder extends Seeder
      */
     public function run()
     {
-        factory(User::class, 10)->create(); // 10人分のデータを作成
+        factory(User::class, 20)->create(); // 20人分のデータを作成
     }
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -11,6 +11,15 @@
     margin: 0 auto;
 }
 
+.card-body img.avatar {
+    width: 55px !important;
+    height: 55px !important;
+    object-fit: cover;
+    border-radius: 50%;
+    display: inline-block;
+    vertical-align: middle;
+}
+
 .formcontrol.custom-textarea {
     display: block;
     width: 10%;

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -56,3 +56,10 @@ textarea{
     padding: 2px;
     white-space: pre-wrap;
 }
+
+.hr1 {
+    border: 1px;
+    height: 1px;
+    background-color: hsl(188, 63%, 42%);
+    margin: 20px 0;
+}

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -20,7 +20,7 @@
     vertical-align: middle;
 }
 
-.formcontrol.custom-textarea {
+.formgroup .formcontrol.custom-textarea {
     display: block;
     width: 10%;
     height: auto;

--- a/resources/views/buttons/follow_button.blade.php
+++ b/resources/views/buttons/follow_button.blade.php
@@ -40,7 +40,7 @@
     </script>
 
 @else
-    <span class="badge badge-info mb-4">
+    <span class="badge badge-info mb-2">
         フォロー数：{{ $countFollowUsers}}
     </span>
 @endif

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,6 +1,6 @@
 <header class="mb-5">
     <nav class="navbar navbar-expand-sm navbar-dark bg-info">
-        <a class="navbar-brand" href="/">Topic Posts</a>
+        <a class="navbar-brand" href="/">学習共有プラットフォーム</a>
         <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="ja">
     <head>
         <meta charset="utf-8">
-        <title>Topic Posts</title>
+        <title>学習共有プラットフォーム</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
         <link rel="stylesheet" href="{{ asset('css/styles.css') }}"> {{-- 様々なファイルの表示を、追加訂正するためのCSS --}}

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -3,12 +3,12 @@
     <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
             <h1>
-                <i class="fab fa-telegram fa-lg pr-3"></i>
-                Topic Posts
+                <i class="fa-solid fa-book pr-3"></i>
+                学習共有プラットフォーム
             </h1>
         </div>
     </div>
-    <h5 class="description text-center">"○○"について140文字以内で会話しよう！</h5>
+    <h5 class="description text-center">今日の学習内容は？</h5>
 
     {{-- ログインしていると、投稿フォームが表示される。してないと表示されない。 --}}
     @if (Auth::check())

--- a/resources/views/posts/new_post_form.blade.php
+++ b/resources/views/posts/new_post_form.blade.php
@@ -3,13 +3,55 @@
 
 {{-- 投稿フォーム --}}
 <div class="text-center mt-3 mb-3">
-        <form method="POST" action="{{route('post.store')}}">
-            @csrf
-            <div class="form-group">
-                <textarea type="content" class="form-control custom-textarea" name="content" rows="4"></textarea>
-                <div class="text-left mt-3">
-                    <button type="submit" class="btn btn-primary mt-2">投稿する</button>
-                </div>
-            </div>
-        </form>
+    <form method="POST" action="{{route('post.store')}}">
+        @csrf
+        <div class="form-group">
+            <textarea type="content" class="form-control custom-textarea" name="content" rows="4"></textarea>
+        </div>
+        
+        <!-- タグ入力フィールド -->
+        <label for="tag-input"><i class="fa-solid fa-circle-down" style="color: hsl(187, 72%, 65%);"></i>タグをつけてね！（Enterまたはカンマで追加）</label>
+        <input type="text" id="tag-input" class="form-control mb-2" placeholder="Laravel, PHP など">
+        <div id="tag-container" class="mb-3"></div>
+        <input type="hidden" name="tags" id="hidden-tags">
+        
+        <script>
+            const tagInput = document.getElementById('tag-input');
+            const tagContainer = document.getElementById('tag-container');
+            const hiddenTagsInput = document.getElementById('hidden-tags');
+            let tags = [];
+
+            tagInput.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter' || e.key === ',') {
+                    e.preventDefault();
+                    const value = tagInput.value.trim().replace(/^#|＃/, '');
+                    if (value && !tags.includes(value)) {
+                        tags.push(value);
+                        renderTags();
+                        tagInput.value = '';
+                    }
+                }
+            });
+
+            function renderTags() {
+                tagContainer.innerHTML = '';
+                tags.forEach((tag, index) => {
+                    const badge = document.createElement('span');
+                    badge.className = 'badge badge-primary mr-1';
+                    badge.innerHTML = `#${tag} <span style="cursor:pointer" onclick="removeTag(${index})">&times;</span>`;
+                    tagContainer.appendChild(badge);
+                });
+                hiddenTagsInput.value = tags.join(',');
+            }
+
+            function removeTag(index) {
+                tags.splice(index, 1);
+                renderTags();
+            }
+        </script>
+
+        <div class="text-left mt-3">
+            <button type="submit" class="btn btn-primary mt-2">投稿する</button>
+        </div>
+    </form>
 </div>

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -7,20 +7,33 @@
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">
+                    {{-- 投稿内容 --}}
                     <p class="mb-2">{{$post->content}}</p>
                     <p class="text-muted">{{$post->created_at}}</p>
-                    @include('follow_button', ['post' => $post]) {{-- フォローボタン --}}
+
+                    {{-- フォローボタン --}}
+                    @include('buttons.follow_button', ['post' => $post]) 
                 </div>
+
+                <div class="text-left d-inline-block w-75">
+                    {{-- タグの表示 --}}
+                    @foreach ($post->tags as $tag)
+                        <a href="{{ route('tags.show', $tag->id) }}" class="badge badge-success">#{{ $tag->name }}</a>
+                    @endforeach
+                </div>
+
+                {{-- 投稿の削除・編集ボタン --}}
                 @if (Auth::id() === $post->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                         <form method="" action="">
-                            <button type="submit" class="btn btn-danger">削除</button>
+                            <button type="submit" class="btn btn-danger mt-3">削除</button>
                         </form>
-                        <a href="#" class="btn btn-primary">編集する</a>
+                        <a href="#" class="btn btn-primary mt-3">編集する</a>
                     </div>
                 @endif
             </div>
         </li>
+        <hr class="hr1">
     @endforeach
 </ul>
 <div class="m-auto" style="width: fit-content"></div>

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -1,3 +1,4 @@
+{{-- タグをクリックした際、そのタグと同じワードのタグをつけてる投稿を一覧表示するページ --}}
 @extends('layouts.app')
 @section('content')
     <h3>タグ: <span class="badge badge-primary">{{ $tag->name }}</span> に関連する投稿</h3>
@@ -7,6 +8,11 @@
             <li class="mb-4">
                 <div class="card">
                     <div class="card-body">
+                        <div class="text-left d-inline-block w-10 mb-2">
+                            <img class="avatar mr-2" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                            <p class="mt-3 mb-0 d-inline-block"><a href="">{{$post->user->name}}</a></p>
+                        </div>
+                        <hr class="hr1">
                         <p>{{ $post->content }}</p>
                         <p class="text-muted">投稿日時: {{ $post->created_at->format('Y/m/d H:i') }}</p>
 

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app')
+@section('content')
+    <h3>タグ: <span class="badge badge-primary">{{ $tag->name }}</span> に関連する投稿</h3>
+
+    <ul class="list-unstyled">
+        @foreach ($posts as $post)
+            <li class="mb-4">
+                <div class="card">
+                    <div class="card-body">
+                        <p>{{ $post->content }}</p>
+                        <p class="text-muted">投稿日時: {{ $post->created_at->format('Y/m/d H:i') }}</p>
+
+                        {{-- タグの表示 --}}
+                        @foreach ($post->tags as $tag)
+                            <span class="badge badge-info">#{{ $tag->name }}</span>
+                        @endforeach
+                    </div>
+                </div>
+            </li>
+        @endforeach
+    </ul>
+
+    <div class="pagination justify-content-center">
+        {{ $posts->links() }}
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ Route::group(['middleware' => 'auth'], function () {
     Route::delete('unfollow/{id}', 'FollowController@delete')->name('follow.delete');
 });
 
+Route::get('tags/{id}', 'TagController@show')->name('tags.show');
 
 
 


### PR DESCRIPTION
## issue #1491 

## 概要
　文章を投稿する際、タグも投稿するようにした。投稿文には、タグが表示される。タグを押すと、同じタグを含む投稿一覧が表示される。これにより、自分が興味がある内容の投稿を抽出できる。このような機能を作成した。

## 行ったとこと
・投稿欄の下にタグ入力欄を作成
・投稿されたタグを保存するコード（PostsControllerのstoreメソッド内）
・タグと投稿文に多対多の関係を構築
　　タグデータを操作するモデル（Tag.php）、保存用テーブル（create_tags_table.php）を作成
　　中間テーブル作成（create_post_tag_table.php）
　　Tag.phpに$this->belongsToMany(Post::class);
　　Post.phpに$this->belongsToMany(Tag::class);
・タグ表示のbladeコード記述（各投稿の中@foreach ($post->tags as $tag)）
・タグ検索機能の作成
　タグ検索用の一覧ページ表示（TagController.php）
　選択されたタグの投稿一覧表示（tags/show.blade.php）
・users_tableとposts_tableに入れるデータを再度作り直すため、PostsTableSeeder.phpとUsersTableSeeder.phpを書き直した。かつ、tagデータを作るTagsTablerSeeder.phpを作成。
　

##動作確認手順
（１）ログインする。
（２）適当に投稿してみる。この際、タグもつけてみる。
タグを入力、エンターを押すと下に、タグワードのバッジが現れる。バッジの「×」を押すと消せることを確認。投稿ボタンを押して、投稿する。
![image](https://github.com/user-attachments/assets/e45475e3-276a-428b-bd6e-467c2af5885d)
（３）（２）の投稿を見る。投稿文、フォロー表示の下にタグが表示されていることを確認する。
![image](https://github.com/user-attachments/assets/25a61add-ba0a-4d8f-84d9-5a9883d9a5f5)
（４）投稿文のタグをクリックすると、そのワードを含む投稿一覧が表示されることを確認。
![image](https://github.com/user-attachments/assets/11db1912-5880-4e1c-b6de-beec8b257771)
（５）自分以外のユーザによる投稿のタグを押しても、同様にタグワードを含む投稿一覧ページが表示されることを確認。
<img width="215" alt="image" src="https://github.com/user-attachments/assets/21c342bf-6143-4c6a-86cb-a34ac0afe786" />
![image](https://github.com/user-attachments/assets/1c60206e-87d5-4156-9699-b260513410ac)

　　
