### PR TITLE
#95 posts（投稿）テーブルのマイグレーションとシーダー作成(ちゃこ)

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Post extends Model
+{
+    use SoftDeletes;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -38,4 +38,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/database/migrations/2025_05_07_155851_create_posts_table.php
+++ b/database/migrations/2025_05_07_155851_create_posts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->text('content'); //投稿内容は「今日の気分」と仮定しました
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/migrations/2025_05_07_155851_create_posts_table.php
+++ b/database/migrations/2025_05_07_155851_create_posts_table.php
@@ -16,7 +16,7 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
-            $table->text('content'); //投稿内容は「今日の気分」と仮定しました
+            $table->text('content');
             $table->timestamps();
             $table->softDeletes();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $users = DB::table('users')->get();
+
+        foreach ($users as $user) {
+            DB::table('posts')->insert([
+                [
+                    'user_id' => $user->id,
+                    'content' => 'シーダーのテスト投稿です',
+                ],
+                [
+                    'user_id' => $user->id,
+                    'content' => 'シーダーから複数投稿のテストです',
+                ],
+            ]);
+        }
+    }
+}

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -14,15 +14,20 @@ class PostsTableSeeder extends Seeder
     {
         $users = DB::table('users')->get();
 
+        //投稿内容は「今日の気分」と仮定しました
         foreach ($users as $user) {
             DB::table('posts')->insert([
                 [
                     'user_id' => $user->id,
-                    'content' => 'シーダーのテスト投稿です',
+                    'content' => '今日はコーヒーが飲みたい',
                 ],
                 [
                     'user_id' => $user->id,
-                    'content' => 'シーダーから複数投稿のテストです',
+                    'content' => '今日の天気は晴れで気持ちがいい',
+                ],
+                [
+                    'user_id' => $user->id,
+                    'content' => '今日のご飯はお肉にしよう！',
                 ],
             ]);
         }


### PR DESCRIPTION
## issue
- Closes #95

## 概要
- posts（投稿）テーブルのマイグレーションとシーダー作成

## 動作確認手順
- 下記コマンドを実行
php artisan migrate --seed
Adminerでpostsテーブルとpostsデータ(投稿)が保存されていることを確認。

## 考慮してほしいこと
- 状況に応じて、下記コマンドで動作確認する必要あり。
php artisan migrate:fresh --seed

## 確認してほしいこと
- 仮の投稿内容として「今日の気分」と想定して、マイグレーションを作成しました。
- シーダーではユーザーが複数投稿できるか確認のため、1ユーザーにつき、2つの投稿した、という設定としています。
- Postモデルに下記fillableのコードは、迷いましたが教材になかったため書きませんでした。
```
protected $fillable = [
    'user_id',
    'content',
];
```
