### PR TITLE
リプライ機能（投稿）（もりお）

### DIFF
--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -3,8 +3,33 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Reply;
+use App\Post;
 
 class RepliesController extends Controller
 {
-    //
+    public function store(Request $request, $postId)
+    {
+        $request->validate([
+            'content' => 'required|max:1000',
+        ]);
+
+        $post = Post::findOrFail($postId);
+
+        // 自分の投稿にはリプライできないようにする
+        if ($post->user_id === Auth::id()) {
+            return redirect()->route('post.show', $postId)
+                ->with('error', '自分の投稿にはリプライできません。');
+        }
+
+        $reply = new Reply();
+        $reply->post_id = $postId;
+        $reply->user_id = Auth::id();
+        $reply->content = $request->content;
+        $reply->save();
+
+        return redirect()->route('post.show', $postId)
+            ->with('success', 'リプライを投稿しました！');
+    }
 }

--- a/app/Http/Controllers/RepliesController.php
+++ b/app/Http/Controllers/RepliesController.php
@@ -12,7 +12,7 @@ class RepliesController extends Controller
     public function store(Request $request, $postId)
     {
         $request->validate([
-            'content' => 'required|max:1000',
+            'content' => 'required|max:140',
         ]);
 
         $post = Post::findOrFail($postId);

--- a/database/migrations/2025_06_11_131521_create_replies_table.php
+++ b/database/migrations/2025_06_11_131521_create_replies_table.php
@@ -23,7 +23,7 @@ class CreateRepliesTable extends Migration
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
-
+    
 
     /**
      * Reverse the migrations.

--- a/resources/views/components/flash_message.blade.php
+++ b/resources/views/components/flash_message.blade.php
@@ -7,5 +7,9 @@
 @endif
 
 @if (session('error'))
-    <p>{{ session('error') }}</p>
+    <div>
+        <span style="background-color: #FFCCCC;">
+            {{ session('error') }}
+        </span>
+    </div>
 @endif

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -4,6 +4,7 @@
     @foreach ($posts as $post)  
         <div class="card mb-4" style="width: 700px;">
             <div class="card-body">
+                
                 {{-- ユーザ―情報 --}}
                 <div class="d-flex align-items-center mb-3">
                     <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
@@ -55,14 +56,15 @@
                     @endif
                 </div>
 
-                {{-- リプライ＋編集削除 --}}
+                {{-- リプライリンク＋編集削除 --}}
                 <div class="d-flex justify-content-between align-items-center mt-4">
-                    {{-- リプライ --}}
+                    
+                    {{-- リプライリンク --}}
                     <a href="{{ route('post.show', ['id' => $post->id]) }}" class="btn btn-outline-secondary btn-sm">
                         💬リプライを見る
                     </a>
 
-                    {{-- 編集・削除 --}}
+                    {{-- 編集・削除ボタン（投稿者のみ） --}}
                     @if (Auth::id() === $post->user_id)
                         <div class="d-flex">
                             <form method="POST" action="">
@@ -77,7 +79,9 @@
                             </a>
                         </div>
                     @endif
+
                 </div>
+
             </div>
         </div>
     @endforeach

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -56,15 +56,15 @@
                     @endif
                 </div>
 
-                {{-- リプライリンク＋編集削除 --}}
+                {{-- リプライ＋編集削除 --}}
                 <div class="d-flex justify-content-between align-items-center mt-4">
                     
-                    {{-- リプライリンク --}}
+                    {{-- リプライ --}}
                     <a href="{{ route('post.show', ['id' => $post->id]) }}" class="btn btn-outline-secondary btn-sm">
                         💬リプライを見る
                     </a>
 
-                    {{-- 編集・削除ボタン（投稿者のみ） --}}
+                    {{-- 編集・削除 --}}
                     @if (Auth::id() === $post->user_id)
                         <div class="d-flex">
                             <form method="POST" action="">
@@ -79,7 +79,6 @@
                             </a>
                         </div>
                     @endif
-
                 </div>
 
             </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,5 +1,5 @@
 @extends('layouts.app')
-
+    @include('commons.error_messages')
 @section('content')
     @include('components.flash_message')
 

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,115 +1,124 @@
 @extends('layouts.app')
 
 @section('content')
-@include('components.flash_message')
+    @include('components.flash_message')
 
-<div class="card mb-4" style="width: 700px;">
-    <div class="card-body">
-        {{-- ユーザ―情報 --}}
-        <div class="d-flex align-items-center mb-3">
-            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-            <div>
-                <a href="{{ route('user.show', ['id' => $post->user->id]) }}">{{ $post->user->name }}</a>
-                <small class="text-muted">
-                    投稿日: {{ optional($post->created_at)->diffForHumans() }}
-                    @if ($post->updated_at && $post->updated_at != $post->created_at)
-                        ／更新: {{ optional($post->updated_at)->diffForHumans() }}
-                    @endif
-                </small>
-            </div>
-        </div>
-       
-        {{-- 投稿内容 --}}
-        <div class="d-flex gap-3 mt-2">
-            <div class="flex-grow-1">
-                <p class="card-text mb-2">{{ $post->content }}</p>
-            </div>
-
-            {{-- 投稿画像 --}}
-            @if ($post->image_path)
-                <div class="mb-2" style="max-width: 200px;">
-                    <img 
-                        src="{{ asset($post->image_path) }}" 
-                        alt="投稿画像" 
-                        class="img-fluid mt-2" 
-                        style="max-height: 100px; object-fit: contain;"
-                        data-toggle="modal"
-                        data-target="#imageModal{{ $post->id }}"
-                    >
-                </div>
-
-                {{-- モーダル --}}
-                <div class="modal fade" id="imageModal{{ $post->id }}" tabindex="-1" role="dialog">
-                    <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title">画像表示</h5>
-                                <button type="button" class="close" data-dismiss="modal">
-                                    <span>&times;</span>
-                                </button>
-                            </div>
-                            <div class="modal-body text-center">
-                                <img src="{{ asset($post->image_path) }}" class="img-fluid" alt="拡大画像">
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            @endif
-        </div>
-
-        {{-- 編集・削除ボタン --}}
-        @if (Auth::id() === $post->user_id)
-            <div class="d-flex flex-wrap justify-content-end mt-3">
-                <form method="POST" action="">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-light p-1" onclick="return confirm('本当に削除しますか？')">
-                        <img src="{{ asset('images/icons/ゴミ箱のアイコン素材.png') }}" alt="削除" style="width: 20px; height: 20px;">
-                    </button>
-                </form>
-                <a href="{{ route('post.edit', $post->id) }}" class="btn btn-light p-1 ml-3">
-                    <img src="{{ asset('images/icons/鉛筆のアイコン素材.png') }}" alt="編集" style="width: 20px; height: 20px;">
-                </a>
-            </div>
-        @endif
-    </div>
-</div>
-
-
-{{-- リプライ一覧 --}}
-<h5 class="mt-4">リプライ一覧</h5>
-
-@forelse ($replies as $reply)
     <div class="card mb-4" style="width: 700px;">
         <div class="card-body">
-            {{-- ユーザー情報 --}}
+            {{-- ユーザ―情報 --}}
             <div class="d-flex align-items-center mb-3">
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
                 <div>
-                    <a href="{{ route('user.show', ['id' => $reply->user->id]) }}">{{ $reply->user->name }}</a>
+                    <a href="{{ route('user.show', ['id' => $post->user->id]) }}">{{ $post->user->name }}</a>
                     <small class="text-muted">
-                        投稿日: {{ optional($reply->created_at)->diffForHumans() }}
-                        @if ($reply->updated_at && $reply->updated_at != $reply->created_at)
-                            ／更新: {{ optional($reply->updated_at)->diffForHumans() }}
+                        投稿日: {{ optional($post->created_at)->diffForHumans() }}
+                        @if ($post->updated_at && $post->updated_at != $post->created_at)
+                            ／更新: {{ optional($post->updated_at)->diffForHumans() }}
                         @endif
                     </small>
                 </div>
             </div>
 
-            {{-- 本文 --}}
+            {{-- 投稿内容 --}}
             <div class="d-flex gap-3 mt-2">
                 <div class="flex-grow-1">
-                    <p class="card-text mb-2">{{ $reply->content }}</p>
+                    <p class="card-text mb-2">{{ $post->content }}</p>
+                </div>
+
+                {{-- 投稿画像 --}}
+                @if ($post->image_path)
+                    <div class="mb-2" style="max-width: 200px;">
+                        <img 
+                            src="{{ asset($post->image_path) }}" 
+                            alt="投稿画像" 
+                            class="img-fluid mt-2" 
+                            style="max-height: 100px; object-fit: contain;"
+                            data-toggle="modal"
+                            data-target="#imageModal{{ $post->id }}"
+                        >
+                    </div>
+
+                    {{-- モーダル --}}
+                    <div class="modal fade" id="imageModal{{ $post->id }}" tabindex="-1" role="dialog">
+                        <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title">画像表示</h5>
+                                    <button type="button" class="close" data-dismiss="modal">
+                                        <span>&times;</span>
+                                    </button>
+                                </div>
+                                <div class="modal-body text-center">
+                                    <img src="{{ asset($post->image_path) }}" class="img-fluid" alt="拡大画像">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                @endif
+            </div>
+
+            {{-- 編集・削除ボタン --}}
+            @if (Auth::id() === $post->user_id)
+                <div class="d-flex flex-wrap justify-content-end mt-3">
+                    <form method="POST" action="">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-light p-1" onclick="return confirm('本当に削除しますか？')">
+                            <img src="{{ asset('images/icons/ゴミ箱のアイコン素材.png') }}" alt="削除" style="width: 20px; height: 20px;">
+                        </button>
+                    </form>
+                    <a href="{{ route('post.edit', $post->id) }}" class="btn btn-light p-1 ml-3">
+                        <img src="{{ asset('images/icons/鉛筆のアイコン素材.png') }}" alt="編集" style="width: 20px; height: 20px;">
+                    </a>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    {{-- リプライ投稿フォーム --}}
+    @auth
+        <form action="{{ route('replies.store', $post->id) }}" method="POST" class="mt-4">
+            @csrf
+            <div class="form-group">
+                <textarea name="content" class="form-control" rows="3" placeholder="リプライ内容を入力してください">{{ old('content') }}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary mt-2">リプライを投稿</button>
+        </form>
+    @endauth
+
+    {{-- リプライ一覧 --}}
+    <h5 class="mt-4">リプライ一覧</h5>
+
+    @forelse ($replies as $reply)
+        <div class="card mb-4" style="width: 700px;">
+            <div class="card-body">
+                {{-- ユーザー情報 --}}
+                <div class="d-flex align-items-center mb-3">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
+                    <div>
+                        <a href="{{ route('user.show', ['id' => $reply->user->id]) }}">{{ $reply->user->name }}</a>
+                        <small class="text-muted">
+                            投稿日: {{ optional($reply->created_at)->diffForHumans() }}
+                            @if ($reply->updated_at && $reply->updated_at != $reply->created_at)
+                                ／更新: {{ optional($reply->updated_at)->diffForHumans() }}
+                            @endif
+                        </small>
+                    </div>
+                </div>
+
+                {{-- 本文 --}}
+                <div class="d-flex gap-3 mt-2">
+                    <div class="flex-grow-1">
+                        <p class="card-text mb-2">{{ $reply->content }}</p>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-@empty
-    <p class="text-muted mt-4">リプライはまだありません。</p>
-@endforelse
+    @empty
+        <p class="text-muted mt-4">リプライはまだありません。</p>
+    @endforelse
 
-
-{{-- ページネーション --}}
+    {{-- ページネーション --}}
     <div class="mt-4">
         {{ $replies->links('pagination::bootstrap-4') }}
     </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,5 +1,4 @@
 @extends('layouts.app')
-    @include('commons.error_messages')
 @section('content')
     @include('components.flash_message')
 
@@ -74,7 +73,7 @@
             @endif
         </div>
     </div>
-
+    @include('commons.error_messages')
     {{-- リプライ投稿フォーム --}}
     @auth
         <form action="{{ route('replies.store', $post->id) }}" method="POST" class="mt-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,3 +42,6 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 Route::get('/', 'PostsController@index')->name('post.index');
 Route::get('posts/{id}', 'PostsController@show')->name('post.show');
+
+// リプライ投稿（POST）
+Route::post('/posts/{post}/replies', 'RepliesController@store')->name('replies.store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::group(['middleware' => 'auth'], function () {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
         Route::put('{id}', 'PostsController@update')->name('post.update');
         Route::delete('{id}', 'PostsController@destroy')->name('post.destroy');
+        Route::post('{id}/replies', 'RepliesController@store')->name('replies.store');
     });
 
     Route::prefix('users')->group(function () {
@@ -42,6 +43,3 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 Route::get('/', 'PostsController@index')->name('post.index');
 Route::get('posts/{id}', 'PostsController@show')->name('post.show');
-
-// リプライ投稿（POST）
-Route::post('/posts/{post}/replies', 'RepliesController@store')->name('replies.store');


### PR DESCRIPTION
## issue
- Closes #1557

## 概要
- リプライ機能（投稿）を作成いたしました。

## 動作確認手順
- サイトにログインしていない状態で下記をご確認ください。
ユーザーの投稿詳細ページへ遷移していただき、リプライ投稿が出来ない状態であることをご確認ください。

- サイトにログインした状態で下記の1、2をご確認ください。
1.  投稿一覧の中の他のユーザーの投稿詳細ページへ遷移していただき、リプライ入力欄をご確認ください。リプライ入力欄よりリプライを投稿していただき、リプライ一覧にリプライ投稿内容が表示されていることをご確認ください。また、空欄の状態で投稿を行った場合、「contentは、必ず指定してください。」とエラー表示が出ることをご確認ください。更に、141文字以上の投稿で「contentは、140文字以下にしてください。」とエラー表示が出ることをご確認ください。

2. 投稿一覧の中の投稿者本人の投稿詳細ページに行き、リプライ入力欄よりリプライしていただくと、ユーザ情報欄の上に、エラーメッセージ「自分の投稿にはリプライできません。」と表示されることをご確認ください。また、空欄の状態で投稿を行った場合、「contentは、必ず指定してください。」とエラー表示が出ることをご確認ください。

## 考慮して欲しいこと
- 投稿者本人が投稿した際のエラーメッセージのバックの色の表示がされていませんでしたので、components > flash_message.blade.php を変更（無色 → ピンク色）いたしました。
- 投稿詳細画面への遷移ボタン名の "リプライを見る" ですが、リプライ入力欄が出来まして、少しボタン名に違和感を感じるようになりました。（前回の作業で自分が命名したのですが）次のチームミーティングでメンバーに伺って、名称を変更するか考えたいと思います。

## 確認して欲しいこと
- ご指摘いただきました、「リプライの文字制限数の変更」「空欄で投稿した場合、エラー表示されるように変更」、「ログインしていないと投稿できないようにするルーティングの設置」の部分の修正を行いました。
大変お忙しいところ誠に申し訳ございませんが、お手隙のお時間がございましたら、ご確認いただけますと幸いに存じます。
何とぞよろしくお願いいたします。