### PR TITLE
ユーザ検索機能追加（きしもと）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -112,23 +112,4 @@ class PostsController extends Controller
         return back()->with('success', '投稿を削除しました！'); 
     }
 
-    public function search(Request $request)
-    {
-        $keyword = $request->input('keyword');
-
-        $query = Post::query();
-
-        if (!empty($keyword)) {
-            $query->where(function($q) use ($keyword) {
-                $q->where('content', 'like', '%' . $keyword . '%');
-            });
-        }
-
-        $posts = $query->orderBy('id', 'desc')->paginate(10);
-
-        return view('welcome', [
-            'posts' => $posts,
-            'keyword' => $keyword,   
-        ]);
-    }    
 }

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -32,10 +32,6 @@ class SearchController extends Controller
                 })
                 ->orderBy('created_at', 'desc')
                 ->paginate(10);
-            // 投稿はそのままの順序で取得
-            $posts = Post::with('user', 'images')
-                ->orderBy('created_at', 'desc')
-                ->paginate(10);
         }
 
         return view('welcome', compact('posts', 'users', 'keyword', 'type'));

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -24,16 +24,16 @@ class SearchController extends Controller
                 })
                 ->orderBy('created_at', 'desc')
                 ->paginate(10);
-        } elseif ($type === 'users') {
-            // ユーザ検索
-            $users = User::when($keyword, function ($query, $keyword) {
-                    $query->where('name', 'like', "%{$keyword}%")
-                          ->orWhere('email', 'like', "%{$keyword}%");
-                })
-                ->orderBy('created_at', 'desc')
-                ->paginate(10);
+            return view('welcome', compact('posts', 'users', 'keyword', 'type'));
         }
-
+        
+        // ユーザ検索
+        $users = User::when($keyword, function ($query, $keyword) {
+                    $query->where('name', 'like', "%{$keyword}%")
+                            ->orWhere('email', 'like', "%{$keyword}%");
+            })
+            ->orderBy('created_at', 'desc')
+            ->paginate(10);
         return view('welcome', compact('posts', 'users', 'keyword', 'type'));
     }
 

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Post;
+use App\User;
+
+class SearchController extends Controller
+{
+    public function index(Request $request)
+    {
+        $keyword = $request->input('keyword');
+        $type = $request->input('type', 'posts'); // デフォルトは投稿検索
+
+        $posts = collect();
+        $users = collect();
+
+        if ($type === 'posts') {
+            // 投稿検索
+            $posts = Post::with('user', 'images')
+                ->when($keyword, function ($query, $keyword) {
+                    $query->where('content', 'like', "%{$keyword}%");
+                })
+                ->orderBy('created_at', 'desc')
+                ->paginate(10);
+        } elseif ($type === 'users') {
+            // ユーザ検索
+            $users = User::when($keyword, function ($query, $keyword) {
+                    $query->where('name', 'like', "%{$keyword}%")
+                          ->orWhere('email', 'like', "%{$keyword}%");
+                })
+                ->orderBy('created_at', 'desc')
+                ->paginate(10);
+            // 投稿はそのままの順序で取得
+            $posts = Post::with('user', 'images')
+                ->orderBy('created_at', 'desc')
+                ->paginate(10);
+        }
+
+        return view('welcome', compact('posts', 'users', 'keyword', 'type'));
+    }
+
+}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,12 +1,18 @@
 @extends('layouts.app')
 @section('content')
 @include('commons.success_messages')
+    {{-- 検索フォーム --}}
     <div class="d-flex justify-content-end mb-3 pr-5">
-        <form action="{{ route('posts.search') }}" method="GET" class="form-inline d-inline-block">
+        <form action="{{ route('search') }}" method="GET" class="form-inline d-inline-block">
             <input type="text" name="keyword" class="form-control mr-2" placeholder="キーワードを入力" value="{{ request('keyword') }}">
+            <select name="type" class="form-control mr-2">
+                <option value="posts" {{ request('type') === 'posts' ? 'selected' : '' }}>投稿</option>
+                <option value="users" {{ request('type') === 'users' ? 'selected' : '' }}>ユーザ</option>
+            </select>
             <button type="submit" class="btn btn-primary">検索</button>
         </form>
     </div>
+    {{-- ヘッダー --}}
     <div class="container">
         <div class="jumbotron bg-info">
             <div class="text-center text-white mt-2 pt-1">
@@ -15,6 +21,7 @@
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+    {{-- 投稿フォーム（ログイン時のみ） --}}
     @if (Auth::check())     
         <div class="w-75 m-auto">
             @include('commons.error_messages', ['errorBag' => 'post'])
@@ -42,5 +49,37 @@
             </form>
         </div>
     @endif
-    @include('posts.posts', ['posts' => $posts])
+    {{-- 検索結果表示 --}}
+    @if (!empty($keyword))
+        <div class="w-75 m-auto mb-4">
+            <p>「{{ $keyword }}」の検索結果</p>
+        </div>
+        {{-- ユーザ検索結果 --}}
+        @if (isset($users) && $users->isNotEmpty())
+            <div class="w-75 m-auto mb-5">
+                <h5>ユーザ</h5>
+                <ul class="list-unstyled">
+                    @foreach ($users as $user)
+                        <li class="mb-3">
+                            <a href="{{ route('users.show', ['id' => $user->id]) }}">
+                                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="ユーザのアバター画像">
+                                {{ $user->name }}
+                            </a>
+                        </li>
+                    @endforeach
+                </ul>
+                <div>{{ $users->appends(request()->query())->links('pagination::bootstrap-4') }}</div>
+            </div>
+        @endif
+        {{-- 投稿検索結果（あれば置き換え、なければ通常タイムライン） --}}
+        @if (isset($posts) && $posts->isNotEmpty())
+            @include('posts.posts', ['posts' => $posts])
+        @else
+            {{-- 投稿がなければ通常タイムラインを出す --}}
+            @include('posts.posts', ['posts' => $timeline])
+        @endif
+    @else
+        {{-- タイムライン --}}
+        @include('posts.posts', ['posts' => $posts])
+    @endif
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -85,6 +85,6 @@
         @endif
     @else
         {{-- タイムライン --}}
-        @include('posts.posts', ['posts' => $timeline])
+        @include('posts.posts', ['posts' => $posts])
     @endif
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -55,31 +55,36 @@
             <p>「{{ $keyword }}」の検索結果</p>
         </div>
         {{-- ユーザ検索結果 --}}
-        @if (isset($users) && $users->isNotEmpty())
-            <div class="w-75 m-auto mb-5">
-                <h5>ユーザ</h5>
-                <ul class="list-unstyled">
-                    @foreach ($users as $user)
-                        <li class="mb-3">
-                            <a href="{{ route('users.show', ['id' => $user->id]) }}">
-                                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="ユーザのアバター画像">
-                                {{ $user->name }}
-                            </a>
-                        </li>
-                    @endforeach
-                </ul>
-                <div>{{ $users->appends(request()->query())->links('pagination::bootstrap-4') }}</div>
-            </div>
+        @if ($type === 'users')
+            @if ($users->isNotEmpty())
+                <div class="w-75 m-auto mb-5">
+                    <h5>ユーザ</h5>
+                        <ul class="list-unstyled">
+                            @foreach ($users as $user)
+                                <li class="mb-3">
+                                    <a href="{{ route('users.show', ['id' => $user->id]) }}">
+                                        <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="ユーザのアバター画像">
+                                        {{ $user->name }}
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    <div>{{ $users->appends(request()->query())->links('pagination::bootstrap-4') }}</div>
+                </div>
+            @else
+                <p class="text-center">該当するユーザはいません。</p>
+            @endif
         @endif
-        {{-- 投稿検索結果（あれば置き換え、なければ通常タイムライン） --}}
-        @if (isset($posts) && $posts->isNotEmpty())
-            @include('posts.posts', ['posts' => $posts])
-        @else
-            {{-- 投稿がなければ通常タイムラインを出す --}}
-            @include('posts.posts', ['posts' => $timeline])
+        {{-- 投稿検索 --}}
+        @if ($type === 'posts')
+            @if ($posts->isNotEmpty())
+                @include('posts.posts', ['posts' => $posts])
+            @else
+                <p class="text-center">該当する投稿はありません。</p>
+            @endif
         @endif
     @else
         {{-- タイムライン --}}
-        @include('posts.posts', ['posts' => $posts])
+        @include('posts.posts', ['posts' => $timeline])
     @endif
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -64,5 +64,5 @@ Route::group(['middleware' => 'auth'], function () {
         Route::delete('replies/{id}', 'RepliesController@destroy')->name('replies.delete');
     });
 });
-// 投稿検索
-Route::get('posts/search','PostsController@search')->name('posts.search');
+// ユーザ・投稿検索
+Route::get('search','SearchController@index')->name('search');


### PR DESCRIPTION
## 概要
- ユーザ検索機能追加

## 動作確認手順
- 検索ワード欄に検索したい文字を入力
- その横にる「ユーザ」か「投稿」を選択し、検索ボタンを押下
- ユーザ検索した場合
- 該当ユーザがいる場合は、該当ユーザが表示。該当ユーザがいない場合は、「該当するユーザはいません。」と表示される。
- 投稿を検索した場合
- 該当の投稿があった場合は、該当の投稿のみ表示。該当の投稿がない場合は、「該当する投稿はありません。」と表示される。

## 考慮してほしいこと
- 最初にプッシュしたものは、ユーザ検索しても、検索結果の下に投稿が表示される仕様でしたが、何度か繰り返すうちに、検索している内容以外のものが表示される仕様に違和感を感じてきたため、検索した結果以外は表示されないように修正しました。
 
## 確認してほしいこと
- ポストコントローラに検索機能がありましたが、ユーザと投稿を同じフォームで検索するため、サーチコントローラを作成しました。
- 実際の運用する場合は、ユーザコントローラ、ポストコントローラに検索機能を追加した方がよいのか、
- 今回のように機能としてまとめることができるものは、新たなコントローラにまとめた方が良いのか教えていただきたいです。