### PR TITLE
☆の5段階評価の機能(ちゃこ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -21,6 +21,9 @@ class PostsController extends Controller
             })
             ->orderBy('id', 'desc')
             ->paginate(9);
+        foreach ($posts as $post) {
+            $post->average_ratings = Reply::averageRatingsForPost($post);
+        }
         $data = [
             'keyword' => $keyword,
             'posts' => $posts,
@@ -38,11 +41,13 @@ class PostsController extends Controller
         if (Auth::check() && Auth::id() !== $post->user_id) {
             $hasReplied = Reply::hasReplied(Auth::user(), $post);
         }
+        $averageRatings = Reply::averageRatingsForPost($post);
         $data = [
             'post' => $post,
             'replies' => $replies,
             'latestReply' => $latestReply,
             'hasReplied' => $hasReplied,
+            'averageRatings' => $averageRatings,
         ];
         $data += Reply::replyCounts($post);
         return view('posts.show', $data);

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -16,6 +16,9 @@ class RepliesController extends Controller
         $post = Post::findOrFail($postId);
         $reply = new Reply();
         $reply->content = $request->reply_body;
+        $reply->rating_service = $request->input('rating_service');
+        $reply->rating_cost = $request->input('rating_cost');
+        $reply->rating_quality = $request->input('rating_quality');
         $reply->user_id = Auth::id();
         $reply->post_id = $post->id;
         $reply->save();
@@ -46,6 +49,9 @@ class RepliesController extends Controller
             abort(403);
         }
         $reply->content = $request->reply_body;
+        $reply->rating_service = $request->input('rating_service') !== '' ? $request->input('rating_service') : null;
+        $reply->rating_cost = $request->input('rating_cost') !== '' ? $request->input('rating_cost') : null;
+        $reply->rating_quality = $request->input('rating_quality') !== '' ? $request->input('rating_quality') : null;
         $reply->save();
         return redirect()->route('posts.show', $post);
     }

--- a/app/Http/Requests/ReplyRequest.php
+++ b/app/Http/Requests/ReplyRequest.php
@@ -25,6 +25,9 @@ class ReplyRequest extends FormRequest
     {
         return [
             'reply_body' => 'required|string|max:100',
+            'rating_service' => 'nullable|integer|min:1|max:5',
+            'rating_cost' => 'nullable|integer|min:1|max:5',
+            'rating_quality' => 'nullable|integer|min:1|max:5',
         ];
     }
 
@@ -32,6 +35,9 @@ class ReplyRequest extends FormRequest
     {
         return [
             'reply_body' => 'リプライ',
+            'rating_service' => '接客・対応',
+            'rating_cost' => '料金',
+            'rating_quality' => '技術',
         ];
     }
 

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -46,4 +46,24 @@ class Reply extends Model
                     ->latest()
                     ->first();
     }
+
+    // 投稿に対するリプライ評価の平均を計算
+    public static function averageRatingsForPost(Post $post)
+    {
+        $replies = $post->replies()->whereNull('deleted_at');
+        $serviceAvg = $replies->avg('rating_service');
+        $costAvg    = $replies->avg('rating_cost');
+        $qualityAvg = $replies->avg('rating_quality');
+        $service = $serviceAvg ? round($serviceAvg, 1) : null;
+        $cost = $costAvg ? round($costAvg, 1) : null;
+        $quality = $qualityAvg ? round($qualityAvg, 1) : null;
+        $values = collect([$service, $cost, $quality])->filter();
+        $overall = $values->isNotEmpty() ? round($values->avg(), 1) : null;
+        return [
+            'service' => $service,
+            'cost'    => $cost,
+            'quality' => $quality,
+            'overall' => $overall,
+        ];
+    }
 }

--- a/app/Reply.php
+++ b/app/Reply.php
@@ -47,16 +47,20 @@ class Reply extends Model
                     ->first();
     }
 
+    // 評価の平均を丸めて返す
+    public static function getRoundedAverage($collection, $key)
+    {
+        $average = $collection->avg($key);
+        return $average ? round($average, 1) : null;
+    }
+
     // 投稿に対するリプライ評価の平均を計算
     public static function averageRatingsForPost(Post $post)
     {
         $replies = $post->replies()->whereNull('deleted_at');
-        $serviceAvg = $replies->avg('rating_service');
-        $costAvg    = $replies->avg('rating_cost');
-        $qualityAvg = $replies->avg('rating_quality');
-        $service = $serviceAvg ? round($serviceAvg, 1) : null;
-        $cost = $costAvg ? round($costAvg, 1) : null;
-        $quality = $qualityAvg ? round($qualityAvg, 1) : null;
+        $service = self::getRoundedAverage($replies, 'rating_service');
+        $cost    = self::getRoundedAverage($replies, 'rating_cost');
+        $quality = self::getRoundedAverage($replies, 'rating_quality');
         $values = collect([$service, $cost, $quality])->filter();
         $overall = $values->isNotEmpty() ? round($values->avg(), 1) : null;
         return [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,10 @@
+<?php
+
+if (!function_exists('display_star_rating')) {
+    function display_star_rating(?float $value): string
+    {
+        return $value !== null
+            ? number_format($value, 1) . '★'
+            : '-';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "classmap": [
             "database/seeds",
             "database/factories"
+        ],
+        "files": [
+        "app/helpers.php"
         ]
     },
     "autoload-dev": {

--- a/database/migrations/2025_05_25_095713_create_replies_table.php
+++ b/database/migrations/2025_05_25_095713_create_replies_table.php
@@ -18,6 +18,9 @@ class CreateRepliesTable extends Migration
             $table->bigInteger('post_id')->unsigned()->index();
             $table->bigInteger('user_id')->unsigned()->index();
             $table->text('content');
+            $table->tinyInteger('rating_service')->unsigned()->nullable();
+            $table->tinyInteger('rating_cost')->unsigned()->nullable();
+            $table->tinyInteger('rating_quality')->unsigned()->nullable();
             $table->timestamps();
             $table->softDeletes();
             $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,1 @@
+@import url("star-rating.css");

--- a/public/css/star-rating.css
+++ b/public/css/star-rating.css
@@ -1,0 +1,35 @@
+.star-rating {
+    display: inline-flex;
+    font-size: 1.1rem;
+    line-height: 1;
+    gap: 0.1em;
+}
+
+.star {
+    position: relative;
+    display: inline-block;
+    color: #ccc;
+    width: 1.1em;
+    height: 1.1em;
+    flex-shrink: 0;
+}
+
+.star:last-child {
+    margin-right: 0;
+}
+
+.star-base {
+    position: relative;
+    z-index: 1;
+    color: #ccc;
+}
+
+.star-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    z-index: 2;
+    color: gold;
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,7 @@
         <title>@yield('title', '修理どこがいい？クルマの名医ナビ')</title>
         <meta name="description" content="@yield('meta_description', '信頼できる自動車整備工場が口コミで見つかる車修理レビューアプリ')">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" ...>
+        <link rel="stylesheet" href="{{ asset('/css/app.css') }}">
     </head>
     <body>
         @include('commons.header')

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -32,20 +32,6 @@
                         </div>
                     </div>
 
-                    {{-- 評価（★） --}}
-                    @if ($post->rating)
-                        <div class="mb-2">
-                            評価:
-                            @for ($i = 1; $i <= 5; $i++)
-                                @if ($i <= $post->rating)
-                                    <span style="color: gold;">★</span>
-                                @else
-                                    <span style="color: #ccc;">★</span>
-                                @endif
-                            @endfor
-                        </div>
-                    @endif
-
                     {{-- 📷 投稿画像（常に表示：投稿者が画像を投稿していない場合はデフォルト） --}}
                     @php
                         $defaultImage = config('constants.no_image_path');
@@ -59,6 +45,44 @@
                         style="height: 200px; object-fit: contain; background-color: #f8f9fa;"
                         alt="投稿画像">
                     </a>
+                    
+                    {{-- 評価（★） --}}
+                    @php
+                        $overall = $post->average_ratings['overall'] ?? null;
+                    @endphp
+                    <div class="mb-2">
+                        評価：
+                        @if (!empty($overall))
+                            <span class="fw-bold">{{ number_format($overall, 1) }}</span>
+                            <span class="star-rating">
+                                @for ($i = 1; $i <= 5; $i++)
+                                    @php
+                                        $fillRatio = $overall - $i + 1;
+                                        $fill = 0;
+
+                                        if ($fillRatio >= 1) {
+                                            $fill = 100;
+                                        } elseif ($fillRatio >= 0.75) {
+                                            $fill = 75;
+                                        } elseif ($fillRatio >= 0.5) {
+                                            $fill = 50;
+                                        } elseif ($fillRatio >= 0.25) {
+                                            $fill = 25;
+                                        } else {
+                                            $fill = 0;
+                                        }
+                                    @endphp
+                                    <span class="star">
+                                        <span class="star-fill" style="width: {{ $fill }}%;">★</span>
+                                        <span class="star-base">★</span>
+                                    </span>
+                                @endfor
+                            </span>
+                        @else
+                            <span class="text-muted">-</span>
+                        @endif
+                    </div>
+
                     {{-- 📝 投稿内容 --}}
                     <p class="card-text mb-2" style="max-height: 120px; overflow: hidden; text-overflow: ellipsis;">
                         <a href="{{ route('posts.show', $post->id) }}" style="color: #212529; text-decoration: none;">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -50,38 +50,39 @@
                     @php
                         $overall = $post->average_ratings['overall'] ?? null;
                     @endphp
-                    <div class="mb-2">
-                        評価：
-                        @if (!empty($overall))
-                            <span class="fw-bold">{{ number_format($overall, 1) }}</span>
-                            <span class="star-rating">
-                                @for ($i = 1; $i <= 5; $i++)
-                                    @php
-                                        $fillRatio = $overall - $i + 1;
-                                        $fill = 0;
-
-                                        if ($fillRatio >= 1) {
-                                            $fill = 100;
-                                        } elseif ($fillRatio >= 0.75) {
-                                            $fill = 75;
-                                        } elseif ($fillRatio >= 0.5) {
-                                            $fill = 50;
-                                        } elseif ($fillRatio >= 0.25) {
-                                            $fill = 25;
-                                        } else {
+                    <a href="{{ route('posts.show', $post->id) }}" style="text-decoration: none; color: inherit;">
+                        <div class="mb-2">
+                            評価：
+                            @if (!empty($overall))
+                                <span class="fw-bold">{{ number_format($overall, 1) }}</span>
+                                <span class="star-rating">
+                                    @for ($i = 1; $i <= 5; $i++)
+                                        @php
+                                            $fillRatio = $overall - $i + 1;
                                             $fill = 0;
-                                        }
-                                    @endphp
-                                    <span class="star">
-                                        <span class="star-fill" style="width: {{ $fill }}%;">★</span>
-                                        <span class="star-base">★</span>
-                                    </span>
-                                @endfor
-                            </span>
-                        @else
-                            <span class="text-muted">-</span>
-                        @endif
-                    </div>
+                                            if ($fillRatio >= 1) {
+                                                $fill = 100;
+                                            } elseif ($fillRatio >= 0.75) {
+                                                $fill = 75;
+                                            } elseif ($fillRatio >= 0.5) {
+                                                $fill = 50;
+                                            } elseif ($fillRatio >= 0.25) {
+                                                $fill = 25;
+                                            } else {
+                                                $fill = 0;
+                                            }
+                                        @endphp
+                                        <span class="star">
+                                            <span class="star-fill" style="width: {{ $fill }}%;">★</span>
+                                            <span class="star-base">★</span>
+                                        </span>
+                                    @endfor
+                                </span>
+                            @else
+                                <span class="text-muted">-</span>
+                            @endif
+                        </div>
+                    </a>
 
                     {{-- 📝 投稿内容 --}}
                     <p class="card-text mb-2" style="max-height: 120px; overflow: hidden; text-overflow: ellipsis;">

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -111,31 +111,37 @@
                             </div>
                             <p class="mt-2 mb-2">{{ $reply->content }}</p>
                             <ul class="list-unstyled ms-2">
-                            @if ($reply->rating_service)
                                 <li>
                                     接客・対応の満足度　：
-                                    @for ($i = 1; $i <= 5; $i++)
-                                        <span style="color: {{ $i <= $reply->rating_service ? 'gold' : 'lightgray' }}">★</span>
-                                    @endfor
+                                    @if ($reply->rating_service !== null)
+                                        @for ($i = 1; $i <= 5; $i++)
+                                            <span style="color: {{ $i <= $reply->rating_service ? 'gold' : 'lightgray' }}">★</span>
+                                        @endfor
+                                    @else
+                                        <span class="text-muted">-</span>
+                                    @endif
                                 </li>
-                            @endif
-                            @if ($reply->rating_cost)
                                 <li>
                                     料金の妥当性について：
-                                    @for ($i = 1; $i <= 5; $i++)
-                                        <span style="color: {{ $i <= $reply->rating_cost ? 'gold' : 'lightgray' }}">★</span>
-                                    @endfor
+                                    @if ($reply->rating_cost !== null)
+                                        @for ($i = 1; $i <= 5; $i++)
+                                            <span style="color: {{ $i <= $reply->rating_cost ? 'gold' : 'lightgray' }}">★</span>
+                                        @endfor
+                                    @else
+                                        <span class="text-muted">-</span>
+                                    @endif
                                 </li>
-                            @endif
-                            @if ($reply->rating_quality)
                                 <li>
                                     修理の仕上がり精度　：
-                                    @for ($i = 1; $i <= 5; $i++)
-                                        <span style="color: {{ $i <= $reply->rating_quality ? 'gold' : 'lightgray' }}">★</span>
-                                    @endfor
+                                    @if ($reply->rating_quality !== null)
+                                        @for ($i = 1; $i <= 5; $i++)
+                                            <span style="color: {{ $i <= $reply->rating_quality ? 'gold' : 'lightgray' }}">★</span>
+                                        @endfor
+                                    @else
+                                        <span class="text-muted">-</span>
+                                    @endif
                                 </li>
-                            @endif
-                        </ul>
+                            </ul>
                             @if (Auth::check() && Auth::id() === $reply->user_id)
                                 <div class="text-end">
                                     <a href="{{ route('replies.edit', ['post_id' => $post->id, 'reply_id' => $reply->id]) }}" class="btn btn-sm btn-outline-primary me-1">編集</a>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -10,6 +10,24 @@
                     </strong>
                     <small class="text-muted">{{ $post->created_at }}</small>
                 </div>
+                @if ($averageRatings)
+                    <div class="mb-2">
+                        <h5 class="mb-1">
+                            平均評価：
+                            <span style="font-size: 1.5rem; color: #000;">
+                                {{ $averageRatings['overall'] !== null ? number_format($averageRatings['overall'], 1) : '-' }}
+                            </span>
+                            <span style="color: gold; font-size: 1.5rem;">
+                                {{ $averageRatings['overall'] !== null ? '★' : '' }}
+                            </span>
+                        </h5>
+                        <small class="text-muted">
+                            接客：{{ $averageRatings['service'] !== null ? number_format($averageRatings['service'], 1) . '★' : '-' }}　
+                            料金：{{ $averageRatings['cost'] !== null ? number_format($averageRatings['cost'], 1) . '★' : '-' }}　
+                            技術：{{ $averageRatings['quality'] !== null ? number_format($averageRatings['quality'], 1) . '★' : '-' }}
+                        </small>
+                    </div>
+                @endif
                 @php
                     $defaultImage = config('constants.no_image_path');
                     $imageUrl = $post->image
@@ -31,6 +49,36 @@
                     <div class="form-group">
                         <label for="reply_body">リプライ内容</label>
                         <textarea name="reply_body" id="reply_body" class="form-control" rows="3">{{ old('reply_body') }}</textarea>
+                    </div>
+                    {{-- 接客・対応 --}}
+                    <div class="form-group mt-3">
+                        <label>接客・対応の満足度（1〜5☆）※任意</label><br>
+                        @for ($i = 1; $i <= 5; $i++)
+                            <label class="me-2">
+                                <input type="radio" name="rating_service" value="{{ $i }}" {{ old('rating_service') == $i ? 'checked' : '' }}>
+                                {{ $i }}<span style="color: gold;">★</span>
+                            </label>
+                        @endfor
+                    </div>
+                    {{-- 料金の妥当性 --}}
+                    <div class="form-group mt-2">
+                        <label>料金の妥当性について（1〜5☆）※任意</label><br>
+                        @for ($i = 1; $i <= 5; $i++)
+                            <label class="me-2">
+                                <input type="radio" name="rating_cost" value="{{ $i }}" {{ old('rating_cost') == $i ? 'checked' : '' }}>
+                                {{ $i }}<span style="color: gold;">★</span>
+                            </label>
+                        @endfor
+                    </div>
+                    {{-- 技術・仕上がり --}}
+                    <div class="form-group mt-2">
+                        <label>修理の仕上がり精度（1〜5☆）※任意</label><br>
+                        @for ($i = 1; $i <= 5; $i++)
+                            <label class="me-2">
+                                <input type="radio" name="rating_quality" value="{{ $i }}" {{ old('rating_quality') == $i ? 'checked' : '' }}>
+                                {{ $i }}<span style="color: gold;">★</span>
+                            </label>
+                        @endfor
                     </div>
                     <button type="submit" class="btn btn-primary mt-2">リプライする</button>
                 </form>
@@ -62,6 +110,32 @@
                                 <small class="text-muted">{{ $reply->created_at }}</small>
                             </div>
                             <p class="mt-2 mb-2">{{ $reply->content }}</p>
+                            <ul class="list-unstyled ms-2">
+                            @if ($reply->rating_service)
+                                <li>
+                                    接客・対応の満足度　：
+                                    @for ($i = 1; $i <= 5; $i++)
+                                        <span style="color: {{ $i <= $reply->rating_service ? 'gold' : 'lightgray' }}">★</span>
+                                    @endfor
+                                </li>
+                            @endif
+                            @if ($reply->rating_cost)
+                                <li>
+                                    料金の妥当性について：
+                                    @for ($i = 1; $i <= 5; $i++)
+                                        <span style="color: {{ $i <= $reply->rating_cost ? 'gold' : 'lightgray' }}">★</span>
+                                    @endfor
+                                </li>
+                            @endif
+                            @if ($reply->rating_quality)
+                                <li>
+                                    修理の仕上がり精度　：
+                                    @for ($i = 1; $i <= 5; $i++)
+                                        <span style="color: {{ $i <= $reply->rating_quality ? 'gold' : 'lightgray' }}">★</span>
+                                    @endfor
+                                </li>
+                            @endif
+                        </ul>
                             @if (Auth::check() && Auth::id() === $reply->user_id)
                                 <div class="text-end">
                                     <a href="{{ route('replies.edit', ['post_id' => $post->id, 'reply_id' => $reply->id]) }}" class="btn btn-sm btn-outline-primary me-1">編集</a>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -22,9 +22,9 @@
                             </span>
                         </h5>
                         <small class="text-muted">
-                            接客：{{ $averageRatings['service'] !== null ? number_format($averageRatings['service'], 1) . '★' : '-' }}　
-                            料金：{{ $averageRatings['cost'] !== null ? number_format($averageRatings['cost'], 1) . '★' : '-' }}　
-                            技術：{{ $averageRatings['quality'] !== null ? number_format($averageRatings['quality'], 1) . '★' : '-' }}
+                            接客：{{ display_star_rating($averageRatings['service']) }}　
+                            料金：{{ display_star_rating($averageRatings['cost']) }}　
+                            技術：{{ display_star_rating($averageRatings['quality']) }}
                         </small>
                     </div>
                 @endif

--- a/resources/views/replies/edit.blade.php
+++ b/resources/views/replies/edit.blade.php
@@ -17,6 +17,54 @@
                     @method('PUT')
                     <div class="form-group">
                         <textarea name="reply_body" id="reply_body" class="form-control" rows="3">{{ old('reply_body', $reply->content) }}</textarea>
+                        {{-- 接客・対応 --}}
+                        <div class="form-group mt-3">
+                            <label>接客・対応の満足度　（1〜5☆）※任意</label><br>
+                            <label class="me-2">
+                                <input type="radio" name="rating_service" value="" 
+                                    {{ old('rating_service', $reply->rating_service) === null ? 'checked' : '' }}>
+                                未選択
+                            </label>
+                            @for ($i = 1; $i <= 5; $i++)
+                                <label class="me-2">
+                                    <input type="radio" name="rating_service" value="{{ $i }}" 
+                                        {{ old('rating_service', $reply->rating_service) == $i ? 'checked' : '' }}>
+                                    {{ $i }}<span style="color: gold;">★</span>
+                                </label>
+                            @endfor
+                        </div>
+                        {{-- 料金の妥当性 --}}
+                        <div class="form-group mt-3">
+                            <label>料金の妥当性について（1〜5☆）※任意</label><br>
+                            <label class="me-2">
+                                <input type="radio" name="rating_cost" value="" 
+                                    {{ old('rating_cost', $reply->rating_cost) === null ? 'checked' : '' }}>
+                                未選択
+                            </label>
+                            @for ($i = 1; $i <= 5; $i++)
+                                <label class="me-2">
+                                    <input type="radio" name="rating_cost" value="{{ $i }}" 
+                                        {{ old('rating_cost', $reply->rating_cost) == $i ? 'checked' : '' }}>
+                                    {{ $i }}<span style="color: gold;">★</span>
+                                </label>
+                            @endfor
+                        </div>
+                        {{-- 技術・仕上がり --}}
+                        <div class="form-group mt-3">
+                            <label>修理の仕上がり精度（1〜5☆）※任意</label><br>
+                            <label class="me-2">
+                                <input type="radio" name="rating_quality" value="" 
+                                    {{ old('rating_quality', $reply->rating_quality) === null ? 'checked' : '' }}>
+                                未選択
+                            </label>
+                            @for ($i = 1; $i <= 5; $i++)
+                                <label class="me-2">
+                                    <input type="radio" name="rating_quality" value="{{ $i }}" 
+                                        {{ old('rating_quality', $reply->rating_quality) == $i ? 'checked' : '' }}>
+                                    {{ $i }}<span style="color: gold;">★</span>
+                                </label>
+                            @endfor
+                        </div>
                     </div>
                     <button type="submit" class="btn btn-primary mt-2">更新する</button>
                     <a href="{{ route('posts.show', $post->id) }}" class="btn btn-secondary mt-2">キャンセル</a>


### PR DESCRIPTION
## issue
- ☆の5段階評価の機能

## 概要
- 投稿に対するリプライ機能に、3項目の5段階評価（接客 / 料金 / 技術）を追加しました。
- 投稿詳細ページには、リプライの評価平均を表示し、★（星）による視覚的な評価も実装しています。
- 投稿一覧ページでも、投稿ごとの評価平均スコアと★表示を追加しました。
- 動作確認済みです
- データベース上でも、評価を入力した場合は各項目のカラムに数値が入り、未入力の場合は null となっていることを確認済みです。

## 動作確認手順
1. 投稿詳細ページで他ユーザーとしてログインし、リプライを投稿する  
2. 評価項目（接客・料金・技術）を1〜5の中から任意で選択して投稿  
3. 投稿詳細ページに平均スコアと各項目の平均★が表示されるか確認 
4. リプライ一覧に、 各項目の★が表示されるか確認 
5. 投稿一覧ページでも overall の平均スコアと★が表示されているか確認  
6. 自分のリプライが編集・削除できるか確認

## 考慮してほしいこと
- 評価は任意項目のため、nullのままでも投稿できます（編集時も未選択可能）
- 投稿がない場合は、平均スコアや各項目の★が表示されないようにnull対応済みです

## 確認してほしいこと
- 評価表示が崩れていないか（特に★表示）
- 投稿一覧・詳細ページで平均評価の表示が意図通り動作しているか
- コードの記述や分け方に不自然な点がないか
- チームの他の書き方と大きくずれていないか
- モデル・コントローラー・ビューのコードが冗長になっていないか