### PR TITLE
投稿一覧から投稿編集画面への遷移（もりお）

### DIFF
--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -17,7 +17,7 @@
                             @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('post.edit', ['id' => $post->id]) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>


### PR DESCRIPTION
## issue
- Closes #1536

## 概要
- 投稿一覧から投稿編集画面への遷移

## 動作確認手順
- ログイン後、トップページの投稿画面より投稿していただき、投稿した右横に表示されている「編集する」ボタンを押下していただくと、投稿編集画面へ遷移することをご確認ください。

## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- コードの記載に誤りがないかご確認いただけましたらと思います。
よろしくお願いいたします。