### PR TITLE
レイアウトの修正（智美）

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,7 +5,7 @@
     <h1><i class="fab fa-telegram fa-lg pr-3"></i>寺子屋＠プログラミング</h1>
 </div>
 <div class="text-center mt-3">
-    <p class="text-left d-inline-block">ログインすると投稿で<br>コミュニケーションができるようになります。</p>
+    <p class="text-center d-inline-block">ログインすると投稿で<br>コミュニケーションができるようになります。</p>
 </div>
 <div class="text-center">
     <h3 class="login_title text-left d-inline-block mt-5">ログイン</h3>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,6 +9,17 @@
     </head>
     <body>
         @include('commons.header')
+
+        {{-- ▼ フラッシュメッセージ（退会完了時のみ表示） --}}
+        @if (session('success') === '退会が完了しました！')
+            <div class="alert alert-warning alert-dismissible fade show text-center mb-0 rounded-0" role="alert">
+                {{ session('success') }}
+                <button type="button" class="close" data-dismiss="alert" aria-label="閉じる">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        @endif
+
         <div class="container">  
             @yield('content')
         </div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,4 +1,3 @@
-@include('components.flash_message')
 @if ($posts->isEmpty())
     <p class="text-center text-muted mt-4">一致する投稿はありませんでした。</p>
 @else
@@ -77,22 +76,22 @@
                     
                     {{-- リプライ --}}
                     <a href="{{ route('post.show', ['id' => $post->id]) }}" class="btn btn-outline-secondary btn-sm">
-                        💬リプライを見る
+                        💬リプライ
                     </a>
 
                     {{-- 編集・削除 --}}
                     @if (Auth::id() === $post->user_id)
                         <div class="d-flex">
+                            <a href="{{ route('post.edit', $post->id) }}" class="btn btn-light p-1">
+                                <img src="{{ asset('images/icons/鉛筆のアイコン素材.png') }}" alt="編集" style="width: 20px; height: 20px;">
+                            </a>
                             <form method="POST" action="">
                                 @csrf
                                 @method('DELETE')
-                                <button type="submit" class="btn btn-light p-1" onclick="return confirm('本当に削除しますか？')">
+                                <button type="submit" class="btn btn-light p-1 ml-3" onclick="return confirm('本当に削除しますか？')">
                                     <img src="{{ asset('images/icons/ゴミ箱のアイコン素材.png') }}" alt="削除" style="width: 20px; height: 20px;">
                                 </button>
                             </form>
-                            <a href="{{ route('post.edit', $post->id) }}" class="btn btn-light p-1 ml-3">
-                                <img src="{{ asset('images/icons/鉛筆のアイコン素材.png') }}" alt="編集" style="width: 20px; height: 20px;">
-                            </a>
                         </div>
                     @endif
                 </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,12 +1,12 @@
 @extends('layouts.app')
 @section('content')
-    @include('components.flash_message')
+@include('components.flash_message')
 
     <div class="card mb-4" style="width: 700px;">
         <div class="card-body">
             {{-- ユーザ―情報 --}}
             <div class="d-flex align-items-center mb-3">
-                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
+                <img class="mr-2 rounded-circle" src="{{ $post->user->avatar_image_url }}" width="55" height="55" style="object-fit: cover;" alt="ユーザのアバター画像">
                 <div>
                     <a href="{{ route('user.show', ['id' => $post->user->id]) }}">{{ $post->user->name }}</a>
                     <small class="text-muted">
@@ -82,7 +82,7 @@
             @endif
         </div>
     </div>
-    @include('components.flash_message')
+
     {{-- リプライ投稿フォーム --}}
     @auth
         <form action="{{ route('replies.store', $post->id) }}" method="POST" class="mt-4">
@@ -102,7 +102,7 @@
             <div class="card-body">
                 {{-- ユーザー情報 --}}
                 <div class="d-flex align-items-center mb-3">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 55) }}" alt="ユーザのアバター画像">
+                    <img class="mr-2 rounded-circle" src="{{ $reply->user->avatar_image_url }}" width="55" height="55" style="object-fit: cover;" alt="ユーザのアバター画像">
                     <div>
                         <a href="{{ route('user.show', ['id' => $reply->user->id]) }}">{{ $reply->user->name }}</a>
                         <small class="text-muted">
@@ -125,13 +125,17 @@
                 @if (Auth::id() === $reply->user_id)
                     <div class="d-flex justify-content-end mt-2 gap-2">
                         {{-- 編集ボタン --}}
-                        <a href="{{ route('replies.edit', [$post->id, $reply->id]) }}" class="btn btn-sm btn-outline-secondary mr-2">編集</a>
+                        <a href="{{ route('replies.edit', [$post->id, $reply->id]) }}" class="btn btn-light p-1">
+                            <img src="{{ asset('images/icons/鉛筆のアイコン素材.png') }}" alt="編集" style="width: 20px; height: 20px;">
+                        </a>
 
                         {{-- 削除フォーム --}}
                         <form method="POST" action="{{ route('replies.destroy', [$post->id, $reply->id]) }}" onsubmit="return confirm('本当に削除しますか？')">
                             @csrf
                             @method('DELETE')
-                            <button type="submit" class="btn btn-sm btn-danger">削除</button>
+                            <button type="submit" class="btn btn-light p-1 ml-3">
+                                <img src="{{ asset('images/icons/ゴミ箱のアイコン素材.png') }}" alt="削除" style="width: 20px; height: 20px;">
+                            </button>
                         </form>
                     </div>
                 @endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -9,7 +9,7 @@
                 @include('follow.follow_button', ['user' => $user])
             </div>
             <div class="card-body text-center px-4 py-0">
-                <img class="rounded-circle my-5" src="{{ $user->avatar_image_url }}" width="180" height="180" style="object-fit: cover;" alt="ユーザのアバター画像">
+                <img class="rounded-circle my-5" src="{{ $user->avatar_image_url }}" width="250" height="250" style="object-fit: cover;" alt="ユーザのアバター画像">
 
                 @if (Auth::check() && Auth::id() === $user->id)
                     {{-- アイコン編集リンク --}}
@@ -38,7 +38,7 @@
             {{-- フォローフォロワーの一覧表示 --}}
             @foreach ($followers as $follower)
                 <div class="media mb-3">
-                    <img class="mr-3 rounded-circle" src="{{ Gravatar::src($follower->email, 70) }}" alt="アイコン">
+                    <img class="mr-3 rounded-circle" src="{{ $follower->avatar_image_url }}" width="70" height="70" style="object-fit: cover;" alt="アイコン">
                     <div class="media-body">
                         <h5 class="mt-0">
                             <a href="{{ route('user.show', $follower->id) }}">{{ $follower->name }}</a>


### PR DESCRIPTION
## issue
- Closes

## 概要
- レイアウトの修正

## 動作確認手順
[http://localhost:8080](url)へアクセス
- ユーザーアバター変更時に関連する箇所（投稿・リプライ・フォロー・タイムライン）に反映
- 退会後、フラッシュメッセージをTOP画面上部に表示
- ログイン画面のサブタイトルを中央に表示
- リプライ一覧の編集・削除ボタンを投稿で使用しているものに統一

## 考慮してほ退会しいこと
変更内容を書き出したつもりですが、抜けているところがあったらすみません。
また、退会後のフラッシュメッセージですが、場所を統一しようと思ったのですが、新規投稿の上に出そうと思うと、ログイン状態から外れてしまう為、表示されないので、今回は、単独で表示させるようにしました。

## 確認してほしいこと
上記、フラッシュメッセージの件ですが、この対応でよかったでしょうか？
