### PR TITLE
#107 ヘッダーに新規ユーザ登録のリンク記載とヘッダーにユーザ名を記載するように変更(丸山)

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -11,6 +11,7 @@
     </div>
     <div class="row mt-5 mb-5">
         <div class="col-sm-6 offset-sm-3">
+            @include('commons.error_messages')
             <form method="POST" action="{{ route('signup.post') }}">
                 @csrf
                 <div class="form-group">

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -7,10 +7,14 @@
         <div class="collapse navbar-collapse" id="nav-bar">
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
-                    <li class="nav-item"><a href="" class="nav-link text-light">ログインユーザ名</a></li>
+                @if(Auth::check())
+                    <li class="nav-item"><a href="" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                     <li class="nav-item"><a href="" class="nav-link text-light">ログアウト</a></li>
+                @else
                     <li class="nav-item"><a href="" class="nav-link text-light">ログイン</a></li>
-                    <li class="nav-item"><a href="" class="nav-link text-light">新規ユーザ登録</a></li>
+                    <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>
+                @endif
+            </ul>
         </div>
     </nav>
 </header>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,7 +9,6 @@
     <body>
         @include('commons.header')
         <div class="container">
-            @include('commons.error_messages')
             @yield('content')
         </div>
         @include('commons.footer')


### PR DESCRIPTION
## issue
- Closses #107

## 概要
- ヘッダーに新規ユーザ登録のリンク記載とヘッダーにユーザ名を記載するように変更

## 動作確認手順
- 新規ユーザ登録をクリックしたとき登録フォームに行くのを確認。
新規登録後トップページで右上にユーザー名と、ログアウトが出るのを確認

## 考慮して欲しいこと
（補足）register.blade.phpに新規ユーザー登録の下にエラーメッセージが表示するようにしましたが、
app.blade.phpに@include('commons.error_messages')があり二重に表示されるためapp.blade.phpの方の記述を消しました。
## 確認して欲しいこと