### PR TITLE
#95posts（投稿）テーブルのマイグレーションとシーダー作成（杉田）

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -3,9 +3,12 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Post extends Model
 {
+    use SoftDeletes;
+    
     protected $fillable = [
         'content',
     ]

--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    protected $fillable = [
+        'content',
+    ]
+}

--- a/database/migrations/2025_11_23_123238_create_posts_table.php
+++ b/database/migrations/2025_11_23_123238_create_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/migrations/2025_11_23_123238_create_posts_table.php
+++ b/database/migrations/2025_11_23_123238_create_posts_table.php
@@ -15,8 +15,13 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->text('content');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->string('content', 140);
             $table->timestamps();
+            $table->softDeletes();
+
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -13,15 +13,19 @@ class PostsTableSeeder extends Seeder
     public function run()
     {
         DB::table('posts')->insert([
+            'user_id' => 1,
             'content' => 'テスト投稿１',
         ]);
         DB::table('posts')->insert([
+            'user_id' => 2,
             'content' => 'テスト投稿２',
         ]);
         DB::table('posts')->insert([
+            'user_id' => 3,
             'content' => 'テスト投稿３',
         ]);
         DB::table('posts')->insert([
+            'user_id' => 4,
             'content' => 'テスト投稿４',
         ]);
     }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('posts')->insert([
+            'content' => 'テスト投稿１',
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'テスト投稿２',
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'テスト投稿３',
+        ]);
+        DB::table('posts')->insert([
+            'content' => 'テスト投稿４',
+        ]);
+    }
+}


### PR DESCRIPTION
## issue
- Closes #95

## 概要
- posts（投稿）テーブルのマイグレーションとシーダー作成

## 動作確認手順
- seederで登録、Adminerでpsersテーブルに2個のカラム(id)と(content)が保存されていることを確認

- 下記コマンドを実行
 php artisan make:seeder PostsTableSeeder
 Adminerでpsersテーブルに4個のレコード(id 1~4)と(content 投稿内容)が保存されていることを確認
 投稿内容の編集も確認済み

## 考慮して欲しいこと

## 確認して欲しいこと
お手本アプリだと投稿内容のみ表示されてる感じだったのですが、他に追加するものやコードの記述で訂正が有れば教えて下さい。