### PR TITLE
#127 フォロー機能（きしもと）

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -17,5 +17,4 @@ class FollowController extends Controller
         \Auth::user()->unfollow($id);
         return back();
     }
-
 }

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class FollowController extends Controller
+{
+    public function store($id)
+    {
+        \Auth::user()->follow($id);
+        return back();
+    }
+
+    public function destroy($id)
+    {
+        \Auth::user()->unfollow($id);
+        return back();
+    }
+
+}

--- a/app/User.php
+++ b/app/User.php
@@ -54,7 +54,7 @@ class User extends Authenticatable
         });
     }
 
-     public function followings()
+    public function followings()
     // ユーザがフォローしているユーザを取得
     {
         return $this->belongsToMany(User::class, 'follows', 'user_id', 'followed_user_id')->withTimestamps();
@@ -92,7 +92,7 @@ class User extends Authenticatable
         if ($exist) {
             $this->followings()->detach($userId);
             return true;
-        }else {
+        } else {
             return false;
         }
     }

--- a/app/User.php
+++ b/app/User.php
@@ -53,4 +53,47 @@ class User extends Authenticatable
             $user->posts()->delete();
         });
     }
+
+     public function followings()
+    // ユーザがフォローしているユーザを取得
+    {
+        return $this->belongsToMany(User::class, 'follows', 'user_id', 'followed_user_id')->withTimestamps();
+    }
+
+    public function followers()
+    // ユーザをフォローしているユーザを取得
+    {
+        return $this->belongsToMany(User::class, 'follows', 'followed_user_id', 'user_id')->withTimestamps();
+    }
+
+    public function isFollow($userId)
+    // ユーザが特定のユーザをフォローしているか確認
+    {
+        return $this->followings()->where('followed_user_id', $userId)->exists();
+    }
+
+
+    public function follow($userId)
+    // ユーザをフォローする
+    {
+        $exist = $this->isFollow($userId);
+        if ($exist) {
+            return false;
+        } else {
+            $this->followings()->attach($userId);
+            return true;
+        }
+    }
+
+    public function unfollow($userId)
+    // ユーザのフォローを解除する
+    {
+        $exist = $this->isFollow($userId);
+        if ($exist) {
+            $this->followings()->detach($userId);
+            return true;
+        }else {
+            return false;
+        }
+    }
 }

--- a/database/migrations/2025_08_02_222103_create_follows_table.php
+++ b/database/migrations/2025_08_02_222103_create_follows_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->bigInteger('followed_user_id')->unsigned()->index();
+            $table->timestamps();
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('followed_user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->unique(['user_id','followed_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,6 +14,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             UsersTableSeeder::class,
             PostsTableSeeder::class,
+            FollowsTableSeeder::class,
         ]);
     }
 }

--- a/database/seeds/FollowsTableSeeder.php
+++ b/database/seeds/FollowsTableSeeder.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use App\User;
+
+class FollowsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $follows = [
+            2 => [3, 4], // ID 2のユーザは ID 3, 4のユーザをフォロー
+            3 => [2, 4], // ID 3のユーザは ID 2, 4のユーザをフォロー
+            4 => [2],    // ID 4のユーザは ID 2のユーザをフォロー
+        ];
+
+        foreach ($follows as $usersId => $followedUsersIds) {
+            foreach ($followedUsersIds as $followedUsersId) {
+                DB::table('follows')->insert([
+                    'user_id' => $usersId,
+                    'followed_user_id' => $followedUsersId,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+    }
+}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -4,8 +4,9 @@
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
                 <p class="mt-3 mb-0 d-inline-block"><a href="">{{$post->user->name}}</a></p>
+                @include('users.follow_button',['user'=> $post->user])
             </div>
-            <div class="">
+            <div class="contaier">
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{$post->content}}</p>
                     <p class="text-muted">{{$post->created_at}}</p>

--- a/resources/views/users/follow_button.blade.php
+++ b/resources/views/users/follow_button.blade.php
@@ -1,0 +1,14 @@
+@if (Auth::check() && Auth::id() !== $user->id)
+    @if (Auth::user()->isFollow($user->id))
+        <form method="POST" action="{{ route('users.unfollow', $user->id) }}">
+            @csrf
+            @method('DELETE')
+            <br><button type="submit" class="btn btn-danger">フォローを外す</button>
+        </form>
+    @else
+        <form method="POST" action="{{ route('users.follow', $user->id) }}">
+            @csrf
+            <br><button type="submit" class="btn btn-primary">フォローする</button>
+        </form>
+    @endif
+@endif

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -5,7 +5,9 @@
         <aside class="col-sm-4 mb-5">
             <div class="card bg-info">
                 <div class="card-header">
-                    <h3 class="card-title text-light">{{ $user->name }}</h3>
+                    <h3 class="card-title text-light">{{ $user->name }}
+                     @include('users.follow_button',['user'=> $user])
+                    </h3>
                 </div>
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="ユーザのアバター画像">
@@ -21,7 +23,7 @@
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
-                <li class="nav-item"><a href="" class="nav-link {{ Request::is('users/' . $user->id) ? 'active' : '' }}">タイムライン</a></li>
+                <li class="nav-item"><a href="{{ route('users.show', $user->id) }}" class="nav-link {{ Request::is('users/' . $user->id) ? 'active' : '' }}">タイムライン</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
             </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,9 @@ Route::prefix('users/{id}')->group(function () {
     Route::put('', 'UsersController@update')->name('users.update');
     // ユーザ削除
     Route::delete('', 'UsersController@destroy')->name('users.delete');
+    // フォロー・アンフォロー
+    Route::post('follow', 'FollowController@store')->name('users.follow');
+    Route::delete('unfollow', 'FollowController@destroy')->name('users.unfollow');
 });
 //トップページ
 Route::get('/', 'PostsController@index'); 


### PR DESCRIPTION
## issue
- Closes #127 

## 概要
- フォロー機能

## 動作確認手順
- ログインしていない状態では「フォローする」
 「フォローを外す」ボタンがないことを確認
- ログイン後、ログインユーザのコメントには
  コメントの削除ボタン、編集ボタンのみ表示
- ログインユーザ以外には、
  フォローしていなければ「フォローする」ボタン
  フォローしていれば「フォローを外す」ボタン
  が表示されることを確認。

## 考慮してほしいこと

## 確認してほしいこと
- 「フォローする」ボタンを押下すると、adminerのfollowsテーブルにログインユーザ（user_id)とフォローしたユーザ（followed_user_id)が記録されているか。
- 「フォローを外す」ボタンを押下すると、adminerのfollowsテーブルにログインユーザ（user_id)とフォローしたユーザ（followed_user_id)が物理削除されているか。