### PR TITLE
投稿の検索機能(ちゃこ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -6,16 +6,23 @@ use Illuminate\Http\Request;
 use App\Post;
 use App\User;
 use App\Http\Requests\PostRequest;
+use App\Http\Requests\SearchRequest;
 
 class PostsController extends Controller
 {
-    public function index()
-    { 
-        $posts = Post::orderBy('id','desc')->paginate(10);
-        
-        return view ('welcome', [
+    public function index(SearchRequest $request)
+    {
+        $keyword = $request->input('keyword');
+        $posts = Post::when($keyword, function ($query, $keyword) {
+            return $query->where('content', 'like', "%{$keyword}%");
+        })
+        ->orderBy('id', 'desc')
+        ->paginate(10);
+        $data = [
+            'keyword' => $keyword,
             'posts' => $posts,
-        ]);
+        ];
+        return view('welcome', $data);
     }
 
     public function store(PostRequest $request)

--- a/app/Http/Requests/SearchRequest.php
+++ b/app/Http/Requests/SearchRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'keyword' => 'nullable|string|max:100',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'keyword' => '投稿の検索',
+        ];
+    }
+}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,4 +1,7 @@
 <ul class="list-unstyled">
+    @if ($posts->isEmpty())
+        <li class="text-center text-muted py-3">投稿が見つかりませんでした。</li>
+    @endif
     @foreach ($posts as $post)
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
@@ -25,5 +28,5 @@
     @endforeach
 </ul>
 <div class="m-auto" style="width: fit-content">
-    {{ $posts->links('pagination::bootstrap-4') }}
+    {{ $posts->appends(['keyword' => $keyword])->links('pagination::bootstrap-4') }}
 </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,15 +1,28 @@
 @extends('layouts.app')
-
 @section('content')
-<div class="center jumbotron bg-info">
+    <div class="w-100 position-relative" style="margin-top: -15px;">
+        <form method="GET" action="{{ url('/') }}" class="d-block d-md-block position-absolute" style="right: 1px; width: 200px; z-index: 10;">
+            <label for="keyword" class="sr-only">投稿の検索</label>
+            <div class="input-group input-group-sm">
+                <input id="keyword" type="text" name="keyword" class="form-control" placeholder="投稿の検索" value="{{ old('keyword', $keyword ?? '') }}" style="border-radius: 0.25rem 0 0 0.25rem;">
+                <div class="input-group-append">
+                    <button class="btn btn-outline-secondary" type="submit" style="border-color: #ced4da; background-color: #f8f9fa; border-radius: 0 0.25rem 0.25rem 0;">
+                        🔍
+                    </button>
+                </div>
+            </div>
+        </form>
+        <div style="height: 45px;"></div>
+    </div>
+    <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
             <h1><i class="pr-3"></i>Topic Posts</h1>
         </div>
     </div>
-    
-    
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-    <div class="w-75 mx-auto mb-2 text-left">@include('commons.error_messages')</div>
+    <div class="w-75 mx-auto mb-2 text-left">
+        @include('commons.error_messages')
+    </div>
     @if (Auth::check())
         <div class="text-center mb-3">
             <form method="POST" action="{{ route('posts.store') }}" class="d-inline-block w-75">
@@ -23,5 +36,5 @@
             </form>
         </div>
     @endif
-@include('posts.posts',['posts' => $posts])
+@include('posts.posts',['posts' => $posts, 'keyword' => $keyword])
 @endsection 


### PR DESCRIPTION
## issue
- 投稿の検索機能

## 概要
- 投稿の内容（content）に対してキーワード検索ができるようにしました。
- キーワードを入力して検索ボタンを押すと、部分一致で投稿一覧が絞り込まれます。
- キーワード及び空欄での検索の絞り込み、バリデーションの表示、動作確認済みです。

## 動作確認手順
1. トップページ上部の検索フォームに任意のキーワードを入力
2. 検索ボタンを押して該当する投稿が一覧表示されることを確認
3. ページネーションしてもキーワードが保持されていることを確認
4. 存在しないキーワードを入れると「投稿が見つかりませんでした。」が表示されることを確認
5. スマホ・PC それぞれの表示が崩れていないか確認

## 考慮してほしいこと
- バリデーションはSearchRequestを使って実装。100文字以内、nullableで設定

## 確認してほしいこと
- 検索機能が正しく動作しているか
- ページネーション時にキーワードが保持されているか
- レイアウト崩れがないか（PC・スマホ）
- コードの書き方や構成に違和感がないか（あれば教えていただきたいです）
- 「投稿の検索機能」は別フォイルに切り分けて、welcom.blade.phpでincludeした方がいいのか、少し迷いました。
ひとまずそのままwelcom.blade.phpに記載しております。