### PR TITLE
ユーザ編集機能（街）　退会ボタン訂正　

### DIFF
--- a/resources/views/buttons/user_withdrawal_button.blade.php
+++ b/resources/views/buttons/user_withdrawal_button.blade.php
@@ -1,19 +1,9 @@
-{{-- rikoさんユーザ編集ページにこのファイルをincludeしてもらう --}}
-@extends('layouts.app') {{-- rikoさんユーザ編集ページがマージされたら、削除する --}}
-@section('content') {{-- rikoさんユーザ編集ページがマージされたら、削除する --}}
-    @if (Auth::check()) {{-- rikoさんユーザ編集ページがマージされたら、削除する --}}
-
-        {{-- 共通削除モーダル --}}
-        @include('commons.delete_modal')
-
-        <!-- 削除ボタン：data-url でURLを渡す -->
-        <button class="btn btn-danger"
-            data-toggle="modal"
-            data-target="#deleteModal"
-            data-title="本当に退会しますか？"
-            data-url="{{ route('users.delete', $user->id) }}"
-            data-btn_name="退会">
-            退会
-        </button>
-    @endif {{-- rikoさんユーザ編集ページがマージされたら、削除する --}}
-@endsection {{-- rikoさんユーザ編集ページがマージされたら、削除する --}}
+<!-- 削除ボタン：data-url でURLを渡す -->
+<button type="button" class="btn btn-danger"
+    data-toggle="modal"
+    data-target="#deleteModal"
+    data-title="本当に退会しますか？"
+    data-url="{{ route('users.delete', $user->id) }}"
+    data-btn_name="退会">
+    退会
+</button>

--- a/resources/views/users/edit_user_form.blade.php
+++ b/resources/views/users/edit_user_form.blade.php
@@ -5,10 +5,13 @@
     <h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
     {{-- バリデーションエラーの表示 --}}
     @include('commons.error_messages')
+
+    {{-- 共通削除モーダル。user_withdrawalボタンの中に入れると、formがネストされる。退会ボタンを押した瞬間に処理が発動してしまう。よって外に出した。 --}}
+    @include('commons.delete_modal')
+
     <form method="POST" action="{{route('users.update', $user->id)}}">
         @csrf
         @method('PUT')
-        <input type="hidden" name="id" value="" />
         <div class="form-group">
             <label for="name">ユーザ名</label>
             <input class="form-control" value="{{$user->name}}" name="name" />
@@ -30,27 +33,8 @@
         </div>
 
         <div class="d-flex justify-content-between">
-            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            @include('buttons.user_withdrawal_button')
             <button type="submit" class="btn btn-primary">更新する</button>
         </div>
     </form>
-
-    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h4>確認</h4>
-                </div>
-                <div class="modal-body">
-                    <label>本当に退会しますか？</label>
-                </div>
-                <div class="modal-footer d-flex justify-content-between">
-                    <form action="" method="POST">
-                        <button type="submit" class="btn btn-danger">退会する</button>
-                    </form>
-                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-                </div>
-            </div>
-        </div>
-    </div>
 @endsection


### PR DESCRIPTION
## 概要
Rikoさんに途中までご作成頂いたユーザ編集ページにて、退会処理を修正する

## 行ったこと
・退会ボタンとして、buttons.user_withdrawal_buttonをincludeした。

## 動作確認
（１）ログインする（下図は、ユーザ「a」）。headerに表示されているユーザ名をクリック、ユーザ詳細ページへ遷移する。
![image](https://github.com/user-attachments/assets/d9c3a13b-da7d-40dc-aaaf-099d41c98bc3)

（２）退会ボタンを押す。モーダルが現れることを確認する。
![image](https://github.com/user-attachments/assets/8b7bcb44-c77a-413a-9c8a-1c74b85becd1)

（３）モーダルの中の「退会」ボタンを押す。トップページに遷移することを確認。adminerでログインしていたユーザ「a」のdeleted_atに日付が入ってる（＝論理削除された）ことを確認する。
![image](https://github.com/user-attachments/assets/81756649-992c-433a-bb0c-c5eae0801800)
<img width="612" alt="image" src="https://github.com/user-attachments/assets/0168ed4a-d6ec-4df3-ab56-877704f0e18b" />
