### PR TITLE
フォロワーランキング機能レイアウト修正

### DIFF
--- a/resources/views/users/follower_ranking.blade.php
+++ b/resources/views/users/follower_ranking.blade.php
@@ -1,34 +1,39 @@
-<h5>フォロワーランキング</h5>
+<div class="card mx-auto" style="max-width: 350px;">
+    <div class="card-body p-4">
+        <h5 class="text-center mb-4">フォロワーランキング</h5>
+        @php
+            $prevCount = null;
+            $displayRank = 0;
+        @endphp
 
-@php
-    $prevCount = null;
-    $displayRank = 0;
-@endphp
+        @foreach ($rankingUsers as $index => $user)
+            @php
+                if ($user->followers_count !== $prevCount) {
+                    $displayRank = $index + 1;
+                    $prevCount = $user->followers_count;
+                }
+                $rankStyle = 'display: inline-block; width: 30px; height: 30px; text-align: center; line-height: 30px; vertical-align: middle;';
+            @endphp
+            <div class="d-flex align-items-center justify-content-center mb-2">
+                {{-- ランキング表示（1位から3位はアイコン、それ以降は数字）--}}
+                @if ($displayRank === 1)
+                    <img src="{{ asset('images/icons/rank1.png') }}" alt="1位" style="width: 30px; height: 30px;">
+                @elseif ($displayRank === 2)
+                    <img src="{{ asset('images/icons/rank2.png') }}" alt="2位" style="width: 30px; height: 30px;">
+                @elseif ($displayRank === 3)
+                    <img src="{{ asset('images/icons/rank3.png') }}" alt="3位" style="width: 30px; height: 30px;">
+                @else
+                    <span class="mr-2" style="{{ $rankStyle }}">{{ $displayRank }}位</span>
+                @endif
 
-@foreach ($rankingUsers as $index => $user)
-    @php
-        if ($user->followers_count !== $prevCount) {
-            $displayRank = $index + 1;
-            $prevCount = $user->followers_count;
-        }
-    @endphp
-    <div class="d-flex align-items-center mb-2">
-        {{-- ランキング表示（1位から3位はアイコン、それ以降は数字）--}}
-        @if ($displayRank === 1)
-            <img src="{{ asset('images/icons/rank1.png') }}" alt="1位" style="width: 30px; height: 30px;">
-        @elseif ($displayRank === 2)
-            <img src="{{ asset('images/icons/rank2.png') }}" alt="2位" style="width: 30px; height: 30px;">
-        @elseif ($displayRank === 3)
-            <img src="{{ asset('images/icons/rank3.png') }}" alt="3位" style="width: 30px; height: 30px;">
-        @else
-            <span class="mr-2" style="width: 30px;">{{ $displayRank }}位</span>
-        @endif
-
-        {{-- ユーザー情報 --}}
-        <div class="ml-2">
-            <strong>{{ $user->name }}</strong><br>
-            フォロワー数：{{ $user->followers_count }}人
-        </div>
+                {{-- ユーザー情報 --}}
+                <div class="ml-2">
+                    <strong>{{ $user->name }}</strong><br>
+                    フォロワー数：{{ $user->followers_count }}人
+                </div>
+            </div>
+        @endforeach
     </div>
-@endforeach
+</div>       
+
             


### PR DESCRIPTION
## 概要
- ランキングを表示している部分をカードで囲い、中央揃えにし、アイコン部分とアイコン無しの部分の位置が微妙にずれていたのを修正しました！

## 動作確認手順
- トップページのランキング表示にcard-bodyが入っているのを確認
- ランキング表示が中央に来ているのを確認
- 順位のアイコンとアイコン無しの部分のずれがないか確認

## 確認して欲しいこと
- 変更した見た目は問題ないか