### PR TITLE
#127 フォロー機能

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -11,3 +11,6 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 }
+
+
+

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -11,6 +11,3 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 }
-
-
-

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    public function store($id)
+    {
+        \Auth::user()->follow($id);
+        return back();
+    }
+
+    public function destroy($id)
+    {
+        \Auth::user()->unfollow($id);
+        return back();
+    }
+}

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -10,8 +10,7 @@ use Illuminate\Support\Facades\Auth;
 class UsersController extends Controller
 {
     //ユーザ詳細(なりさんご担当)
-
-
+    
     // 編集画面
     public function edit($id)
     {
@@ -46,4 +45,33 @@ class UsersController extends Controller
         $user->delete();
         return redirect('/');
     }
+
+    //自分がフォローしているユーザー一覧
+    public function followings($id)
+    {
+        $user = User::findOrFail($id);
+        $followings = $user->followings()->paginate(10);
+        $data = [
+            'user' => $user,
+            'users' => $followings,
+        ]; 
+        $data += $this->userCounts($user);
+        
+        return view('users.followings', $data);
+    }
+
+    //自分をフォローしているユーザー一覧
+    public function followers($id)
+    {
+        $user = User::findOrFail($id);
+        $followers = $user->followers()->paginate(10);
+        $data = [
+            'user' => $user,
+            'users' => $followers,
+        ];
+        $data += $this->userCounts($user);
+        
+        return view('users.followers', $data);
+    }
+
 }

--- a/app/User.php
+++ b/app/User.php
@@ -44,16 +44,51 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'user_id', 'follower_id')->withTimestamps();
+    }
+
+    public function followings()
+    {
+        return $this->belongsToMany(User::class, 'followers', 'follower_id', 'user_id')->withTimestamps();
+    }
+    
     public function follow($userId)
     {
         if($this->id === $userId || $this->isFollowing($userId)) 
         {
             return false;
-        }
-            
+        }    
         $this->followings()->attach($userId);
         return true;
-
     }   
+
+    public function unfollow($userId)
+    {
+        if ($this->isFollowing($userId))  
+        {
+            $this->followings()->detach($userId);
+            return true;
+        }
+        return false;  
+    }
+
+    public function isFollowing($userId)
+    {
+        return $this->followings()->where('user_id', $userId)->exists();
+    }
+
+    public function userCounts()
+    {
+        $countFollowings = $this->followings()->count();
+        $countFollowers = $this->followers()->count();
+
+        return [
+            'countFollowings' => $countFollowings,
+            'countFollowers' => $countFollowers,
+        ];
+    }
 }
+
 

--- a/app/User.php
+++ b/app/User.php
@@ -56,7 +56,7 @@ class User extends Authenticatable
     
     public function follow($userId)
     {
-        if($this->id === $userId || $this->isFollowing($userId)) 
+        if ($this->id === $userId || $this->isFollowing($userId)) 
         {
             return false;
         }    

--- a/app/User.php
+++ b/app/User.php
@@ -43,5 +43,17 @@ class User extends Authenticatable
     {
         return $this->hasMany(Post::class);
     }
+
+    public function follow($userId)
+    {
+        if($this->id === $userId || $this->isFollowing($userId)) 
+        {
+            return false;
+        }
+            
+        $this->followings()->attach($userId);
+        return true;
+
+    }   
 }
 

--- a/database/migrations/2025_05_22_221711_create_followers_table.php
+++ b/database/migrations/2025_05_22_221711_create_followers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('followers', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('follower_id')->unsigned()->index();
+            $table->timestamps();
+            //外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('follower_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['user_id','follower_id']);
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('followers');
+    }
+}

--- a/database/migrations/2025_05_22_221711_create_followers_table.php
+++ b/database/migrations/2025_05_22_221711_create_followers_table.php
@@ -22,7 +22,6 @@ class CreateFollowersTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('follower_id')->references('id')->on('users')->onDelete('cascade');
             $table->unique(['user_id','follower_id']);
-
         });
     }
 

--- a/resources/views/follow/follow_button.blade.php
+++ b/resources/views/follow/follow_button.blade.php
@@ -1,0 +1,14 @@
+@if (Auth::check() && Auth::id() !== $user->id)
+    @if (Auth::user()->isFollowing($user->id))
+        <form method="POST" action="{{ route('unfollow', $user->id) }}">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="btn btn-danger">フォロー解除</button>
+        </form>
+    @else
+        <form method="POST" action="{{ route('follow', $user->id) }}">
+            @csrf
+            <button type="submit" class="btn btn-primary">フォローする</button>
+        </form>
+    @endif
+@endif

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -6,14 +6,32 @@
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $post->user->name }}</a></p>
+                {{--<p class="mt-3 mb-0 d-inline-block"><a href="{{ route('users.show', $post->user->id) }}">{{ $post->user->name }}</a></p>--}} {{-- ユーザー名（詳細ページ完成後にリンクを復活） --}}
+                <p class="mt-3 mb-0 d-inline-block">{{ $post->user->name }}</p>
+
+               @if (Auth::check() && Auth::id() !== $post->user->id)   {{-- フォローボタン（ログインユーザーが他ユーザーの投稿の場合） --}}
+                    <div class="d-inline-block ml-3">
+                        @if (Auth::user()->isFollowing($post->user->id))
+                            <form method="POST" action="{{ route('unfollow', $post->user->id) }}">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-sm btn-danger">フォロー解除</button>
+                            </form>
+                        @else
+                            <form method="POST" action="{{ route('follow', $post->user->id) }}">
+                                @csrf
+                                <button type="submit" class="btn btn-sm btn-primary">フォローする</button>
+                            </form>
+                        @endif
+                    </div>
+                @endif
             </div>
-            <div class="">
+            <div class="">  {{-- 投稿本文 --}}
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{ $post->content }}</p>
                     <p class="text-muted">{{ $post->created_at }}</p>
                 </div>
-                @if (Auth::id() === $post->user_id)
+                @if (Auth::id() === $post->user_id)  {{-- 投稿者のみ表示：削除・編集 --}}
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                        <form method="POST" action="">   {{-- 削除ルート実装後に記述 --}}
                             @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,8 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
+   // ユーザ詳細表示
+    
    // ユーザ編集、更新、退会
    Route::prefix('users/{id}')->group(function () {
        Route::get('edit', 'UsersController@edit')->name('user.edit');
@@ -33,5 +35,11 @@ Route::group(['middleware' => 'auth'], function () {
    // 新規投稿、編集(なりさん担当)、更新(なりさん担当)、削除(清水さん担当)
    Route::prefix('posts')->group(function () {
        Route::post('', 'PostsController@store')->name('posts.store'); 
+   });
+
+//フォロー・フォロー解除
+Route::group(['prefix' => 'users/{id}'], function() {
+    Route::post('follow', 'FollowController@store')->name('follow');
+    Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
    });
 });


### PR DESCRIPTION
## issue
- Closes #127 

## 概要
- フォロー機能 (トップページへの実装)

## 動作確認
トップページからログイン後、自分以外の投稿者のアバターに【フォローする】ボタンを確認。
押下することで画面遷移とともに【フォロー解除】ボタンに変化。

## 考慮してほしいこと
投稿者ページが現状、未実装のためフォローボタンの動作確認のためトップページに表示してます。
投稿者ページの実装後に改めて、viewファイルを作成し、投稿者ページのアバターにフォローボタンとフォロー数、フォロワー数のカウントの実装を行います。そのため、followers.blade.php、followings.blade.php、users.blade.php、web.phpのルーティングのファイルやコードは削除してます。

## 確認してほしいこと
フォローボタンを押下すると画面遷移の動作が発生しますが、Ⅹ等のSNSは画面遷移の動作無しにフォローする、フォロー解除の切り替えがされます。このような実装が現段階で可能かどうか。