### PR TITLE
投稿編集機能への画像投稿機能の追加

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -94,6 +94,11 @@ class PostsController extends Controller
     {
         $post = Post::findOrFail($id); //idに該当する投稿データを取得。見つからなければ404エラーを返す
         $post->content = $request->input('content'); //投稿内容をpostテーブルのcontentカラムに代入
+        if ($request->hasFile('image')) {
+            $post->deleteImage();
+            $path = $request->file('image')->store('post_images', 'public');
+            $post->image = $path;
+        }
         $post->save(); //postテーブルに保存
         return redirect('/');              
     }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -3,11 +3,21 @@
 <h2 class="mt-5">投稿を編集する</h2>
 @include('commons.error_messages')
 
-    <form method="POST" action="{{ route('posts.update', $post->id) }}">
+    <form method="POST" action="{{ route('posts.update', $post->id) }}" enctype="multipart/form-data" class="w-100">
         @csrf
         @method('PUT')
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="">{{ old('content',$post->content) }}</textarea>   
+        </div>
+        @if ($post->image)
+        <div class="mb-3">
+            <p>現在の画像：</p>
+            <img src="{{ asset('storage/' . $post->image) }}" alt="投稿画像" style="max-width: 200px;">
+        </div>
+        @endif
+        <div class="form-group">
+            <label for="image">画像を変更する</label>
+            <input type="file" class="form-control-file" name="image" id="image">
         </div>
         <button type="submit" class="btn btn-primary">更新する</button>
     </form>


### PR DESCRIPTION
## issue
投稿編集機能がマージされたため、既存の画像投稿機能と統合する対応を行う。

## 概要
- 投稿編集画面に画像投稿の機能を追加しました。
- 既存の画像が表示されるようにし、ユーザーが確認できるようにしました。
- 新しい画像をアップロードすると、旧画像は削除され、差し替えられるようにしました。
- 画像形式（jpeg, pngなど）と2MB以内の容量制限について、バリデーションエラーが正しく表示されることを確認しています。
- DBにて投稿の image カラムに新しい画像パスが正しく保存されていることも確認しています。

## 動作確認手順
1. 投稿編集画面にアクセスする
2. 現在の画像が表示されていることを確認（画像が登録されていない場合は、投稿フォームから画像の投稿をお願いします）
3. 新しい画像を選択して「更新」ボタンを押す
4. 投稿内容と画像が更新されること、旧画像が削除されていることを確認
5. 投稿一覧と投稿詳細画面で、変更した画像が表示されているか確認

## 考慮してほしいこと
- 古い画像が `storage/app/public/post_images/` から確実に削除されているか

## 確認してほしいこと
- 編集画面での画像の表示とファイル選択機能が正常に動作しているか
- バリデーションが意図通り機能しているか（画像形式、サイズ制限）
- 編集後、他の画面（トップ、投稿詳細など）でも変更が反映されているか
- DBにて投稿の image カラムに新しい画像パスが正しく保存されているか