### PR TITLE
#1637 フォローによるタイムライン変更 (丸山)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -17,7 +17,12 @@ class PostsController extends Controller
     public function show($id)
     {
         $user = User::findOrFail($id);
-        $posts = $user->posts()->orderBy('id', 'desc')->paginate(9);
+        // フォロー中ユーザーのID取得
+        $followingIds = $user->followings()->pluck('users.id')->toArray();
+        // 自分自身もタイムラインに含める
+        $followingIds[] = $user->id;
+        // タイムライン投稿（フォロー + 自分）
+        $posts = Post::whereIn('user_id', $followingIds)->orderBy('id', 'desc')->paginate(9);
         $data=[
             'user' => $user,
             'posts' => $posts,

--- a/app/User.php
+++ b/app/User.php
@@ -68,4 +68,14 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(User::class, 'follows', 'followed_id', 'follower_id')->withTimestamps();
     }
+
+    public function timeline()
+    {
+        // 自分がフォローしているユーザーのIDを取得
+        $followingIds = $this->followings()->pluck('users.id')->toArray();
+        // 自分のIDも含めてタイムライン対象にする
+        $followingIds[] = $this->id; 
+        // 投稿を取得
+        return Post::whereIn('user_id', $followingIds)->orderBy('created_at', 'desc')->paginate(9); 
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -68,14 +68,5 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(User::class, 'follows', 'followed_id', 'follower_id')->withTimestamps();
     }
-
-    public function timeline()
-    {
-        // 自分がフォローしているユーザーのIDを取得
-        $followingIds = $this->followings()->pluck('users.id')->toArray();
-        // 自分のIDも含めてタイムライン対象にする
-        $followingIds[] = $this->id; 
-        // 投稿を取得
-        return Post::whereIn('user_id', $followingIds)->orderBy('created_at', 'desc')->paginate(9); 
-    }
+ 
 }


### PR DESCRIPTION
## issue
- Closes #1637

## 概要
- フォローによるタイムライン変更

## 動作確認手順
- ログイン後、投稿している別ユーザーをフォローして、ユーザー詳細に遷移後タイムラインにフォローしたユーザーと自分の投稿のみが表示されているのを確認。

## 考慮してほしいこと(補足)

## 確認してほしいこと