### PR TITLE
Feature/shimizu/user delete v2  #1530

### DIFF
--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -97,7 +97,7 @@
                 {{-- 🛠 編集・削除（投稿者のみ） --}}
                 @if (Auth::id() === $post->user_id)
                     <div class="card-footer bg-white d-flex justify-content-between">
-                        <form method="POST" action="">
+                        <form method="POST" action="{{ route('posts.delete', $post->id) }}">
                             @csrf
                             @method('DELETE')
                             <button type="submit" class="btn btn-sm btn-danger">削除</button>


### PR DESCRIPTION
issue
 - closes 投稿削除　#1530投稿削除(清水)　Projects #121

### 概要
 - post.blade.phpの100行目に一部未記述もれがあり追記しました。
  - {{ route('posts.delete', $post->id) }}←この記述がもれておりました。

 ### 動作確認手順
 - localhost:8080においてログイン後、削除ボタンの挙動確認をいたしました。

 ### 考慮して欲しいこと
 - 特に御座いません。

 ### 確認して欲しいこと
 - 不備が御座いましたらご指摘願います。