### PR TITLE
#110 ユーザログイン・ログアウト(ちゃこ)

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -26,7 +26,7 @@ class LoginController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.
@@ -37,4 +37,5 @@ class LoginController extends Controller
     {
         $this->middleware('guest')->except('logout');
     }
+
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -21,7 +21,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/';
+    public const HOME = '/home';
 
     /**
      * Define your route model bindings, pattern filters, etc.

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -21,7 +21,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/';
 
     /**
      * Define your route model bindings, pattern filters, etc.

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+@section('content')
+    <div class="text-center">
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+    </div>
+    <div class="text-center mt-3">
+        <p class="text-left d-inline-block">ログインすると投稿で<br>コミュニケーションができるようになります。</p>
+    </div>
+    <div class="text-center">
+        <h3 class="login_title text-left d-inline-block mt-5">ログイン</h3>
+    </div>
+    <div class="row mt-5 mb-5">
+        <div class="col-sm-6 offset-sm-3">
+            @if (count($errors) > 0)
+                <ul class="alert alert-danger" role="alert">
+                    @foreach ($errors->all() as $error)
+                        <li class="ml-4">{{ $error }}</li>
+                    @endforeach
+                </ul>
+            @endif
+            <form method="POST" action="{{ route('login.post') }}">
+                @csrf
+                <div class="form-group">
+                    <label for="email">メールアドレス</label>
+                    <input id="email" type="text" class="form-control" name="email" value="{{ old('email') }}">
+                </div>
+                <div class="form-group">
+                    <label for="password">パスワード</label>
+                    <input id="password" type="password" class="form-control" name="password" value="{{ old('password') }}">
+                </div>
+                <button type="submit" class="btn btn-primary mt-2">ログイン</button>
+            </form>
+            <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,5 +1,5 @@
-@extends('layouts.app')
-@section('content')
+{{-- @extends('layouts.app')
+@section('content')  layouts.appがマージされたら、コメントアウトを外す--}}
     <div class="text-center">
         <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
     </div>
@@ -33,4 +33,4 @@
             <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
         </div>
     </div>
-@endsection
+{{-- @endsection --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,3 +14,11 @@
 Route::get('/', function () {
     return view('welcome');
 });
+
+// ユーザ新規登録(清水さんご担当)
+
+
+// ログイン
+Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
+Route::post('login', 'Auth\LoginController@login')->name('login.post');
+Route::get('logout', 'Auth\LoginController@logout')->name('logout');


### PR DESCRIPTION
## issue
- Closes #110

## 概要
- ユーザのログイン・ログアウト機能を実装しました。
- `LoginController` にトレイトを使用し、ログイン・ログアウト処理はLaravelの標準機能に任せています。
- 必要なルート（login、logout）を定義し、仮のトップページやヘッダー、`app.blade.php` を用いて動作確認を行いました。
- `welcome.blade.php` を変更すると履歴が残ってしまうため、確認用として `welcome_temp.blade.php` を一時的に作成しました。
- ログイン、ログアウト、ログイン後のトップページへの移管、バリデーションエラーの表示を確認済みです。
- 作成した動作確認用の仮ファイルは、すべて削除済みです。

## 動作確認手順
※現在、共通レイアウト（`app.blade.php`）とホーム画面が未マージのため、実際の画面での動作確認は難しい状況です。  
そのため、以下のコード部分を中心にご確認をお願いいたします。

- ルート定義（`web.php`）に不備がないか
- フォームに関連するエラーメッセージの表示位置が、意図したとおり（メールアドレス入力欄の上）になっているか

## 考慮してほしいこと
- 共通レイアウトやホーム画面のマージ後に、再度動作確認を実施予定です。
- ヘッダーにログインユーザー名を表示する機能は、ヘッダーファイルが未マージのため今回のブランチでは対応していません。
- 認証関連の言語ファイル（`resources/lang/ja/auth.php`）による日本語化は、このブランチでは未対応です。

## 確認してほしいこと
- コントローラーおよびルーティングに不備がないか
- Blade内のエラー表示の位置がフォーム構造に対して適切かどうか(※)
-  `RouteServiceProvider.php` の記載は適切か(※ ※ )

※  教材では `app.blade.php` に `error_messages.blade.php` をインクルードする形式でしたが、  
お手本アプリではエラーメッセージが「メールアドレス欄の上」に表示されていたため、  
今回の実装では `login.blade.php` の中に直接記述しております。

※ ※  教材では `RouteServiceProvider.php` のファイルを触ることはなかったと存じます。
しかし今回ログイン後の移管の動作確認を行ったところ、/homeに移管してしまいました。
そのため、 `RouteServiceProvider.php`  のもともとの記述である `public const HOME = '/home';` がログイン後のリダイレクト先として優先されていた可能性があると考えたため、`'/'` に変更しています。