### PR TITLE
投稿フォーム、レビュー平均、クエリ・UIの整理などを統合(ちゃこ)

### DIFF
--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,6 +24,8 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
+            'shop_name' => 'required|string|max:100',
+            'address' => 'required|string|max:100',
             'content' => 'required|max:1000',
             'image' => 'nullable|image|max:2048', 
         ];
@@ -32,6 +34,8 @@ class PostRequest extends FormRequest
     public function attributes()
     {
         return [
+            'shop_name' => '整備工場名',
+            'address' => '住所',
             'content' => '投稿',
             'image' => '画像',
         ];

--- a/app/Post.php
+++ b/app/Post.php
@@ -34,23 +34,10 @@ class Post extends Model
         }
     }
 
-    // 投稿に対するリプライ評価の平均を計算
-    public function averageRatings()
+    // 論理削除されていないレビューの各評価項目の平均値を連想配列で返すアクセサ
+    public function getAverageRatingsAttribute()
     {
-        $replies = $this->replies()->whereNull('deleted_at');
-        $serviceAvg = $replies->avg('rating_service');
-        $costAvg    = $replies->avg('rating_cost');
-        $qualityAvg = $replies->avg('rating_quality');
-        $service = $serviceAvg ? round($serviceAvg, 1) : null;
-        $cost = $costAvg ? round($costAvg, 1) : null;
-        $quality = $qualityAvg ? round($qualityAvg, 1) : null;
-        $values = collect([$service, $cost, $quality])->filter();
-        $overall = $values->isNotEmpty() ? round($values->avg(), 1) : null;
-        return [
-            'service' => $service,
-            'cost'    => $cost,
-            'quality' => $quality,
-            'overall' => $overall,
-        ];
+        $reviews = $this->reviews()->whereNull('deleted_at')->get();
+        return Review::averageRatingsFromCollection($reviews);
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -33,4 +33,24 @@ class Post extends Model
             Storage::disk('public')->delete($this->image);
         }
     }
+
+    // 投稿に対するリプライ評価の平均を計算
+    public function averageRatings()
+    {
+        $replies = $this->replies()->whereNull('deleted_at');
+        $serviceAvg = $replies->avg('rating_service');
+        $costAvg    = $replies->avg('rating_cost');
+        $qualityAvg = $replies->avg('rating_quality');
+        $service = $serviceAvg ? round($serviceAvg, 1) : null;
+        $cost = $costAvg ? round($costAvg, 1) : null;
+        $quality = $qualityAvg ? round($qualityAvg, 1) : null;
+        $values = collect([$service, $cost, $quality])->filter();
+        $overall = $values->isNotEmpty() ? round($values->avg(), 1) : null;
+        return [
+            'service' => $service,
+            'cost'    => $cost,
+            'quality' => $quality,
+            'overall' => $overall,
+        ];
+    }
 }

--- a/app/Review.php
+++ b/app/Review.php
@@ -47,19 +47,18 @@ class Review extends Model
     }
 
     // 評価の平均を丸めて返す
-    public static function getRoundedAverage($collection, $key)
+    public static function getRoundedAverageFromCollection($collection, $key)
     {
         $average = $collection->avg($key);
         return $average ? round($average, 1) : null;
     }
 
     // 投稿に対するレビュー評価の平均を計算
-    public static function averageRatingsForPost(Post $post)
+    public static function averageRatingsFromCollection($reviews)
     {
-        $reviews = $post->reviews()->whereNull('deleted_at');
-        $service = self::getRoundedAverage($reviews, 'rating_service');
-        $cost    = self::getRoundedAverage($reviews, 'rating_cost');
-        $quality = self::getRoundedAverage($reviews, 'rating_quality');
+        $service = self::getRoundedAverageFromCollection($reviews, 'rating_service');
+        $cost    = self::getRoundedAverageFromCollection($reviews, 'rating_cost');
+        $quality = self::getRoundedAverageFromCollection($reviews, 'rating_quality');
         $values = collect([$service, $cost, $quality])->filter();
         $overall = $values->isNotEmpty() ? round($values->avg(), 1) : null;
         return [

--- a/database/migrations/2025_05_07_155851_create_posts_table.php
+++ b/database/migrations/2025_05_07_155851_create_posts_table.php
@@ -16,6 +16,8 @@ class CreatePostsTable extends Migration
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('shop_name', 100);
+            $table->string('address', 100);
             $table->text('content');
             $table->string('image')->nullable();
             $table->timestamps();

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -13,21 +13,25 @@ class PostsTableSeeder extends Seeder
     public function run()
     {
         $users = DB::table('users')->get();
-
-        //投稿内容は「今日の気分」と仮定しました
         foreach ($users as $user) {
             DB::table('posts')->insert([
                 [
                     'user_id' => $user->id,
-                    'content' => '今日はコーヒーが飲みたい',
+                    'shop_name' => 'コーヒー整備工場',
+                    'address' => '新潟県三条市カフェ通り1-1',
+                    'content' => 'コーヒー整備工場の接客はとても親切だ',
                 ],
                 [
                     'user_id' => $user->id,
-                    'content' => '今日の天気は晴れで気持ちがいい',
+                    'shop_name' => '青空モーターズ',
+                    'address' => '新潟県三条市晴れ町2-2',
+                    'content' => '青空モーターズは安価で安心な整備工場だ',
                 ],
                 [
                     'user_id' => $user->id,
-                    'content' => '今日のご飯はお肉にしよう！',
+                    'shop_name' => 'にくにくオート',
+                    'address' => '新潟県三条市焼肉通り3-3',
+                    'content' => 'にくにくオートは修理の技術がとても高くて素晴らしい',
                 ],
             ]);
         }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,1 +1,2 @@
+@import url("welcome.css");
 @import url("star-rating.css");

--- a/public/css/welcome.css
+++ b/public/css/welcome.css
@@ -1,0 +1,42 @@
+.welcome-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1rem 2.2rem;
+    font-size: 1.25rem;
+    border-radius: 50px;
+    font-weight: bold;
+    transition: all 0.3s ease;
+    text-decoration: none;
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.welcome-button-group {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin: 2rem 0;
+}
+
+.welcome-button i {
+    font-size: 1.4rem;
+}
+
+.welcome-button:hover {
+    transform: scale(1.05);
+    text-decoration: none;
+}
+
+.welcome-btn-about {
+    background-color: white;
+    color: #343a40;
+    border: 2px solid #343a40;
+}
+
+.welcome-btn-about:hover {
+    background-color: #343a40;
+    color: #fff;
+    border-color: #343a40;
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -34,6 +34,9 @@
                     </div>
                     <button type="submit" class="btn btn-primary mt-2">新規登録</button>
                 </form>
+                <div class="mt-2">
+                    <a href="{{ route('login') }}">ログインはこちら</a>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -9,6 +9,9 @@
             <ul class="navbar-nav">
                 @if (Auth::check())
                     <li class="nav-item">
+                        <a href="{{ route('posts.create') }}" class="nav-link text-light">投稿する</a>
+                    </li>
+                    <li class="nav-item">
                         <a href="" class="nav-link text-light">{{ Auth::user()->name }}</a>
                     </li>
                     <li class="nav-item">

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+@section('title', 'レビューを投稿')
+@section('content')
+    <div class="container mt-4 mb-5">
+        <h2 class="text-center mb-4"><i class="fas fa-wrench mr-1"></i>整備工場を投稿する</h2>
+        @include('commons.error_messages')
+        <form method="POST" action="{{ route('posts.store') }}" enctype="multipart/form-data">
+            @csrf
+            <div class="form-group w-75 mb-3">
+                <label for="shop_name" class="form-label">整備工場名</label>
+                <input type="text" id="shop_name" name="shop_name" class="form-control" value="{{ old('shop_name') }}">
+            </div>
+            <div class="form-group w-75 mb-3">
+                <label for="address" class="form-label">住所</label>
+                <input type="text" id="address" name="address" class="form-control" value="{{ old('address') }}">
+            </div>
+            <div class="form-group mb-3">
+                <label for="content" class="form-label">おすすめポイント</label>
+                <textarea id="content" name="content" class="form-control" rows="5" placeholder="例：接客・対応、料金、修理の仕上がりなど">{{ old('content') }}</textarea>
+            </div>
+            <div class="form-group mb-4">
+                <label for="image" class="form-label">画像をアップロード（任意）</label>
+                <input type="file" id="image" name="image" class="form-control-file">
+            </div>
+            <div class="text-left">
+                <button type="submit" class="btn btn-primary">投稿する</button>
+            </div>
+        </form>
+    </div>
+    <div class="container mb-5">
+        <h4 class="text-center fw-bold mb-4">
+            <i class="fas fa-clock me-2 text-secondary"></i> 新着投稿
+        </h4>
+        @include('posts.posts', ['posts' => $posts, 'keyword' => $keyword])
+    </div>
+@endsection

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -5,8 +5,8 @@
 <div class="row">
     @foreach ($posts as $post)
         <div class="col-md-4 mb-4">
-            <div class="card h-100 shadow-sm">
-                <div class="card-body">
+            <div class="card h-100 shadow-sm d-flex flex-column">
+                <div class="card-body flex-grow-1">
 
                     {{-- 👤 ユーザー情報 --}}
                     <div class="d-flex align-items-center mb-3">
@@ -32,7 +32,7 @@
                         </div>
                     </div>
 
-                    {{-- 📷 投稿画像（常に表示：投稿者が画像を投稿していない場合はデフォルト） --}}
+                    {{-- 📷 投稿画像 --}}
                     @php
                         $defaultImage = config('constants.no_image_path');
                         $imageUrl = $post->image
@@ -40,19 +40,16 @@
                             : asset($defaultImage);
                     @endphp
                     <a href="{{ route('posts.show', $post->id) }}">
-                    <img src="{{ $imageUrl }}"
-                        class="img-fluid rounded mb-3 w-100"
-                        style="height: 200px; object-fit: contain; background-color: #f8f9fa;"
-                        alt="投稿画像">
+                        <img src="{{ $imageUrl }}" class="img-fluid rounded mb-3 w-100" style="height: 200px; object-fit: contain; background-color: #f8f9fa;" alt="投稿画像">
                     </a>
-                    
-                    {{-- 評価（★） --}}
+
+                    {{-- ⭐ 評価 --}}
                     @php
                         $overall = $post->average_ratings['overall'] ?? null;
                     @endphp
                     <a href="{{ route('posts.show', $post->id) }}" style="text-decoration: none; color: inherit;">
                         <div class="mb-2">
-                            評価：
+                            <small class="text-muted">評価：</small>
                             @if (!empty($overall))
                                 <span class="fw-bold">{{ number_format($overall, 1) }}</span>
                                 <span class="star-rating">
@@ -84,27 +81,39 @@
                         </div>
                     </a>
 
-                    {{-- 📝 投稿内容 --}}
-                    <p class="card-text mb-2" style="max-height: 120px; overflow: hidden; text-overflow: ellipsis;">
+                    {{-- 🛠 店舗情報 --}}
+                    <a href="{{ route('posts.show', $post->id) }}" style="text-decoration: none; color: inherit;">
+                        <h5 class="card-title mb-1 font-weight-bold">
+                            <i class="fas fa-wrench mr-1"></i>{{ $post->shop_name }}
+                        </h5>
+                        <p class="text-muted small mb-2">
+                            <i class="fas fa-map-marker-alt mr-1"></i>{{ $post->address }}
+                        </p>
+                    </a>
+
+                    {{-- 💬 投稿内容 --}}
+                    <p class="card-text mb-2" style="max-height: 100px; overflow: hidden;">
                         <a href="{{ route('posts.show', $post->id) }}" style="color: #212529; text-decoration: none;">
-                           {{ Str::limit(strip_tags($post->content), 120, '... 続きを読む') }}
+                            {{ Str::limit(strip_tags($post->content), 120, '... 続きを読む') }}
                         </a>
                     </p>
-                    <p class="text-muted small mb-1">レビュー {{ $post->reviews_count }} 件</p>
-                    <p class="text-muted">{{ $post->created_at }}</p>
-                </div>
 
-                {{-- 🛠 編集・削除（投稿者のみ） --}}
-                @if (Auth::id() === $post->user_id)
-                    <div class="card-footer bg-white d-flex justify-content-between">
-                        <form method="POST" action="">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-sm btn-danger">削除</button>
-                        </form>
-                        <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
-                    </div>
-                @endif
+                    {{-- 🗓 投稿日・レビュー数 --}}
+                    <p class="text-muted small mb-1">レビュー {{ $post->reviews_count }} 件</p>
+                    <p class="text-muted small">{{ $post->created_at }}</p>
+
+                    {{-- ✏️ 編集・削除 --}}
+                    @if (Auth::id() === $post->user_id)
+                        <div class="mt-3 d-flex justify-content-between">
+                            <form method="POST" action="">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-sm btn-danger">削除</button>
+                            </form>
+                            <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-sm btn-primary">編集する</a>
+                        </div>
+                    @endif
+                </div>
             </div>
         </div>
     @endforeach

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -3,41 +3,56 @@
     <div class="container">
         <div class="w-75 mx-auto">
             <div class="mb-4 b-3">
-                <h4>{{ $post->user->name }} さんの投稿</h4>
-                <div class="alert alert-info">
-                    <strong>投稿内容：<br>
-                    <div class="text-break"> {{ $post->content }}</div>
-                    </strong>
-                    <small class="text-muted">{{ $post->created_at }}</small>
-                </div>
+                <h4 class="fw-bold border-bottom pb-2 mb-3">
+                    <i class="fas fa-user-circle me-2 text-secondary"></i> {{ $post->user->name }} さんの投稿
+                </h4>
                 @if ($averageRatings)
-                    <div class="mb-2">
-                        <h5 class="mb-1">
-                            平均評価：
-                            <span style="font-size: 1.5rem; color: #000;">
+                    <div class="mt-3 mb-3">
+                        <h6 class="fw-bold mb-1">平均評価</h6>
+                        <div class="d-flex align-items-center">
+                            <span class="me-1" style="font-size: 1.4rem; color: #000;">
                                 {{ $averageRatings['overall'] !== null ? number_format($averageRatings['overall'], 1) : '-' }}
                             </span>
-                            <span style="color: gold; font-size: 1.5rem;">
+                            <span style="color: gold; font-size: 1.4rem;">
                                 {{ $averageRatings['overall'] !== null ? '★' : '' }}
                             </span>
-                        </h5>
+                        </div>
                         <small class="text-muted">
-                            接客：{{ display_star_rating($averageRatings['service']) }}
-                            料金：{{ display_star_rating($averageRatings['cost']) }}
+                            接客：{{ display_star_rating($averageRatings['service']) }}／
+                            料金：{{ display_star_rating($averageRatings['cost']) }}／
                             技術：{{ display_star_rating($averageRatings['quality']) }}
                         </small>
                     </div>
                 @endif
+                <div class="p-4 border rounded bg-light mb-4">
+                    <h5 class="mb-3 text-break">
+                        <i class="fas fa-tools me-2 text-secondary"></i>
+                        <strong>{{ $post->shop_name }}</strong>
+                    </h5>
+                    <div class="mb-3">
+                        <p class="mb-0 text-break text-muted">
+                            <i class="fas fa-map-marker-alt me-2 text-secondary"></i>{{ $post->address }}
+                        </p>
+                    </div>
+
+                    <div class="mb-3">
+                        <div class="fw-bold text-dark mb-1">投稿内容：</div>
+                        <p class="mb-0 text-break">{{ $post->content }}</p>
+                    </div>
+
+                    <div class="text-end">
+                        <small class="text-muted">投稿日：{{ $post->created_at }}</small>
+                    </div>
+                </div>
                 @php
                     $defaultImage = config('constants.no_image_path');
                     $imageUrl = $post->image
                         ? asset('storage/' . $post->image)
                         : asset($defaultImage);
                 @endphp
-                <img src="{{ $imageUrl }}"
-                    class="img-fluid rounded mb-3 d-block mx-auto"
-                    style="max-height: 400px; object-fit: contain; background-color: #f8f9fa;"
-                    alt="投稿画像">
+                <div class="text-center">
+                    <img src="{{ $imageUrl }}" class="img-fluid rounded shadow-sm mb-3" style="max-height: 400px; object-fit: contain; background-color: #f8f9fa;" alt="投稿画像">
+                </div>
             </div>
             @include('commons.error_messages')
             @if (Auth::check() && Auth::id() !== $post->user_id)
@@ -94,9 +109,9 @@
             @else
                 @foreach ($reviews as $review)
                     <div
-                        class="card mb-3 {{ $latestReview && $review->id === $latestReview->id ? 'border border-info' : '' }}"
+                        class="card mb-3 {{ $latestReview && $review->id === $latestReview->id ? 'border border-dark' : '' }}"
                         @if ($latestReview && $review->id === $latestReview->id)
-                            style="background-color: #f0fafd;"
+                            style="background-color: #f8f9fa;"
                         @endif
                     >
                         <div class="card-body">
@@ -104,7 +119,7 @@
                                 <strong>
                                     {{ $review->user->name }}
                                     @if ($latestReview && $review->id === $latestReview->id)
-                                        <span class="badge border border-info text-info ms-2">最新</span>
+                                        <span class="badge border border-dark text-dark ms-2">最新</span>
                                     @endif
                                 </strong>
                                 <small class="text-muted">{{ $review->created_at }}</small>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -6,21 +6,21 @@
                 <h4 class="fw-bold border-bottom pb-2 mb-3">
                     <i class="fas fa-user-circle me-2 text-secondary"></i> {{ $post->user->name }} さんの投稿
                 </h4>
-                @if ($averageRatings)
+                @if ($post->average_ratings)
                     <div class="mt-3 mb-3">
                         <h6 class="fw-bold mb-1">平均評価</h6>
                         <div class="d-flex align-items-center">
                             <span class="me-1" style="font-size: 1.4rem; color: #000;">
-                                {{ $averageRatings['overall'] !== null ? number_format($averageRatings['overall'], 1) : '-' }}
+                                {{ $post->average_ratings['overall'] !== null ? number_format($post->average_ratings['overall'], 1) : '-' }}
                             </span>
                             <span style="color: gold; font-size: 1.4rem;">
-                                {{ $averageRatings['overall'] !== null ? '★' : '' }}
+                                {{ $post->average_ratings['overall'] !== null ? '★' : '' }}
                             </span>
                         </div>
                         <small class="text-muted">
-                            接客：{{ display_star_rating($averageRatings['service']) }}／
-                            料金：{{ display_star_rating($averageRatings['cost']) }}／
-                            技術：{{ display_star_rating($averageRatings['quality']) }}
+                            接客：{{ display_star_rating($post->average_ratings['service']) }}／
+                            料金：{{ display_star_rating($post->average_ratings['cost']) }}／
+                            技術：{{ display_star_rating($post->average_ratings['quality']) }}
                         </small>
                     </div>
                 @endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -37,27 +37,20 @@
         </form>
     </div>
 </div>
-
-{{-- 投稿フォーム（ログインユーザーのみ） --}}
-@if (Auth::check())
-    <div class="container mb-4">
-        <div class="text-center">
-            <form method="POST" action="{{ route('posts.store') }}" enctype="multipart/form-data" class="w-100">
-                @csrf
-                <div class="form-group">
-                    <textarea class="form-control" name="content" rows="3" placeholder="レビューを1000字以内で投稿">{{ old('content') }}</textarea>
-                </div>
-                <div class="form-group mt-2">
-                    <input type="file" name="image" class="form-control-file">
-                </div>
-                <div class="text-left mt-2">
-                    <button type="submit" class="btn btn-primary">投稿する</button>
-                </div>
-            </form>
-        </div>
-    </div>
-@endif
-
+<div class="welcome-button-group">
+    @if(Auth::check())
+        <a href="{{ route('posts.create') }}" class="welcome-button welcome-btn-about">
+            <i class="fas fa-pen mr-1"></i> 投稿する
+        </a>
+    @else
+        <a href="{{ route('register') }}" class="welcome-button welcome-btn-about">
+            <i class="fas fa-user-plus mr-1"></i> 無料登録で投稿
+        </a>
+    @endif
+    <a href="{{ url('/about') }}" class="welcome-button welcome-btn-about">
+        <i class="fas fa-user-circle mr-1"></i> 運営者紹介
+    </a>
+</div>
 {{-- エラーメッセージ --}}
 <div class="container mb-3">
     @include('commons.error_messages')

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,7 @@
 Route::get('/', 'PostsController@index');
 
 // 投稿詳細ページ
-Route::get('posts/{post}', 'PostsController@show')->name('posts.show');
+Route::get('post/{id}', 'PostsController@show')->name('posts.show');
 
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('register');
@@ -38,6 +38,7 @@ Route::group(['middleware' => 'auth'], function () {
     });
     // 新規投稿、編集、更新、削除
     Route::prefix('posts')->group(function () {
+        Route::get('create', 'PostsController@create')->name('posts.create');
         Route::post('', 'PostsController@store')->name('posts.store');
         Route::delete('{id}', 'PostsController@destroy')->name('posts.delete');
         Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit'); 
@@ -59,4 +60,3 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('users/{id}/followings', 'UsersController@followings')->name('users.followings');
     Route::get('users/{id}/followers', 'UsersController@followers')->name('users.followers');  
 });
-


### PR DESCRIPTION
## issue
- なし

## 概要
- 投稿フォームの作成に加えて、投稿一覧・詳細画面のUIおよびレビュー関連のロジックを整理しました。
- ご指摘のあった、PostsControllerのcreateメソッドでデータベースに何度もアクセスしていた問題を修正するとともに、indexメソッドとshowメソッドにも同様の問題があったため対応しています。
- 投稿に紐づくレビュー評価の平均値を$post->average_ratingsで取得できるようにアクセサを導入し、ロジックを統一しています。
- 全て動作確認済みです

## 動作確認手順
1. トップページから投稿フォームにアクセスし、新規投稿を作成
2. 投稿内容（整備工場名・住所・おすすめポイント・画像）が保存され、トップページに反映されるか確認
3. 投稿詳細ページ /post/{id} にて投稿内容と画像、平均評価が正しく表示されるか確認
4. 評価が表示されない場合もレイアウトが崩れないことを確認
5. 投稿一覧のカード表示に崩れがないか確認
6. ヘッダーの「投稿する」ボタンからも投稿フォームに遷移できるか確認
7. 削除済み（論理削除）のレビューはカウント・平均に含まれないことを確認

## 考慮してほしいこと
- 投稿モデルにアクセサを追加しています（getAverageRatingsAttribute()）
- withCount(['reviews' => ...]) にて論理削除されたレビューを除外しています

## 確認してほしいこと
- 投稿フォームが問題なく動作しているか
- 投稿詳細ページで平均評価が正しく表示されているか
- 投稿一覧ページでも $post->average_ratings で値が取得できているか
- クエリ数の無駄が減っているか
- UI・レイアウトが破綻していないか