### PR TITLE
リプライ機能(ちゃこ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -35,10 +35,8 @@ class PostsController extends Controller
         $replies = $post->replies()->with('user')->orderBy('id', 'desc')->paginate(10);
         $latestReply = Reply::latestReply($post);
         $hasReplied = false;
-        if (Auth::check()) {
-            if (Auth::id() !== $post->user_id) {
-                $hasReplied = Reply::hasReplied(Auth::user(), $post);
-            }
+        if (Auth::check() && Auth::id() !== $post->user_id) {
+            $hasReplied = Reply::hasReplied(Auth::user(), $post);
         }
         $data = [
             'post' => $post,
@@ -59,36 +57,4 @@ class PostsController extends Controller
 
          return back();
     }
-
-    // 清水さんへ
-    // 投稿削除処理（destroyメソッド）をこのコントローラーに実装していただく際に、
-    // 投稿と一緒にリプライも論理削除されるように、
-    // 「$post->deleteWithReplies();」を記載していただけるとありがたいです。
-    // 清水さんのコードと合わせると下記のようになるかと思います。
-    // ※下記コードで動作確認完了
-
-    // public function destroy($id)
-    // {
-    //     $post = Post::findOrFail($id);
-    //     if (\Auth::id() === $post->user_id) {
-    //         $post->delete();
-    //     }
-    //     $post->deleteWithReplies();　←これを追加
-    //     return redirect()->back();
-    // }
-
-    // 理由：
-    // Postモデルに以下のメソッドを記載しており、
-    // 投稿を削除する際に、リプライも一緒に削除される仕組みになっています。
-    // public function deleteWithReplies()
-    // {
-    //     $this->replies()->delete();
-    //     $this->delete();
-    // }
-    // このメソッドを使わない場合、投稿だけ削除されてリプライがデータベースに残ってしまいます。
-    // お手数をおかけして、申し訳ございません。
-    // もし分からなければ、後で私の方で、リプライの修正ブランチを作成し、「$post->deleteWithReplies();」を
-    // 後で記載いたしますので、ご心配には及びません。
-    // ご不明点があれば、聞いてくださいね！
-    // ※※※「$post->deleteWithReplies();」を追記したらこのコメントアウトは削除してください ※※※
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -5,24 +5,50 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Post;
 use App\User;
+use App\Reply;
 use App\Http\Requests\PostRequest;
 use App\Http\Requests\SearchRequest;
+use Illuminate\Support\Facades\Auth;
 
 class PostsController extends Controller
 {
     public function index(SearchRequest $request)
     {
         $keyword = $request->input('keyword');
-        $posts = Post::when($keyword, function ($query, $keyword) {
-            return $query->where('content', 'like', "%{$keyword}%");
-        })
-        ->orderBy('id', 'desc')
-        ->paginate(10);
+        $posts = Post::withCount('replies')
+            ->when($keyword, function ($query, $keyword) {
+                return $query->where('content', 'like', "%{$keyword}%");
+            })
+            ->orderBy('id', 'desc')
+            ->paginate(10);
         $data = [
             'keyword' => $keyword,
             'posts' => $posts,
         ];
         return view('welcome', $data);
+    }
+
+    public function show($postId)
+    {
+        $post = Post::findOrFail($postId);
+        $post->load('user');
+        $replies = $post->replies()->with('user')->orderBy('id', 'desc')->paginate(10);
+        $replyCount = Reply::replyCount($post)['countReplies'];
+        $latestReply = Reply::latestReply($post);
+        $hasReplied = false;
+        if (Auth::check()) {
+            if (Auth::id() !== $post->user_id) {
+                $hasReplied = Reply::hasReplied(Auth::user(), $post);
+            }
+        }
+        $data = [
+            'post' => $post,
+            'replies' => $replies,
+            'replyCount' => $replyCount,
+            'latestReply' => $latestReply,
+            'hasReplied' => $hasReplied,
+        ];
+        return view('posts.show', $data);
     }
 
     public function store(PostRequest $request)
@@ -34,4 +60,34 @@ class PostsController extends Controller
 
          return back();
     }
+
+    // 清水さんへ
+    // 投稿削除処理（destroyメソッド）をこのコントローラーに実装していただく際に、
+    // 投稿と一緒にリプライも論理削除されるように、
+    // 「$post->deleteWithReplies();」を記載していただけるとありがたいです。
+    // 清水さんのコードと合わせると下記のようになるかと思います。
+
+    // public function destroy($id)
+    // {
+    //     $post = Post::findOrFail($id);
+    //     if (\Auth::id() === $post->user_id) {
+    //         $post->delete();
+    //     }
+    //     $post->deleteWithReplies();　←これを追加
+    //     return redirect()->back();
+    // }
+
+    // 理由：
+    // Postモデルに以下のメソッドを記載しており、
+    // 投稿を削除する際に、リプライも一緒に削除される仕組みになっています。
+    // public function deleteWithReplies()
+    // {
+    //     $this->replies()->delete();
+    //     $this->delete();
+    // }
+    // このメソッドを使わない場合、投稿だけ削除されてリプライがデータベースに残ってしまいます。
+    // お手数をおかけして、申し訳ございません。
+    // もし分からなければ、後で私の方で、リプライの修正ブランチを作成し、「$post->deleteWithReplies();」を
+    // 後で記載いたしますので、ご心配には及びません。
+    // ご不明点があれば、聞いてくださいね！
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -28,12 +28,11 @@ class PostsController extends Controller
         return view('welcome', $data);
     }
 
-    public function show($postId)
+    public function show($id)
     {
-        $post = Post::findOrFail($postId);
+        $post = Post::findOrFail($id);
         $post->load('user');
         $replies = $post->replies()->with('user')->orderBy('id', 'desc')->paginate(10);
-        $replyCount = Reply::replyCount($post)['countReplies'];
         $latestReply = Reply::latestReply($post);
         $hasReplied = false;
         if (Auth::check()) {
@@ -44,10 +43,10 @@ class PostsController extends Controller
         $data = [
             'post' => $post,
             'replies' => $replies,
-            'replyCount' => $replyCount,
             'latestReply' => $latestReply,
             'hasReplied' => $hasReplied,
         ];
+        $data += Reply::replyCounts($post);
         return view('posts.show', $data);
     }
 
@@ -66,6 +65,7 @@ class PostsController extends Controller
     // 投稿と一緒にリプライも論理削除されるように、
     // 「$post->deleteWithReplies();」を記載していただけるとありがたいです。
     // 清水さんのコードと合わせると下記のようになるかと思います。
+    // ※下記コードで動作確認完了
 
     // public function destroy($id)
     // {
@@ -90,4 +90,5 @@ class PostsController extends Controller
     // もし分からなければ、後で私の方で、リプライの修正ブランチを作成し、「$post->deleteWithReplies();」を
     // 後で記載いたしますので、ご心配には及びません。
     // ご不明点があれば、聞いてくださいね！
+    // ※※※「$post->deleteWithReplies();」を追記したらこのコメントアウトは削除してください ※※※
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -51,9 +51,8 @@ class RepliesController extends Controller
     }
 
     // 削除処理
-    public function destroy($postId, $replyId)
+    public function destroy($replyId)
     {
-        $post = Post::findOrFail($postId);
         $reply = Reply::findOrFail($replyId);
         if (Auth::id() !== $reply->user_id) {
             abort(403);

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\ReplyRequest;
+use Illuminate\Support\Facades\Auth;
+use App\Reply;
+use App\Post;
+
+class RepliesController extends Controller
+{
+    // リプライ作成
+    public function store(ReplyRequest $request, $postId)
+    {
+        $post = Post::findOrFail($postId);
+        $reply = new Reply();
+        $reply->content = $request->reply_body;
+        $reply->user_id = Auth::id();
+        $reply->post_id = $post->id;
+        $reply->save();
+        return back();
+    }
+
+    // 編集画面
+    public function edit($postId, $replyId)
+    {
+        $post = Post::findOrFail($postId);
+        $reply = Reply::findOrFail($replyId);
+        if (Auth::id() !== $reply->user_id) {
+            abort(403);
+        }
+        $data = [
+            'reply' => $reply,
+            'post' => $post,
+        ];
+        return view('replies.edit', $data);
+    }
+
+    // 更新処理
+    public function update(ReplyRequest $request, $postId, $replyId)
+    {
+        $post = Post::findOrFail($postId);
+        $reply = Reply::findOrFail($replyId);
+        if (Auth::id() !== $reply->user_id) {
+            abort(403);
+        }
+        $reply->content = $request->reply_body;
+        $reply->save();
+        return redirect()->route('posts.show', $post);
+    }
+
+    // 削除処理
+    public function destroy($postId, $replyId)
+    {
+        $post = Post::findOrFail($postId);
+        $reply = Reply::findOrFail($replyId);
+        if (Auth::id() !== $reply->user_id) {
+            abort(403);
+        }
+        $reply->delete();
+        return back();
+    }
+}

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -19,7 +19,7 @@ class RepliesController extends Controller
         $reply->user_id = Auth::id();
         $reply->post_id = $post->id;
         $reply->save();
-        return back();
+        return redirect()->route('posts.show', $post);
     }
 
     // 編集画面

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReplyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'reply_body' => 'required|string|max:100',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'reply_body' => 'リプライ',
+        ];
+    }
+}

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -34,4 +34,13 @@ class ReplyRequest extends FormRequest
             'reply_body' => 'リプライ',
         ];
     }
+
+    public function messages()
+    {
+        return [
+            'reply_body.required' => 'リプライを入力してください。',
+            'reply_body.string'   => 'リプライは文字列で入力してください。',
+            'reply_body.max'      => 'リプライは、100文字以下にしてください。',
+        ];
+    }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -13,4 +13,16 @@ class Post extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
+
+    // 投稿を削除したら関連リプライも論理削除される
+    public function deleteWithReplies()
+    {
+        $this->replies()->delete();
+        $this->delete();
+    }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -29,12 +29,11 @@ class Reply extends Model
     }
 
     // リプライ件数
-    public static function replyCount(Post $post)
+    public static function replyCounts(Post $post)
     {
         $countReplies = self::where('post_id', $post->id)
                             ->whereNull('deleted_at')
                             ->count();
-
         return [
             'countReplies' => $countReplies,
         ];

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Reply extends Model
+{
+    use SoftDeletes;
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    // ユーザが、投稿にリプライをしたことがあるかの確認
+    public static function hasReplied(User $user, Post $post)
+    {
+        return self::where([
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+        ])->exists();
+    }
+
+    // リプライ件数
+    public static function replyCount(Post $post)
+    {
+        $countReplies = self::where('post_id', $post->id)
+                            ->whereNull('deleted_at')
+                            ->count();
+
+        return [
+            'countReplies' => $countReplies,
+        ];
+    }
+
+    // 最新リプライ
+    public static function latestReply(Post $post)
+    {
+        return self::where('post_id', $post->id)
+                    ->latest()
+                    ->first();
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -44,6 +44,11 @@ class User extends Authenticatable
         return $this->hasMany(Post::class);
     }
 
+    public function replies()
+    {
+        return $this->hasMany(Reply::class);
+    }
+
     public function followers()
     {
         return $this->belongsToMany(User::class, 'followers', 'user_id', 'follower_id')->withTimestamps();
@@ -90,5 +95,3 @@ class User extends Authenticatable
         ];
     }
 }
-
-

--- a/database/migrations/2025_05_25_095713_create_replies_table.php
+++ b/database/migrations/2025_05_25_095713_create_replies_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('replies', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->text('content');
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('replies');
+    }
+}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -37,9 +37,12 @@
                         </a>
                     </p>
                     <p class="mb-1 text-muted" style="font-size: 0.9em;">
-                        {{-- 今後ここに「いいね数」などを追加 --}}
-                        {{-- 例：| いいね {{ $post->likes_count }} 件 --}}
-                        {{-- 配置場所やデザインをカスタマイズしてもらって大丈夫です --}}
+                        {{-- 
+                            今後ここに「いいね数」などを追加
+                            例：| いいね {{ $post->favorites_count }} 件や 
+                            例：| いいね {{ $countFavorites}} など
+                            配置場所やデザインをカスタマイズしてもらって大丈夫です
+                         --}}
                         リプライ {{ $post->replies_count }} 件
                     </p>
                     <p class="text-muted">{{ $post->created_at }}</p>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -28,7 +28,20 @@
             </div>
             <div class="">  {{-- 投稿本文 --}}
                 <div class="text-left d-inline-block w-75">
-                    <p class="mb-2">{{ $post->content }}</p>
+                    <p class="mb-2">
+                        <a href="{{ route('posts.show', $post->id) }}"
+                        style="color: #212529; text-decoration: none; transition: color 0.2s;"
+                        onmouseover="this.style.color='#007bff'; this.style.textDecoration='underline';"
+                        onmouseout="this.style.color='#212529'; this.style.textDecoration='none';">
+                            {{ $post->content }}
+                        </a>
+                    </p>
+                    <p class="mb-1 text-muted" style="font-size: 0.9em;">
+                        {{-- 今後ここに「いいね数」などを追加 --}}
+                        {{-- 例：| いいね {{ $post->likes_count }} 件 --}}
+                        {{-- 配置場所やデザインをカスタマイズしてもらって大丈夫です --}}
+                        リプライ {{ $post->replies_count }} 件
+                    </p>
                     <p class="text-muted">{{ $post->created_at }}</p>
                 </div>
                 @if (Auth::id() === $post->user_id)  {{-- 投稿者のみ表示：削除・編集 --}}

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,0 +1,75 @@
+{{-- 投稿詳細：デザイン等、カスタマイズOK --}}
+@extends('layouts.app')
+@section('content')
+    <div class="container">
+        <div class="w-75 mx-auto">
+            <div class="mb-4 b-3">
+                <h4>{{ $post->user->name }} さんの投稿</h4>
+                <div class="alert alert-info">
+                    <strong>投稿内容：<br>
+                    {{ $post->content }}<br>
+                    </strong>
+                    <small class="text-muted">{{ $post->created_at }}</small>
+                </div>
+            </div>
+            @include('commons.error_messages')
+            @if (Auth::check() && Auth::id() !== $post->user_id)
+                @if ($hasReplied)
+                    <p class="text-muted">※あなたはこの投稿にすでにリプライしています</p>
+                @endif
+                <form action="{{ route('replies.store', $post->id) }}" method="POST">
+                    @csrf
+                    <div class="form-group">
+                        <label for="reply_body">リプライ内容</label>
+                        <textarea name="reply_body" id="reply_body" class="form-control" rows="3">{{ old('reply_body') }}</textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary mt-2">リプライする</button>
+                </form>
+            @elseif (Auth::check() && Auth::id() === $post->user_id)
+                <p class="text-muted">※自分の投稿にはリプライできません。</p>
+            @else
+                <p class="text-muted">※リプライするにはログインが必要です。</p>
+            @endif
+            <hr>
+            <h5>リプライ一覧（{{ $replyCount }} 件）</h5>
+            @if ($replies->isEmpty())
+                <p class="text-muted">まだリプライはありません。</p>
+            @else
+            @foreach ($replies as $reply)
+                <div
+                    class="card mb-3 {{ $latestReply && $reply->id === $latestReply->id ? 'border border-info' : '' }}"
+                    @if ($latestReply && $reply->id === $latestReply->id)
+                        style="background-color: #f0fafd;"
+                    @endif
+                >
+                    <div class="card-body">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <strong>
+                                {{ $reply->user->name }}
+                                @if ($latestReply && $reply->id === $latestReply->id)
+                                    <span class="badge border border-info text-info ms-2">最新</span>
+                                @endif
+                            </strong>
+                            <small class="text-muted">{{ $reply->created_at }}</small>
+                        </div>
+                        <p class="mt-2 mb-2">{{ $reply->content }}</p>
+                        @if (Auth::check() && Auth::id() === $reply->user_id)
+                            <div class="text-end">
+                                <a href="{{ route('replies.edit', [$post->id, $reply->id]) }}" class="btn btn-sm btn-outline-primary me-1">編集</a>
+                                <form action="{{ route('replies.delete', [$post->id, $reply->id]) }}" method="POST" class="d-inline">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('本当に削除しますか？')">削除</button>
+                                </form>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+            @endif
+        </div>
+    </div>
+    <div class="m-auto" style="width: fit-content">
+    {{ $replies->links('pagination::bootstrap-4') }}
+    </div>
+@endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,4 +1,3 @@
-{{-- 投稿詳細：デザイン等、カスタマイズOK --}}
 @extends('layouts.app')
 @section('content')
     <div class="container">
@@ -35,37 +34,37 @@
             @if ($replies->isEmpty())
                 <p class="text-muted">まだリプライはありません。</p>
             @else
-            @foreach ($replies as $reply)
-                <div
-                    class="card mb-3 {{ $latestReply && $reply->id === $latestReply->id ? 'border border-info' : '' }}"
-                    @if ($latestReply && $reply->id === $latestReply->id)
-                        style="background-color: #f0fafd;"
-                    @endif
-                >
-                    <div class="card-body">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <strong>
-                                {{ $reply->user->name }}
-                                @if ($latestReply && $reply->id === $latestReply->id)
-                                    <span class="badge border border-info text-info ms-2">最新</span>
-                                @endif
-                            </strong>
-                            <small class="text-muted">{{ $reply->created_at }}</small>
-                        </div>
-                        <p class="mt-2 mb-2">{{ $reply->content }}</p>
-                        @if (Auth::check() && Auth::id() === $reply->user_id)
-                            <div class="text-end">
-                                <a href="{{ route('replies.edit', [$post->id, $reply->id]) }}" class="btn btn-sm btn-outline-primary me-1">編集</a>
-                                <form action="{{ route('replies.delete', [$post->id, $reply->id]) }}" method="POST" class="d-inline">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('本当に削除しますか？')">削除</button>
-                                </form>
-                            </div>
+                @foreach ($replies as $reply)
+                    <div
+                        class="card mb-3 {{ $latestReply && $reply->id === $latestReply->id ? 'border border-info' : '' }}"
+                        @if ($latestReply && $reply->id === $latestReply->id)
+                            style="background-color: #f0fafd;"
                         @endif
+                    >
+                        <div class="card-body">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <strong>
+                                    {{ $reply->user->name }}
+                                    @if ($latestReply && $reply->id === $latestReply->id)
+                                        <span class="badge border border-info text-info ms-2">最新</span>
+                                    @endif
+                                </strong>
+                                <small class="text-muted">{{ $reply->created_at }}</small>
+                            </div>
+                            <p class="mt-2 mb-2">{{ $reply->content }}</p>
+                            @if (Auth::check() && Auth::id() === $reply->user_id)
+                                <div class="text-end">
+                                    <a href="{{ route('replies.edit', ['post_id' => $post->id, 'reply_id' => $reply->id]) }}" class="btn btn-sm btn-outline-primary me-1">編集</a>
+                                    <form action="{{ route('replies.delete', ['reply_id' => $reply->id]) }}" method="POST" class="d-inline">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('本当に削除しますか？')">削除</button>
+                                    </form>
+                                </div>
+                            @endif
+                        </div>
                     </div>
-                </div>
-            @endforeach
+                @endforeach
             @endif
         </div>
     </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -31,7 +31,7 @@
                 <p class="text-muted">※リプライするにはログインが必要です。</p>
             @endif
             <hr>
-            <h5>リプライ一覧（{{ $replyCount }} 件）</h5>
+            <h5>リプライ一覧（{{ $countReplies }} 件）</h5>
             @if ($replies->isEmpty())
                 <p class="text-muted">まだリプライはありません。</p>
             @else

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.app')
+@section('content')
+    <div class="container">
+        <div class="w-75 mx-auto">
+            <div class="mb-4 b-3">
+                <h4>{{ $post->user->name }} さんの投稿</h4>
+                <div class="alert alert-info">
+                    <strong>投稿内容：<br>
+                    {{ $post->content }}<br>
+                    </strong>
+                    <small class="text-muted">{{ $post->created_at }}</small>
+                </div>
+                @include('commons.error_messages')
+                <h5 class="mt-4">リプライ内容を編集する</h5>
+                <form action="{{ route('replies.update', [$post->id, $reply->id]) }}" method="POST">
+                    @csrf
+                    @method('PUT')
+                    <div class="form-group">
+                        <textarea name="reply_body" id="reply_body" class="form-control" rows="3">{{ old('reply_body', $reply->content) }}</textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary mt-2">更新する</button>
+                    <a href="{{ route('posts.show', $post->id) }}" class="btn btn-secondary mt-2">キャンセル</a>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,9 @@
 
 Route::get('/', 'PostsController@index');
 
+// 投稿詳細ページ
+Route::get('posts/{post}', 'PostsController@show')->name('posts.show');
+
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('register');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
@@ -24,8 +27,6 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
-   // ユーザ詳細表示
-    
    // ユーザ編集、更新、退会
    Route::prefix('users/{id}')->group(function () {
        Route::get('edit', 'UsersController@edit')->name('user.edit');
@@ -37,9 +38,18 @@ Route::group(['middleware' => 'auth'], function () {
        Route::post('', 'PostsController@store')->name('posts.store'); 
    });
 
-//フォロー・フォロー解除
-Route::group(['prefix' => 'users/{id}'], function() {
-    Route::post('follow', 'FollowController@store')->name('follow');
-    Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
-   });
+    //フォロー・フォロー解除
+    Route::group(['prefix' => 'users/{id}'], function() {
+        Route::post('follow', 'FollowController@store')->name('follow');
+        Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
+    });
+    
+   // リプライ
+    Route::prefix('posts/{id}')->group(function () {
+        // 投稿、編集・更新、削除
+        Route::post('replies', 'RepliesController@store')->name('replies.store');
+        Route::get('replies/{id}/edit', 'RepliesController@edit')->name('replies.edit');
+        Route::put('replies/{id}', 'RepliesController@update')->name('replies.update');
+        Route::delete('replies/{id}', 'RepliesController@destroy')->name('replies.delete');
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,29 +27,26 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
-   // ユーザ編集、更新、退会
-   Route::prefix('users/{id}')->group(function () {
-       Route::get('edit', 'UsersController@edit')->name('user.edit');
-       Route::put('', 'UsersController@update')->name('user.update');
-       Route::delete('', 'UsersController@destroy')->name('user.delete');
-   });
-   // 新規投稿、編集(なりさん担当)、更新(なりさん担当)、削除(清水さん担当)
-   Route::prefix('posts')->group(function () {
-       Route::post('', 'PostsController@store')->name('posts.store'); 
-   });
-
+    // ユーザ編集、更新、退会
+    Route::prefix('users/{id}')->group(function () {
+        Route::get('edit', 'UsersController@edit')->name('user.edit');
+        Route::put('', 'UsersController@update')->name('user.update');
+        Route::delete('', 'UsersController@destroy')->name('user.delete');
+    });
+    // 新規投稿、編集(なりさん担当)、更新(なりさん担当)、削除(清水さん担当)
+    Route::prefix('posts')->group(function () {
+        Route::post('', 'PostsController@store')->name('posts.store');
+    });
+    // リプライ
+    Route::group(['prefix' => 'posts/{post_id}/replies'], function () {
+        Route::post('', 'RepliesController@store')->name('replies.store');
+        Route::get('{reply_id}/edit', 'RepliesController@edit')->name('replies.edit');
+        Route::put('{reply_id}', 'RepliesController@update')->name('replies.update');
+        Route::delete('{reply_id}', 'RepliesController@destroy')->name('replies.delete');
+    });
     //フォロー・フォロー解除
-    Route::group(['prefix' => 'users/{id}'], function() {
+    Route::group(['prefix' => 'users/{id}'], function () {
         Route::post('follow', 'FollowController@store')->name('follow');
         Route::delete('unfollow', 'FollowController@destroy')->name('unfollow');
-    });
-    
-   // リプライ
-    Route::prefix('posts/{id}')->group(function () {
-        // 投稿、編集・更新、削除
-        Route::post('replies', 'RepliesController@store')->name('replies.store');
-        Route::get('replies/{id}/edit', 'RepliesController@edit')->name('replies.edit');
-        Route::put('replies/{id}', 'RepliesController@update')->name('replies.update');
-        Route::delete('replies/{id}', 'RepliesController@destroy')->name('replies.delete');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,8 +42,8 @@ Route::group(['middleware' => 'auth'], function () {
         Route::post('', 'RepliesController@store')->name('replies.store');
         Route::get('{reply_id}/edit', 'RepliesController@edit')->name('replies.edit');
         Route::put('{reply_id}', 'RepliesController@update')->name('replies.update');
-        Route::delete('{reply_id}', 'RepliesController@destroy')->name('replies.delete');
     });
+    Route::delete('replies/{reply_id}', 'RepliesController@destroy')->name('replies.delete');
     //フォロー・フォロー解除
     Route::group(['prefix' => 'users/{id}'], function () {
         Route::post('follow', 'FollowController@store')->name('follow');


### PR DESCRIPTION
## issue
- リプライ機能（表示、投稿、編集・更新、削除）の実装

## 概要
- 投稿詳細画面において、リプライの表示、投稿、編集・更新、削除の実装を行いました。
- 未ログインユーザーや自分自身の投稿にはリプライできないよう制御しています。
- 最新リプライに「最新」バッジを表示、ページネーション機能やリプライ件数のカウントも追加済みです。
- 動作確認済みです。

## 動作確認手順
1. ログイン後、トップページの投稿一覧から、任意の投稿詳細画面へ遷移
2. 他ユーザーの投稿に対してリプライ投稿
3. バリデーション（空欄・100文字超過）の確認
4. リプライ編集・削除の確認（投稿者のみ可能）
5. リプライが最新のものに「最新」バッジが表示されるか確認
6. ページネーションが機能しており、複数ページのリプライが閲覧できることを確認
7. トップページに、リプライ件数が正しく表示されているか確認
8. ログアウトし、未ログインユーザの状態だとリプライできないことを確認

## 考慮してほしいこと
- posts/{post_id}/replies/{reply_id} のルート構造に合わせて、RepliesControllerでは $postId, $replyId の形式にしました。
（posts/{id}/replies/{id} の形式では、ルート定義上の変数名の重複エラーが発生したため）
- RepliesControllerのdestroyメソッドの
```
$post = Post::findOrFail($postId); 
```
は、ルートで {post_id} を受け取っているため一度取得していますが、実際の処理では使用していません（不要であれば削除しても問題ありません）。
- 投稿詳細でリプライ投稿後は1ページ目にリダイレクトされるようにしています（2ページ目で投稿しても、自分の投稿がすぐ確認できるようにしています）
- PostsController にまだ destroy メソッドがなかったため、仮でルート・メソッド・Bladeを追加して検証しました。
親ポスト削除時に子リプライが論理削除されることもDB上で確認済みです。
※仮ルート・メソッド・Bladeは削除しています。

## 確認してほしいこと
- 正しく動作しているか
- レイアウト崩れがないか（PC・スマホ）
- コードの書き方や構成に違和感がないか（あれば教えていただきたいです）
- 特にコントローラー・Bladeの処理や構成に無理がないか
- 命名や変数の表記の統一感はあるか
- 他メンバーのコードと書き方・スタイルにズレがないか（気になる点は遠慮なくご指摘ください）
- 特にPostsControllerの
```
Post::withCount('replies')
```
この表記が他メンバーに分かりづらくないか、書き方にズレが生じるのではないかと少し迷いました。
ただwithCountを使わない場合は$postsをforeachで$postにしてから件数を取得する必要があり、コードが長く煩雑になる懸念があったため、withCountを使用し、リプライ件数をBladeに渡しました。
ご指摘あれば、ご教示ください。