### PR TITLE
#125 ユーザ退会(ちゃこ)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -38,12 +38,12 @@ class UsersController extends Controller
     // 退会処理
     public function destroy($id)
     {
-        $user = Auth::user();
+        $user = User::findOrFail($id);
         if (Auth::id() != $id) {
             abort(403);
         }
+        $user->posts()->delete();
         $user->delete();
-        Auth::logout();
         return redirect('/');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -35,5 +35,15 @@ class UsersController extends Controller
         // return redirect()->route('user.show', $user->id);
     }
 
-    // 退会処理(ちゃこ担当)
+    // 退会処理
+    public function destroy($id)
+    {
+        $user = Auth::user();
+        if (Auth::id() != $id) {
+            abort(403);
+        }
+        $user->delete();
+        Auth::logout();
+        return redirect('/');
+    }
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -43,7 +43,9 @@
                             <label>本当に退会しますか？</label>
                         </div>
                         <div class="modal-footer d-flex justify-content-between">
-                            <form action="" method="POST">
+                            <form action="{{ route('user.delete', $user->id) }}" method="POST">
+                                @csrf
+                                @method('DELETE')
                                 <button type="submit" class="btn btn-danger">退会する</button>
                             </form>
                             <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,5 +28,6 @@ Route::group(['middleware' => 'auth'], function () {
    Route::prefix('users/{id}')->group(function () {
        Route::get('edit', 'UsersController@edit')->name('user.edit');
        Route::put('', 'UsersController@update')->name('user.update');
+       Route::delete('', 'UsersController@destroy')->name('user.delete');
    });
 });


### PR DESCRIPTION
## issue
- #125

## 概要
- ユーザ編集画面から「退会する」ボタンをクリックするとモーダルが表示され、退会の最終確認を行えるようになっています。
- モーダルで「退会する」を押すと、ログインユーザーのみが削除され、自動的にログアウト＆トップページへリダイレクトされます。
- 退会処理にはソフトデリートを使用しており、削除後は deleted_at カラムが設定されていることを確認済みです。
- 不正アクセスを防ぐために、ログインユーザー以外を退会対象とした場合には 403 エラーで処理をブロックする仕様です。
- 念のため、user_id = 2 でログインし、URLを手動で /users/5/edit に変更して退会を試みたところ、正しくログインユーザー（ID2）が削除され、ID5は削除されないことを確認しました。

## 動作確認手順
1 http://localhost:8080/ にアクセス
2 下記ユーザで新規ユーザ登録
メールアドレス：[test6@test.com](mailto:test6@test.com)
パスワード：test6test6test6
3 http://localhost:8080/users/6/edit にアクセス
4 「退会する」ボタンを押すとモーダルが表示されることを確認
5 モーダル内の「退会する」ボタンを押すと退会処理が実行されることを確認
6 削除後はログアウト状態になり、トップページにリダイレクトされることを確認
7 データベース上で、test6のdeleted_at のカラムが設定されていることを確認

## 考慮してほしいこと
- なし

## 確認してほしいこと
- モーダルの表示・退会処理の流れが正しく動作するか
- 不正なID指定で他ユーザーの退会処理を防げているか
- コントローラーおよびルーティングに不備がないか（prefix('users/{id}')構成）
- 削除後、ログアウト処理とトップへのリダイレクトが正しく行われているか
