### PR TITLE
画像表示の修正と他2件の修正（智美）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -120,8 +120,8 @@ class UsersController extends Controller
             }
 
             // 新しい画像保存
-            $path = $request->file('avatar')->store('public/avatars');
-            $user->avatar = str_replace('public/', '', $path);
+            $path = $request->file('avatar')->store('avatars', 'public');
+            $user->avatar = $path;
             $user->save();
 
             return redirect()->route('user.show', $user->id)->with('success', 'アイコンを変更しました');

--- a/resources/views/commons/footer.blade.php
+++ b/resources/views/commons/footer.blade.php
@@ -1,5 +1,5 @@
 <footer class="mt-5">
     <nav class="navbar navbar-dark bg-info justify-content-center">
-        <span class="navbar-brand">©Gut Familie, All rights reserved.</span>
+        <span class="navbar-brand">©Terakoya@Programming 2025</span>
     </nav>
 </footer>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -8,30 +8,7 @@
         <div class="form-group mt-5">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content', $post->content) }}</textarea>
         </div>
-        {{-- 画像の表示 --}}
-        @if ($post->image_path)
-        <div class="mt-4">
-            <p>現在の画像：</p>
-            <img src="{{ asset($post->image_path) }}" alt="投稿画像" style="max-width: 100px;">
-        </div>
-        @endif
 
-        {{-- 画像のアップロード --}}
-        <div class="form-group mt-4">
-            <label class="d-block mb-2">画像を変更する</label>
-            <div class="d-flex align-items-center mb-2">
-                {{-- アイコン --}}
-                <label for="image" style="cursor: pointer;" class="mb-0 mr-2 d-flex align-items-center">
-                    <img src="{{ asset('images/icons/写真アイコン4.png') }}" alt="画像を選択" style="width: 32px; height: 32px;">
-                </label>
-                {{-- ファイル名表示 --}}
-                <span id="file-name" class="text-muted" style="font-size: 0.9rem; line-height: 32px; height: 32px;"></span>
-            </div>
-            <input type="file" name="image" id="image" class="d-none" accept="image/*">
-            {{-- プレビュー画像 --}}
-            <img id="preview" src="#" alt="画像プレビュー" class="img-fluid mb-2" style="display: none; max-height: 100px;">
-        </div>
-        
         {{-- タグの選択 --}}
         <div class="form-group mt-4">
             <label>タグを選択：</label><br>
@@ -43,7 +20,45 @@
                 </label>
             @endforeach
         </div>
-        <button type="submit" class="btn btn-primary mt-5 mb-5">更新する</button>
+        {{-- 画像の表示 --}}
+        @if ($post->image_path)
+            <div class="mt-4">
+                <p>現在の画像：</p>
+                <div class="d-flex align-items-center">
+                    <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿画像" style="max-width: 100px;">
+                </div>
+            </div>
+        @endif
+
+        {{-- 画像のアップロード --}}
+        <div class="form-group mt-4">
+            <label class="d-block mb-2">画像を変更する</label>
+            <div class="d-flex align-items-center justify-content-between mt-4 mb-2">
+                <div class="d-flex align-items-center mb-2">
+                    {{-- アイコン --}}
+                    <label for="image" style="cursor: pointer;" class="mb-0 mr-2 d-flex align-items-center">
+                        <img src="{{ asset('images/icons/写真アイコン4.png') }}" alt="画像を選択" style="width: 32px; height: 32px;">
+                    </label>
+                    {{-- ファイル名表示 --}}
+                    <span id="file-name" class="text-muted" style="font-size: 0.9rem; line-height: 32px; height: 32px;"></span>
+                </div>
+                <input type="file" name="image" id="image" class="d-none" accept="image/*">
+                {{-- プレビュー画像 --}}
+                <img id="preview" src="#" alt="画像プレビュー" class="img-fluid mb-1" style="display: none; max-height: 100px;">
+
+                <div class="d-flex align-items-end">
+                    <button type="submit" class="btn btn-primary">更新する</button>
+                </div>
+            </div>
+        </div>
+    </form>
+    {{-- 画像削除フォーム --}}
+    <form action="{{ route('post.image.destroy', $post->id) }}" method="POST" onsubmit="return confirm('画像を削除してもよろしいですか？');" class="mt-2">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="btn btn-light p-1" title="削除">
+            <img src="{{ asset('images/icons/ゴミ箱のアイコン素材.png') }}" alt="削除" style="width: 20px; height: 20px;">
+        </button>
     </form>
 @endsection
 

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -29,7 +29,7 @@
                 @if ($post->image_path)
                     <div class="mb-2" style="max-width: 200px;">
                         <img 
-                            src="{{ asset($post->image_path) }}" 
+                            src="{{ asset('storage/' . $post->image_path) }}" 
                             alt="投稿画像" 
                             class="img-fluid mt-2" 
                             style="max-height: 100px; object-fit: contain; pointer;"
@@ -49,7 +49,7 @@
                                     </button>
                                 </div>
                                 <div class="modal-body text-center">
-                                    <img src="{{ asset($post->image_path) }}" class="img-fluid" alt="拡大画像">
+                                    <img src="{{ asset('storage/' . $post->image_path) }}" class="img-fluid" alt="拡大画像">
                                 </div>
                             </div>
                         </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -37,7 +37,7 @@
                 @if ($post->image_path)
                     <div class="mb-2" style="max-width: 200px;">
                         <img 
-                            src="{{ asset($post->image_path) }}" 
+                            src="{{ asset('storage/' . $post->image_path) }}" 
                             alt="投稿画像" 
                             class="img-fluid mt-2" 
                             style="max-height: 100px; object-fit: contain;"
@@ -57,7 +57,7 @@
                                     </button>
                                 </div>
                                 <div class="modal-body text-center">
-                                    <img src="{{ asset($post->image_path) }}" class="img-fluid" alt="拡大画像">
+                                    <img src="{{ asset('storage/' . $post->image_path) }}" class="img-fluid" alt="拡大画像">
                                 </div>
                             </div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,8 @@ Route::prefix('users/{id}')->group(function () {
 
 Route::group(['middleware' => 'auth'], function () {
     Route::prefix('posts')->group(function () {
+        // 画像削除
+        Route::delete('{post}/image', 'PostsController@destroyImage')->name('post.image.destroy');
         Route::prefix('{post_id}/replies/{reply}')->group(function () {
             Route::get('edit', 'RepliesController@edit')->name('replies.edit');
             Route::put('/', 'RepliesController@update')->name('replies.update');


### PR DESCRIPTION
## issue
- Closes

## 概要
- 画像表示の修正と他2件の修正

## 動作確認手順
- [http://localhost:8080](url)にアクセス
- ログインし、新規投稿時に画像を添付→投稿一覧に表示
- ユーザー詳細画面→アイコン変更→アイコンに画像を選択した際に画像が表示
- トップ画面最下部→フッターの名称変更
- 投稿の編集→画像の削除

## 考慮してほしいこと
投稿編集から画像を削除できるようにしましが、フォームのなかにフォームが入ることになり、うまく動作しなかったので、フォームの外に出しました。
その為、レイアウトが少し違和感があるかもしれません。
また、画像の表示（投稿画像・ユーザーアイコン）に関しては、デプロイしてみないとちゃんと表示されるかわかりません

## 確認してほしいこと
動作確認はしていますが、再度ご確認をお願いいたします。
