### PR TITLE
投稿編集フォームに整備工場名と住所の項目を追加(ちゃこ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -124,6 +124,6 @@ class PostsController extends Controller
             $post->image = $path;
         }
         $post->save(); //postテーブルに保存
-        return redirect('/');              
+        return redirect()->route('posts.show', $post->id);
     }
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,24 +1,40 @@
 @extends('layouts.app')
+@section('title', '投稿を編集')
 @section('content')
-<h2 class="mt-5">投稿を編集する</h2>
-@include('commons.error_messages')
-
-    <form method="POST" action="{{ route('posts.update', $post->id) }}" enctype="multipart/form-data" class="w-100">
-        @csrf
-        @method('PUT')
-        <div class="form-group">
-            <textarea id="content" class="form-control" name="content" rows="">{{ old('content',$post->content) }}</textarea>   
-        </div>
-        @if ($post->image)
-        <div class="mb-3">
-            <p>現在の画像：</p>
-            <img src="{{ asset('storage/' . $post->image) }}" alt="投稿画像" style="max-width: 200px;">
-        </div>
-        @endif
-        <div class="form-group">
-            <label for="image">画像を変更する</label>
-            <input type="file" class="form-control-file" name="image" id="image">
-        </div>
-        <button type="submit" class="btn btn-primary">更新する</button>
-    </form>
+    <div class="container mt-4 mb-5">
+        <h2 class="text-center mb-4"><i class="fas fa-edit mr-1"></i>投稿内容を編集する</h2>
+        @include('commons.error_messages')
+        <form method="POST" action="{{ route('posts.update', $post->id) }}" enctype="multipart/form-data">
+            @csrf
+            @method('PUT')
+            <div class="form-group w-75 mb-3">
+                <label for="shop_name" class="form-label">整備工場名</label>
+                <input type="text" id="shop_name" name="shop_name" class="form-control" 
+                       value="{{ old('shop_name', $post->shop_name) }}">
+            </div>
+            <div class="form-group w-75 mb-3">
+                <label for="address" class="form-label">住所</label>
+                <input type="text" id="address" name="address" class="form-control" 
+                       value="{{ old('address', $post->address) }}">
+            </div>
+            <div class="form-group mb-3">
+                <label for="content" class="form-label">おすすめポイント</label>
+                <textarea id="content" name="content" class="form-control" rows="5" 
+                          placeholder="例：接客・対応、料金、修理の仕上がりなど">{{ old('content', $post->content) }}</textarea>
+            </div>
+            @if ($post->image)
+                <div class="mb-3">
+                    <p>現在の画像：</p>
+                    <img src="{{ asset('storage/' . $post->image) }}" alt="投稿画像" style="max-width: 200px;">
+                </div>
+            @endif
+            <div class="form-group mb-4">
+                <label for="image" class="form-label">画像を変更する（任意）</label>
+                <input type="file" id="image" name="image" class="form-control-file">
+            </div>
+            <div class="text-left">
+                <button type="submit" class="btn btn-primary">更新する</button>
+            </div>
+        </form>
+    </div>
 @endsection


### PR DESCRIPTION
## issue
- なし

## 概要
- 投稿編集画面に「整備工場名（shop_name）」と「住所（address）」の編集項目を追加しました
- updateメソッドのreturnをredirect()->route('posts.show', $post->id);に変更しました
- 動作確認済みです。

## 動作確認手順
1. ログイン後、投稿一覧から投稿編集画面に遷移
2. 「整備工場名」「住所」「おすすめポイント」「画像」の各項目を編集
3. フォームを送信し、編集内容が投稿詳細にて、正常に保存・表示されていることを確認
4. 投稿一覧でも編集内容が正常に表示されていることを確認
5. バリデーションエラー（未入力・文字数超過など）も表示されることを確認
(「整備工場名」「住所」は100文字、「おすすめポイント」は1000文字制限としています)

## 考慮してほしいこと
- create.blade.php に合わせて edit.blade.php のデザインを統一しています
- 更新した後のリダイレクト先を投稿詳細に変更しました（変更した内容をすぐに確認できるようにするため）

## 確認してほしいこと
- 投稿編集画面に整備工場名・住所の入力欄が表示されていること
- 各項目の編集が正常に反映されること
- バリデーションが機能していること
- UIに不自然な箇所がないか