### PR TITLE
タイトル名の変更（もりお）

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 <div class="text-center">
-    <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+    <h1><i class="fab fa-telegram fa-lg pr-3"></i>寺子屋＠プログラミング</h1>
 </div>
 <div class="text-center mt-3">
     <p class="text-left d-inline-block">ログインすると投稿で<br>コミュニケーションができるようになります。</p>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>寺子屋＠プログラミング</h1>
     </div>
     <div class="text-center mt-3">
         <p class="text-left d-inline-block">新規ユーザ登録すると投稿で<br>コミュニケーションができるようになります。</p>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,6 +1,6 @@
 <header class="mb-5">
     <nav class="navbar navbar-expand-sm navbar-dark bg-info">
-        <a class="navbar-brand" href="/">Topic Posts</a>
+        <a class="navbar-brand" href="/">寺子屋＠プログラミング</a>
         <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
-            <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Topic Posts</h1>
+            <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>寺子屋＠プログラミング</h1>
         </div>
     </div>
     <h5 class="description text-center mb-3">"○○"について140字以内で会話しよう！</h5>


### PR DESCRIPTION
## issue
- タイトル名の変更

## 概要
- welcome.blade.php、header.blade.php、login.blade.php、register.blade.php  各ファイルのタイトル名を、「Topic Posts」より「寺子屋＠プログラミング」へ変更することで、各表示画面の変更をいたしました。

## 動作確認手順
- トップページ  http://localhost:8080  にアクセスの後、タイトル名、及び、ヘッダーが、「Topic Posts」から「寺子屋＠プログラミング」へ変更されていることをご確認ください。
- ログイン画面  http://localhost:8080/login   新規登録画面  http://localhost:8080/signup  にて、タイトル名が「Topic Posts」から「寺子屋＠プログラミング」へ変更されていることをご確認ください。

## 考慮して欲しいこと
- ユーザログイン・ログアウトのファイル login.blade.php は智美さん、ユーザ新規登録のファイル register.blade.php はみこさんのご担当でしたが、智美さんの方はご本人様から、みこさんの方はゆきひろ様よりご了承を得て、森尾の方で修正させていただいております。

## 確認して欲しいこと
- 特にありません。