### PR TITLE
ヒーロー画像の修正と別箇所の修正（智美）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -58,7 +58,7 @@ class UsersController extends Controller
 
         Auth::logout();
         
-        return redirect()->route('posts.index')->with('success', '退会が完了しました！');
+        return redirect()->route('post.index')->with('success', '退会が完了しました！');
     }
 
     public function follows($id)

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,18 +1,3 @@
-/* ヒーローセクション */
-.hero-section {
-    position: relative;
-    background: url('../images/hero2.jpg') no-repeat center center;
-    background-size: cover;
-    width: 100%;
-    height: 60vh;
-    min-height: 300px;
-    margin-bottom: 2rem;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
 /* オーバーレイ */
 .hero-overlay {
     position: absolute;

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,3 +1,4 @@
+@include('components.flash_message')
 @if ($posts->isEmpty())
     <p class="text-center text-muted mt-4">一致する投稿はありませんでした。</p>
 @else

--- a/resources/views/users/follower_ranking.blade.php
+++ b/resources/views/users/follower_ranking.blade.php
@@ -17,18 +17,20 @@
             <div class="d-flex align-items-center justify-content-center mb-2">
                 {{-- ランキング表示（1位から3位はアイコン、それ以降は数字）--}}
                 @if ($displayRank === 1)
-                    <img src="{{ asset('images/icons/rank1.png') }}" alt="1位" style="width: 30px; height: 30px;">
+                    <img class="mr-3" src="{{ asset('images/icons/rank1.png') }}" alt="1位" style="width: 40px; height: 40px;">
                 @elseif ($displayRank === 2)
-                    <img src="{{ asset('images/icons/rank2.png') }}" alt="2位" style="width: 30px; height: 30px;">
+                    <img class="mr-3" src="{{ asset('images/icons/rank2.png') }}" alt="2位" style="width: 40px; height: 40px;">
                 @elseif ($displayRank === 3)
-                    <img src="{{ asset('images/icons/rank3.png') }}" alt="3位" style="width: 30px; height: 30px;">
+                    <img class="mr-3" src="{{ asset('images/icons/rank3.png') }}" alt="3位" style="width: 40px; height: 40px;">
                 @else
-                    <span class="mr-2" style="{{ $rankStyle }}">{{ $displayRank }}位</span>
+                    <span class="mr-3" style="{{ $rankStyle }}">{{ $displayRank }}位</span>
                 @endif
 
                 {{-- ユーザー情報 --}}
-                <div class="ml-2">
-                    <strong>{{ $user->name }}</strong><br>
+                <div>
+                    <a href="{{ route('user.show', ['id' => $user->id]) }}" class="ml-2 text-dark">
+                        <strong>{{ $user->name }}</strong><br>
+                    </a>
                     フォロワー数：{{ $user->followers_count }}人
                 </div>
             </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -3,7 +3,22 @@
     {{-- ▼ container の外にヒーロー画像を出すため、直接ここで閉じてから再開 --}}
     </div> {{-- ← layouts.app で開いている .container を一時閉じる --}}
 
-    <div class="hero-section">
+    {{-- ヒーロー画像 --}}
+    <div style="
+        position: relative;
+        background-image: url('{{ asset('images/hero2.jpg') }}');
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
+        width: 100%;
+        height: 60vh;
+        min-height: 300px;
+        margin-bottom: 2rem;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;">
+
         <div class="hero-overlay"></div>
 
         <div>


### PR DESCRIPTION
## issue
- Closes

## 概要
- ヒーロー画像の修正と別箇所の修正

## 動作確認手順
- [http://localhost:8080/](url)にアクセス
トップ画面確認

## 考慮してほしいこと
ヒーロー画像以外に下記2件修正しました。
・退会後に遷移するルートの命名が違ったので修正
・フォローランキングのユーザー名クリックでユーザー詳細へ遷移するように修正（レイアウト調整も）

## 確認してほしいこと
ヒーロー画像のcssをbladeに戻して、assetでファイル書きました。
これで大丈夫でしょうか？