### PR TITLE
#117 ユーザ編集画面・更新（きしもと）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -39,6 +39,6 @@ class UsersController extends Controller
             $user->password = bcrypt($request->password);     
             $user->save();           
         }     
-        return back();
+        return redirect()->route('user.show', ['id' => $id])->with('success', 'ユーザ情報を更新しました。');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\UserRequest;
 use App\User;
-
+use Illuminate\Validation\Rule;
 class UsersController extends Controller
 {
     public function show($id)
@@ -16,5 +17,28 @@ class UsersController extends Controller
             'posts' => $posts,
         ];
         return view('users.show',$data);
-    } 
+    }
+
+    public function edit($id)
+    {
+        $user = User::findOrFail($id);       
+        if (\Auth::id() === $user->id) {                      
+            return view('users.edit',[
+                'user' => $user,
+            ]);
+        }
+        return back();
+    }
+
+    public function update(UserRequest $request, $id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id) {        
+            $user->name = $request->name;
+            $user->email = $request->email;
+            $user->password = bcrypt($request->password);     
+            $user->save();           
+        }     
+        return back();
+    }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+}

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UserRequest extends FormRequest
@@ -23,9 +24,11 @@ class UserRequest extends FormRequest
      */
     public function rules()
     {
+        $userId = Auth::id();
+
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' =>  ['required', 'email', 'unique:users,email,' . $userId],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ];
     }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -24,7 +24,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">ログイン</button>
             </form>
-            <div class="mt-2"><a href="signup">新規ユーザ登録する？</a></div>
+            <div class="mt-2"><a href="{{ route('signup') }}">新規ユーザ登録する？</a></div>
         </div>
     </div>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -24,7 +24,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">ログイン</button>
             </form>
-            <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
+            <div class="mt-2"><a href="signup">新規ユーザ登録する？</a></div>
         </div>
     </div>
 @endsection

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -13,7 +13,7 @@
 
         <div class="form-group">
             <label for="email">メールアドレス</label>
-            <input class="form-control" value="{{old('email', $user->email)}}" name="name" />
+            <input class="form-control" value="{{old('email', $user->email)}}" name="email" />
         </div>
 
         <div class="form-group">
@@ -23,7 +23,7 @@
 
         <div class="form-group">
             <label for="password_confirmation">パスワードの確認</label>
-            <input class="form-control" type="password" name="password" />
+            <input class="form-control" type="password" name="password_confirmation" />
         </div>
 
         <div class="d-flex justify-content-between">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+    <form method="POST" action="{{ route('user.update', $user->id ) }}">
+        @csrf
+        @method('PUT')
+        @include('commons.error_messages')
+        <input type="hidden" name="id" value="{{$user->id}}" />
+        <div class="form-group">
+            <label for="name">ユーザ名</label>
+            <input class="form-control" value="{{ old('name', $user->name)}}" name="name" />
+        </div>
+
+        <div class="form-group">
+            <label for="email">メールアドレス</label>
+            <input class="form-control" value="{{old('email', $user->email)}}" name="name" />
+        </div>
+
+        <div class="form-group">
+            <label for="password">パスワード</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+
+        <div class="form-group">
+            <label for="password_confirmation">パスワードの確認</label>
+            <input class="form-control" type="password" name="password" />
+        </div>
+
+        <div class="d-flex justify-content-between">
+            <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+            <button type="submit" class="btn btn-primary">更新する</button>
+        </div>
+    </form>
+
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4>確認</h4>
+                </div>
+                <div class="modal-body">
+                    <label>本当に退会しますか？</label>
+                </div>
+                <div class="modal-footer d-flex justify-content-between">
+                    <form action="" method="POST">
+                        <button type="submit" class="btn btn-danger">退会する</button>
+                    </form>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+    

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,5 +1,10 @@
 @extends('layouts.app')
 @section('content')
+@if (session('success'))
+    <div class="alert alert-success">
+        {{ session('success') }}
+    </div>
+@endif
 <div class="row">
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -11,7 +11,7 @@
                     @auth
                         @if (Auth::id() === $user->id)
                             <div class="mt-3">
-                                <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                                <a href="{{route('user.edit', $user->id)}}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                             </div>
                         @endif
                     @endauth    
@@ -24,6 +24,7 @@
                 <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
             </ul>
+            @include('posts.posts', ['posts' => $posts])
         </div>
     </div>
-@endsection    
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,8 +21,12 @@ Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('sign
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
 
 // ユーザ詳細
-Route::prefix('users')->group(function () {
-    Route::get('{id}', 'UsersController@show')->name('user.show'); 
+Route::prefix('users/{id}')->group(function () {
+    Route::get('', 'UsersController@show')->name('user.show'); 
+    // ユーザ情報編集
+    Route::get('edit', 'UsersController@edit')->name('user.edit');
+    // ユーザ情報更新
+    Route::put('', 'UsersController@update')->name('user.update');
 });
 //トップページ
 Route::get('/', 'PostsController@index'); 


### PR DESCRIPTION
## issue
- Closes #117 

## 概要
ユーザ編集画面・更新

## 動作確認手順
- ログイン後、右上のユーザーネームをクリック。
- ユーザー詳細画面の画像下に出てくる「ユーザー情報の編集」をクリック。
- ユーザ名、メールアドレス、パスワードを入力し、更新するボタンを押下。情報が更新されれば、トップページへ戻る。

## 考慮してほしいこと
- ユーザー詳細からのユーザー編集ページを作成しています。
- トップ画面右上の新規ユーザー登録では、新規登録できましたが、ログインボタン押下後の画面にある「[新規ユーザ登録する？]のリンクが機能していなかったので、範囲外かもしれませんが、リンクしました。

## 確認してほしいこと
- 本来であれば、問題を解消してからプッシュすべきですが、どこに問題があるのかが分からないため、コード自体を見ていただきたく、プッシュしています。
- ユーザー情報を編集する画面について、ユーザー名、メールアドレス、パスワード8桁以上を入力し、更新するボタンを押すと、
「メールアドレスは、必ず指定してください。」
「パスワードとパスワード確認が一致しません。」
とエラーが出ます。
また、ユーザー名にはold('name', $user->nameとしているつもりですが、何故かメールアドレスが入ります。
上記エラーが出るため、更新を完了することができませんでした。