### PR TITLE
#168 フラッシュメッセージの実装（もりお）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -51,7 +51,7 @@ class PostsController extends Controller
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
         $post->save();
-        return redirect("/");
+        return redirect()->route('posts.index')->with('success', '更新が完了しました！');
     }
 
     public function store(PostRequest $request)
@@ -60,7 +60,6 @@ class PostsController extends Controller
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
         $post->save();
-
-        return back();
+        return redirect()->route('posts.index')->with('success', '投稿が完了しました！');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -57,6 +57,6 @@ class UsersController extends Controller
 
         Auth::logout();
         
-        return redirect("/")->with('success', '退会が完了しました。');
+        return redirect()->route('posts.index')->with('success', '退会が完了しました！');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -44,8 +44,7 @@ class UsersController extends Controller
         $user->email = $request->email;
         $user->password = $request->password;
         $user->save();
-        return redirect()->route('user.show', $user->id)->with('success', '「ユーザ情報の更新」が完了しました！
-        ');
+        return redirect()->route('user.show', $user->id)->with('success', '「ユーザ情報の更新」が完了しました！');
     }
 
     public function withdrawal($id, Request $request)
@@ -58,6 +57,6 @@ class UsersController extends Controller
 
         Auth::logout();
         
-        return redirect("/");
+        return redirect("/")->with('success', '退会が完了しました。');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -44,6 +44,7 @@ class UsersController extends Controller
         $user->email = $request->email;
         $user->password = $request->password;
         $user->save();
-        return redirect()->route('user.show', $user->id);
+        return redirect()->route('user.show', $user->id)->with('success', '「ユーザ情報の更新」が完了しました！
+        ');
     }
 }

--- a/resources/views/components/flash-message.blade.php
+++ b/resources/views/components/flash-message.blade.php
@@ -1,0 +1,11 @@
+@if (session('success'))
+    <div>
+        <span style="background-color: #99FFFF;">
+            {{ session('success') }}
+        </span>
+    </div>
+@endif
+
+@if (session('error'))
+        <p>{{ session('error') }}</p>
+@endif

--- a/resources/views/components/flash_message.blade.php
+++ b/resources/views/components/flash_message.blade.php
@@ -7,5 +7,5 @@
 @endif
 
 @if (session('error'))
-        <p>{{ session('error') }}</p>
+    <p>{{ session('error') }}</p>
 @endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="ja">
     <head>
         <meta charset="utf-8">
-        <title>Topic Posts</title>
+        <title>寺子屋＠プログラミング</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     </head>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,5 +1,6 @@
 @extends('layouts.app')
 @section('content')
+    @include('components.flash-message')
     <h2 class="mt-5">投稿を編集する</h2>        
     <form method="POST" action="{{ route('post.update', $post->id) }}">
         @include('commons.error_messages') 

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('content')
-@include('components.flash-message')
+@include('components.flash_message')
     <h2 class="mt-5">投稿を編集する</h2>        
     <form method="POST" action="{{ route('post.update', $post->id) }}">
         @include('commons.error_messages') 

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('content')
-    @include('components.flash-message')
+@include('components.flash-message')
     <h2 class="mt-5">投稿を編集する</h2>        
     <form method="POST" action="{{ route('post.update', $post->id) }}">
         @include('commons.error_messages') 

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('content')
-@include('components.flash-message')
+@include('components.flash_message')
 <div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,5 +1,6 @@
 @extends('layouts.app')
 @section('content')
+@include('components.flash-message')
 <div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,6 @@
 @extends('layouts.app')
 @section('content')
+    @include('components.flash-message')
     <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
             <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>寺子屋＠プログラミング</h1>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('content')
-@include('components.flash-message')
+@include('components.flash_message')
     <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
             <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>寺子屋＠プログラミング</h1>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 @section('content')
-    @include('components.flash-message')
+@include('components.flash-message')
     <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
             <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>寺子屋＠プログラミング</h1>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
 |--------------------------------------------------------------------------
 | Web Routes
@@ -9,11 +8,11 @@
 | routes are loaded by the RouteServiceProvider within a group which
 | contains the "web" middleware group. Now create something great!
 |
+
 */
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
-
-Route::get('/', 'PostsController@index');
+Route::get('/', 'PostsController@index')->name('posts.index');
 Route::prefix('users')->group(function () {
 Route::get('{id}', 'UsersController@show')->name('user.show');
 });


### PR DESCRIPTION
## issue
- Close #168

## 概要
- フラッシュメッセージの実装
- 前回の課題漏れを記載（app.blade.phpファイルの中の「Topic Posts」を「寺子屋＠プログラミング」へ変更いたしました）

## 動作確認手順
- 新規投稿した時の表示・・・ログインしていただき、トップページから投稿すると、投稿一覧のタイトル枠の左上の部分に「投稿が完了しました！」と表示されることをご確認ください。
- 投稿編集した時の表示・・・現在投稿一覧画面の右側の編集ボタンが機能していませんので、admin にて、投稿者の投稿 id をご確認いただき、「localhost:8080/posts/投稿者の投稿id/edit」へのアクセスにて投稿編集画面に遷移、「投稿を編集する」画面に入力、更新ボタンを押していただき、遷移先の投稿一覧のタイトル枠の左上の部分に「更新しました！」と表示されることをご確認ください。
- ユーザ情報の更新の表示・・・ユーザ詳細画面にて、ユーザ情報を編集後、「更新する」ボタンを押していただき、ユーザ詳細画面へ遷移した時に、左上に、「ユーザ情報の更新」が完了しました！ と表示されることをご確認ください。
- 退会処理の表示・・・ユーザ編集画面にて、「退会する」ボタンを押していただき、投稿一覧画面にて、「退会が完了しました。」と表示されることをご確認ください。
- 前回の課題漏れを記載・・・サイト上部のタブにカーソルを当てていただき、「寺子屋＠プログラミング」 と表示されることをご確認ください。

## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- ご指摘をいただきありがとうございます。各所、修正をいたしました。ご確認いただけますと幸いです。
よろしくお願いいたします。