### PR TITLE
posts.blade.phpの投稿一覧中のユーザ名のクリックでユーザ詳細画面へ遷移するよう変更（もりお）

### DIFF
--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -3,7 +3,7 @@
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="">{{ $post->user->name }}</a></p>
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', ['id' => $post->user->id]) }}">{{ $post->user->name }}</a></p>
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">


### PR DESCRIPTION
## issue
- posts.blade.phpの投稿一覧中のユーザ名のクリックでユーザ詳細画面へ遷移するよう変更

## 概要
- posts.blade.php ファイルのユーザ名に、そのユーザ詳細画面へ遷移するリンクを設置

## 動作確認手順
- http://localhost:8080/ 投稿一覧の特定のユーザ名をクリックし、そのユーザの詳細画面へ遷移することを確認

## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- 特になし