### PR TITLE
#1651 投稿へのタグ追加機能（編集・更新、削除）　(丸山)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -36,15 +36,20 @@ class PostsController extends Controller
             );
 
             foreach ($names as $name) {
-                $tag = Tag::firstOrCreate(['name' => $name]);
+                $tag = Tag::firstOrCreate(
+                    ['name' => $name],
+                    [
+                        'user_id' => auth()->id(),
+                        'update_count' => 0,
+                    ]
+                );
                 $tagIds[] = $tag->id;
             }
         }
-
         // ③ 紐付け
         $post->tags()->sync($tagIds);
 
-        return back(); 
+        return back();
     }
 
     public function detachTag(Post $post, Tag $tag)

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -10,7 +10,7 @@ class TagController extends Controller
 {
     public function index()
     {
-        $tags = Tag::orderBy('name')->paginate(10);
+        $tags = Tag::where('user_id', auth()->id())->orderBy('name')->paginate(10);
         return view('tags.index', compact('tags'));
     }
 
@@ -22,7 +22,11 @@ class TagController extends Controller
         }
         // 更新1回まで
         if ($tag->update_count >= 1) {
-            return redirect()->route('tags.index')->withErrors(['name' => 'このタグは既に更新されています'])->with('error_tag_id', $tag->id);
+            return redirect()->route('tags.index')->withErrors()->with('error_tag_id', $tag->id);
+        }
+        // 同じ名前チェック
+        if ($request->name === $tag->name) {
+            return redirect()->route('tags.index')->withErrors(['name' => 'タグ名が変更されていません'])->withInput()->with('error_tag_id', $tag->id);
         }
 
         $tag->name = $request->name;

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -7,6 +7,31 @@ use App\Tag;
 
 class TagController extends Controller
 {
+    public function index()
+    {
+        $tags = Tag::orderBy('name')->get();
+        return view('tags.index', compact('tags'));
+    }
+
+    public function update(Request $request, Tag $tag)
+    {
+        $request->validate([
+            'name' => 'required|max:50|unique:tags,name,' . $tag->id,
+        ]);
+        $tag->update(['name' => $request->name]);
+
+        return redirect()->route('tags.index')->with('success', 'タグを更新しました');
+    }
+
+    public function destroy(Tag $tag)
+    {
+        // 紐付け解除
+        $tag->posts()->detach();
+        $tag->delete();
+
+        return redirect()->route('tags.index')->with('success', 'タグを削除しました');
+    }
+
     public function show(Tag $tag)
     {
         $posts = $tag->posts()->with('tags')->orderBy('id', 'desc')->paginate(10);

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -3,28 +3,40 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Http\Requests\TagRequest;
 use App\Tag;
 
 class TagController extends Controller
 {
     public function index()
     {
-        $tags = Tag::orderBy('name')->get();
+        $tags = Tag::orderBy('name')->paginate(10);
         return view('tags.index', compact('tags'));
     }
 
-    public function update(Request $request, Tag $tag)
+    public function update(TagRequest $request, Tag $tag)
     {
-        $request->validate([
-            'name' => 'required|max:50|unique:tags,name,' . $tag->id,
-        ]);
-        $tag->update(['name' => $request->name]);
+        // 作成者チェック
+        if ($tag->user_id !== auth()->id()) {
+            abort(403);
+        }
+        // 更新1回まで
+        if ($tag->update_count >= 1) {
+            return redirect()->route('tags.index')->withErrors(['name' => 'このタグは既に更新されています'])->with('error_tag_id', $tag->id);
+        }
+
+        $tag->name = $request->name;
+        $tag->update_count++;
+        $tag->save();
 
         return redirect()->route('tags.index')->with('success', 'タグを更新しました');
     }
 
     public function destroy(Tag $tag)
     {
+        if ($tag->user_id !== auth()->id()) {
+            abort(403);
+        }
         // 紐付け解除
         $tag->posts()->detach();
         $tag->delete();

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -26,7 +26,7 @@ class PostRequest extends FormRequest
         return [
             'content' => 'required|max:140',
             'tag_ids.*'    => 'exists:tags,id',
-            'new_tags'     => 'nullable|string|max:100',
+            'new_tags'     => 'nullable|string|max:50',
         ];
     }
 

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Tag;
 use Illuminate\Foundation\Http\FormRequest;
 
 class PostRequest extends FormRequest
@@ -35,5 +36,23 @@ class PostRequest extends FormRequest
         return [
             'content' => '投稿内容',
         ];
+    }
+
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            if ($this->filled('new_tags')) {
+                $names = array_unique( array_filter(array_map('trim', explode(',', $this->new_tags))));
+
+                $exists = \App\Tag::whereIn('name', $names)->pluck('name')->toArray();
+
+                if (!empty($exists)) {
+                    $validator->errors()->add(
+                        'new_tags',
+                        '既存タグはチェックボックスから選択してください：' . implode(', ', $exists)
+                    );
+                }
+            }
+        });
     }
 }

--- a/app/Http/Requests/TagRequest.php
+++ b/app/Http/Requests/TagRequest.php
@@ -42,7 +42,7 @@ class TagRequest extends FormRequest
     protected function failedValidation(Validator $validator)
     {
         throw new HttpResponseException(
-            redirect()->route('tags.index')->withErrors($validator)->with('error_tag_id', $this->route('tag')->id)
+            redirect()->route('tags.index')->withErrors($validator)->withInput()->with('error_tag_id', $this->route('tag')->id)
         );
     }
 }

--- a/app/Http/Requests/TagRequest.php
+++ b/app/Http/Requests/TagRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class TagRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required|string|max:50|unique:tags,name,' . $this->route('tag')->id,
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'name.required' => 'タグ名を入力してください',
+            'name.max'      => 'タグ名は50文字以内で入力してください',
+            'name.unique'   => 'このタグ名は既に使われています',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            redirect()->route('tags.index')->withErrors($validator)->with('error_tag_id', $this->route('tag')->id)
+        );
+    }
+}

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -7,7 +7,12 @@ use App\Post;
 
 class Tag extends Model
 {
-    protected $fillable = ['name'];
+    protected $fillable = ['name', 'user_id', 'update_count',];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
     public function posts()
     {

--- a/database/migrations/2025_12_16_103929_create_tags_table.php
+++ b/database/migrations/2025_12_16_103929_create_tags_table.php
@@ -16,7 +16,13 @@ class CreateTagsTable extends Migration
         Schema::create('tags', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('name')->unique();
+            // 作成者（ログインユーザー）
+            $table->unsignedBigInteger('user_id');
+            // 更新回数（1回まで）
+            $table->unsignedTinyInteger('update_count')->default(0);
             $table->timestamps();
+             // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }
     /**

--- a/database/seeds/TagsTableSeeder.php
+++ b/database/seeds/TagsTableSeeder.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Seeder;
 use App\Tag;
+use App\User; 
 
 class TagsTableSeeder extends Seeder
 {
@@ -12,6 +13,8 @@ class TagsTableSeeder extends Seeder
      */
     public function run()
     {
+        $user = User::first();
+
         $tags = [
             'Laravel',
             'PHP',
@@ -21,7 +24,10 @@ class TagsTableSeeder extends Seeder
         ];
         
         foreach ($tags as $name) {
-            Tag::firstOrCreate(['name' => $name]);
+            Tag::firstOrCreate(
+                ['name' => $name],
+                [ 'user_id' => $user->id, 'update_count' => 0,]
+            );
         }
     }
 }

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -2,6 +2,7 @@
 @section('content')
     <div class="container">
         <h3 class="mb-4">タグ編集</h3>
+
         @if(session('success'))
             <p class="text-success">{{ session('success') }}</p>
         @endif
@@ -11,31 +12,45 @@
                 <th>更新</th>
                 <th>削除</th>
             </tr>
-
             @foreach($tags as $tag)
-            <tr>
-                <td>
-                    <form action="{{ route('tags.update', $tag) }}" method="POST">
-                        @csrf
-                        @method('PUT')
-                        <input type="text" name="name" value="{{ old('name', $tag->name) }}" class="form-control">
-                </td>
-                <td>
-                        <button type="submit" class="btn btn-sm btn-primary">更新</button>
-                    </form>
-                </td>
-                <td>
-                    <form action="{{ route('tags.destroy', $tag) }}" method="POST">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('削除しますか？')">
-                            削除
-                        </button>
-                    </form>
-                </td>
-            </tr>
-            @endforeach
+                <tr>
+                    <td>
+                        @if($tag->user_id === auth()->id() && $tag->update_count === 0)
+                            <form action="{{ route('tags.update', $tag) }}" method="POST">
+                                @csrf
+                                @method('PUT')
+                                <input type="text" name="name" value="{{ $tag->name }}" class="form-control @if(session('error_tag_id') == $tag->id && $errors->has('name')) is-invalid @endif">
+                                @if(session('error_tag_id') == $tag->id && $errors->has('name'))
+                                    <div class="invalid-feedback"> {{ $errors->first('name') }} </div>
+                                @endif
+                        @else
+                            {{ $tag->name }}
+                        @endif
+                    </td>
 
+                    <td>
+                        @if($tag->user_id === auth()->id() && $tag->update_count === 0)
+                                <button type="submit" class="btn btn-sm btn-primary">更新</button>
+                            </form>
+                        @else
+                            <span class="text-muted">更新不可</span>
+                        @endif
+                    </td>
+
+                    <td>
+                        @if($tag->user_id === auth()->id())
+                            <form action="{{ route('tags.destroy', $tag) }}" method="POST">
+                                @csrf
+                                @method('DELETE')
+                                <button class="btn btn-sm btn-danger" onclick="return confirm('削除しますか？')">削除</button>
+                            </form>
+                        @else
+                            <span class="text-muted">削除不可</span>
+                        @endif
+                    </td>
+                </tr>
+            @endforeach
         </table>
+        <div class="d-flex justify-content-center">{{ $tags->links() }}</div>
     </div>
 @endsection

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.app')
+@section('content')
+    <div class="container">
+        <h3 class="mb-4">タグ編集</h3>
+        @if(session('success'))
+            <p class="text-success">{{ session('success') }}</p>
+        @endif
+        <table class="table">
+            <tr>
+                <th>タグ名</th>
+                <th>更新</th>
+                <th>削除</th>
+            </tr>
+
+            @foreach($tags as $tag)
+            <tr>
+                <td>
+                    <form action="{{ route('tags.update', $tag) }}" method="POST">
+                        @csrf
+                        @method('PUT')
+                        <input type="text" name="name" value="{{ old('name', $tag->name) }}" class="form-control">
+                </td>
+                <td>
+                        <button type="submit" class="btn btn-sm btn-primary">更新</button>
+                    </form>
+                </td>
+                <td>
+                    <form action="{{ route('tags.destroy', $tag) }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('削除しますか？')">
+                            削除
+                        </button>
+                    </form>
+                </td>
+            </tr>
+            @endforeach
+
+        </table>
+    </div>
+@endsection

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -6,51 +6,49 @@
         @if(session('success'))
             <p class="text-success">{{ session('success') }}</p>
         @endif
-        <table class="table">
-            <tr>
-                <th>タグ名</th>
-                <th>更新</th>
-                <th>削除</th>
-            </tr>
-            @foreach($tags as $tag)
+
+        @if($tags->count() === 0)
+            <div class="alert alert-info">あなたが作成したタグはありません</div>
+        @else
+            <table class="table">
                 <tr>
-                    <td>
-                        @if($tag->user_id === auth()->id() && $tag->update_count === 0)
-                            <form action="{{ route('tags.update', $tag) }}" method="POST">
+                    <th>タグ名</th>
+                    <th>更新</th>
+                    <th>削除</th>
+                </tr>
+                @foreach($tags as $tag)
+                    <tr>
+                        <td>
+                            <form id="update-{{ $tag->id }}" action="{{ route('tags.update', $tag) }}" method="POST">
                                 @csrf
                                 @method('PUT')
-                                <input type="text" name="name" value="{{ $tag->name }}" class="form-control @if(session('error_tag_id') == $tag->id && $errors->has('name')) is-invalid @endif">
+
+                                <input type="text" name="name" class="form-control @if(session('error_tag_id') == $tag->id && $errors->has('name')) is-invalid @endif" value="{{ session('error_tag_id') == $tag->id ? old('name', $tag->name) : $tag->name }}" @if($tag->update_count >= 1) readonly @endif>
                                 @if(session('error_tag_id') == $tag->id && $errors->has('name'))
-                                    <div class="invalid-feedback"> {{ $errors->first('name') }} </div>
+                                    <div class="invalid-feedback">{{ $errors->first('name') }}</div>
                                 @endif
-                        @else
-                            {{ $tag->name }}
-                        @endif
-                    </td>
-
-                    <td>
-                        @if($tag->user_id === auth()->id() && $tag->update_count === 0)
-                                <button type="submit" class="btn btn-sm btn-primary">更新</button>
                             </form>
-                        @else
-                            <span class="text-muted">更新不可</span>
-                        @endif
-                    </td>
+                        </td>
 
-                    <td>
-                        @if($tag->user_id === auth()->id())
+                        <td>
+                            @if($tag->update_count === 0)
+                                <button type="submit" form="update-{{ $tag->id }}" class="btn btn-sm btn-primary">更新</button>
+                            @else
+                                <span class="text-muted">更新済み</span>
+                            @endif
+                        </td>
+
+                        <td>
                             <form action="{{ route('tags.destroy', $tag) }}" method="POST">
                                 @csrf
                                 @method('DELETE')
                                 <button class="btn btn-sm btn-danger" onclick="return confirm('削除しますか？')">削除</button>
                             </form>
-                        @else
-                            <span class="text-muted">削除不可</span>
-                        @endif
-                    </td>
-                </tr>
-            @endforeach
-        </table>
-        <div class="d-flex justify-content-center">{{ $tags->links() }}</div>
+                        </td>
+                    </tr>
+                @endforeach
+            </table>
+            <div class="d-flex justify-content-center">{{ $tags->links() }}</div>
+        @endif
     </div>
 @endsection

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -5,7 +5,6 @@
         タグ：#{{ $tag->name }}
     </h3>
 
-
     @include('posts.posts', ['posts' => $posts])
     {{ $posts->links() }}
 </div>

--- a/resources/views/tags/show.blade.php
+++ b/resources/views/tags/show.blade.php
@@ -5,6 +5,7 @@
         タグ：#{{ $tag->name }}
     </h3>
 
+
     @include('posts.posts', ['posts' => $posts])
     {{ $posts->links() }}
 </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -27,6 +27,9 @@
                             </label>
                         @endforeach
                     </div>
+                    <div class="text-left mt-1 mb-2">
+                        <a href="{{ route('tags.index') }}" class="btn btn-primary">タグを編集する</a>
+                    </div>
                     <!-- 新規タグ -->
                     <div class="form-group text-left">
                         <label>新規タグ（カンマ区切り）</label>
@@ -34,7 +37,7 @@
                     </div>
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-primary">投稿する</button>
-                    </div>
+                    </div>                   
                 </form>
             @endif
         </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -41,5 +41,4 @@
                 </form>
             @endif
         </div>
-
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,12 @@ Route::prefix('users')->group(function () {
     Route::delete('{id}', 'PostsController@destroy')->name('user.delete');
 });
 
+// ログイン後のみ タグ（編集・更新・削除）
+Route::group(['middleware' => 'auth'], function () {   
+    Route::get('tags', 'TagController@index')->name('tags.index');
+    Route::put('tags/{tag}', 'TagController@update')->name('tags.update');
+    Route::delete('tags/{tag}', 'TagController@destroy')->name('tags.destroy');
+});
 // タグ一覧
 Route::get('tags/{tag}', 'TagController@show')->name('tags.show');
 


### PR DESCRIPTION
## issue
- Closes #1651

## 概要
- 投稿へのタグ追加機能（編集・更新、削除）

## 動作確認手順
- ログイン後ホームページにタグを編集するボタンが追加されているのを確認。
- タグ編集ぺージが表示され、タグ名を変えて更新を押すときちんと反映されているのを確認。削除ボタンを押すとデータから消されるのを確認。

## 考慮してほしいこと
- プルリク作成中に気付いたんですが、tags/show.blade.phpに余計な空行、タグ編集の部分にページネーションの記述をするのを忘れていました。

## 確認してほしいこと

