### PR TITLE
投稿へのタグ追加機能（智美）

### DIFF
--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Tag;
+
+class TagController extends Controller
+{
+    public function search($id)
+    {
+        $tag = Tag::findOrFail($id);
+        $posts = $tag->posts()->with('user', 'tags')->latest()->paginate(10);
+
+        return view('tags.search', compact('tag', 'posts'));
+    }
+
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -28,4 +28,9 @@ class Post extends Model
         'image_path',
     ];
 
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = ['name'];
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class);
+    }
+}

--- a/database/migrations/2025_06_16_001216_create_tags_table.php
+++ b/database/migrations/2025_06_16_001216_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->unique(); // タグ名を保存
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/database/migrations/2025_06_16_002531_create_post_tag_table.php
+++ b/database/migrations/2025_06_16_002531_create_post_tag_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->unsignedBigInteger('post_id');
+            $table->unsignedBigInteger('tag_id');
+
+            // 外部キー制約
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
+
+            // 複合主キーで重複防止
+            $table->primary(['post_id', 'tag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post_tag');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(TagSeeder::class,);
     }
 }

--- a/database/seeds/TagSeeder.php
+++ b/database/seeds/TagSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Tag;
+
+class TagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $tags = [
+            'Laravel',
+            'PHP',
+            'JavaScript',
+            'Git',
+            'エラー',
+            'bash',
+            'ターミナル',
+            '学習記録',
+            'MVC',
+        ];
+
+        foreach ($tags as $tagName) {
+            Tag::firstOrCreate(['name' => $tagName]);
+        }
+    }
+}

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -32,6 +32,18 @@
             {{-- プレビュー画像 --}}
             <img id="preview" src="#" alt="画像プレビュー" class="img-fluid mb-2" style="display: none; max-height: 100px;">
         </div>
+        
+        {{-- タグの選択 --}}
+        <div class="form-group mt-4">
+            <label>タグを選択：</label><br>
+            @foreach ($tags as $tag)
+                <label class="mr-3">
+                    <input type="checkbox" name="tags[]" value="{{ $tag->id }}"
+                        {{ in_array($tag->id, $selectedTagIds ?? []) ? 'checked' : '' }}>
+                    {{ $tag->name }}
+                </label>
+            @endforeach
+        </div>
         <button type="submit" class="btn btn-primary mt-5 mb-5">更新する</button>
     </form>
 @endsection

--- a/resources/views/posts/form.blade.php
+++ b/resources/views/posts/form.blade.php
@@ -5,6 +5,18 @@
             <div class="form-group mb-3">
                 <textarea name="content" id="content" class="form-control" rows="3" placeholder="いまどうしてる？">{{ old('content') }}</textarea>
             </div>
+
+            {{-- タグ選択 --}}
+            <div class="form-group mb-3 text-left">
+                <label>タグを選択:</label><br>
+                @foreach ($tags as $tag)
+                    <label class="mr-3">
+                        <input type="checkbox" name="tags[]" value="{{ $tag->id }}"
+                            {{ (is_array(old('tags')) && in_array($tag->id, old('tags'))) ? 'checked' : '' }}>
+                        {{ $tag->name }}
+                    </label>
+                @endforeach
+            </div>
             {{-- 画像添付--}}
             <div class="form-group mb-3">
                 <div class="d-flex align-items-center">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -55,6 +55,17 @@
                     @endif
                 </div>
 
+                {{-- タグ表示（リンク付き） --}}
+                @if ($post->tags->isNotEmpty())
+                    <div class="mb-2 text-left">
+                        @foreach ($post->tags as $tag)
+                            <a href="{{ route('tags.search', ['id' => $tag->id]) }}" class="badge badge-pill badge-info">
+                                #{{ $tag->name }}
+                            </a>
+                        @endforeach
+                    </div>
+                @endif
+
                 {{-- リプライ＋編集削除 --}}
                 <div class="d-flex justify-content-between align-items-center mt-4">
                     {{-- リプライ --}}

--- a/resources/views/tags/search.blade.php
+++ b/resources/views/tags/search.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h2 class="text-center mt-4 mb-4">#{{ $tag->name }} の投稿</h2>
+
+    @if ($posts->isEmpty())
+        <p class="text-center text-muted">このタグにはまだ投稿がありません。</p>
+    @else
+        <div class="mx-auto" style="max-width: 700px;">
+            @include('posts.posts', ['posts' => $posts])
+        </div>
+    @endif
+</div>
+@endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -16,12 +16,25 @@
          </div>
       </div>
     </form>
+
+    {{-- タグ一覧 --}}
+    <div class="mb-4 text-center">
+        <div class="d-inline-flex flex-wrap justify-content-center">
+            @foreach ($tags as $tag)
+                <a href="{{ route('tags.search', ['id' => $tag->id]) }}"
+                class="btn btn-info m-2 px-2 py-0"
+                style="border: 1px solid #17A2B8; color: #17A2B8; border-radius: 20px; background-color: white; font-size: 14px;">
+                    #{{ $tag->name }}
+                </a>
+            @endforeach
+        </div>
+    </div>
+
     @if (Auth::check())
         <div class="w-75 m-auto">@include('commons.error_messages')</div> 
         <div class="text-center mb-3">
             @include('posts.form')
         </div>
     @endif
-    @include('posts.posts', ['posts' => $posts])
-    </div>    
+    @include('posts.posts', ['posts' => $posts]) 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,3 +42,6 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 Route::get('/', 'PostsController@index')->name('post.index');
 Route::get('posts/{id}', 'PostsController@show')->name('post.show');
+
+// タグ
+Route::get('/tags/{id}', 'TagController@search')->name('tags.search');


### PR DESCRIPTION
## issue
- Closes

## 概要
- 投稿へのタグ追加機能

## 動作確認手順
- [http://localhost:8080/](url)へアクセス
検索フォーム下部のタグ一覧から検索したいタグをクリック→選択したタグの投稿一覧へ遷移
投稿に表示されているタグからも該当タグの一覧画面に遷移
- ログイン後
新規投稿画面よりタグ選択（複数可）→投稿にタグ表示
編集画面→選択したタグにチェックが入った状態で表示される→タグの変更し更新

## 考慮してほしいこと
検索フォームとは別にタグごとの検索ができるようにしてあります。

## 確認してほしいこと
投稿へのタグ追加機能とはこういうことであっていましたでしょうか？