### PR TITLE
#1656 フォローによるタイムライン変更(すさ)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,4 +10,16 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+    public function userCounts($user)
+    {
+        $countPosts = $user->posts()->count();
+        $countFollowings = $user->follows()->count();
+        $countFollowers = $user->followed()->count();
+
+        return [
+            'countPosts' => $countPosts,
+            'countFollowings' => $countFollowings,
+            'countFollowers' => $countFollowers,
+        ];
+    }
 }

--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\User; 
 
 class FollowController extends Controller
 {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -7,16 +7,39 @@ use App\User;
 
 class UsersController extends Controller
 {
-    
     public function show($id)
     {
         $user = User::findOrFail($id);
-        $posts = $user->posts()->orderBy('id', 'desc')->paginate(9);
-        $data=[
-            'user' => $user,
-            'posts' => $posts,
-        ];
+        $posts = $user->posts()->orderBy('id', 'desc')->paginate(10);
+
+        $countPosts = $user->posts()->count();
+        $countFollowings = $user->follows()->count();
+        $countFollowers = $user->followed()->count();
         
-        return view('users.show',$data);
+        return view('users.show', compact('user', 'posts', 'countPosts', 'countFollowings', 'countFollowers'))->with('users', collect([]));
+    }
+
+    public function followings($id)
+    {
+        $user = User::findOrFail($id);
+        $users = $user->follows()->paginate(10);
+
+        $countPosts = $user->posts()->count();
+        $countFollowings = $user->follows()->count();
+        $countFollowers = $user->followed()->count();
+        
+        return view('users.show', compact('user', 'users', 'countPosts', 'countFollowings', 'countFollowers'))->with('posts', collect([]));
+    }
+
+    public function followers($id)
+    {
+        $user = User::findOrFail($id);
+        $users = $user->followed()->paginate(10);
+
+        $countPosts = $user->posts()->count();
+        $countFollowings = $user->follows()->count();
+        $countFollowers = $user->followed()->count();
+        
+        return view('users.show', compact('user', 'users', 'countPosts', 'countFollowings', 'countFollowers'))->with('posts', collect([]));
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -11,35 +11,38 @@ class UsersController extends Controller
     {
         $user = User::findOrFail($id);
         $posts = $user->posts()->orderBy('id', 'desc')->paginate(10);
-
-        $countPosts = $user->posts()->count();
-        $countFollowings = $user->follows()->count();
-        $countFollowers = $user->followed()->count();
-        
-        return view('users.show', compact('user', 'posts', 'countPosts', 'countFollowings', 'countFollowers'))->with('users', collect([]));
+        $data = [
+            'user' => $user,
+            'posts' => $posts,
+            'users' => collect([]),
+        ];
+        $data += $this->userCounts($user);
+        return view('users.show', $data);
     }
 
     public function followings($id)
     {
         $user = User::findOrFail($id);
         $users = $user->follows()->paginate(10);
-
-        $countPosts = $user->posts()->count();
-        $countFollowings = $user->follows()->count();
-        $countFollowers = $user->followed()->count();
-        
-        return view('users.show', compact('user', 'users', 'countPosts', 'countFollowings', 'countFollowers'))->with('posts', collect([]));
+        $data = [
+            'user' => $user,
+            'users' => $users,
+            'posts' => collect([]),
+        ];
+        $data += $this->userCounts($user);
+        return view('users.show', $data);
     }
 
     public function followers($id)
     {
         $user = User::findOrFail($id);
         $users = $user->followed()->paginate(10);
-
-        $countPosts = $user->posts()->count();
-        $countFollowings = $user->follows()->count();
-        $countFollowers = $user->followed()->count();
-        
-        return view('users.show', compact('user', 'users', 'countPosts', 'countFollowings', 'countFollowers'))->with('posts', collect([]));
+        $data = [
+            'user' => $user,
+            'users' => $users,
+            'posts' => collect([]),
+        ];
+        $data += $this->userCounts($user);
+        return view('users.show', $data);
     }
 }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -3,19 +3,21 @@
         <li class="mb-3 text-center">
             <div class="text-left d-inline-block w-75 mb-2">
                 <img class="mr-2 rounded-circle" src="{{ Gravatar::src($post->user->email, 55) }}" alt="ユーザのアバター画像">
-                <p class="mt-3 mb-0 d-inline-block"><a href="">{{$post->user->name}}</a></p>
+                <p class="mt-3 mb-0 d-inline-block"><a href="{{ route('user.show', $post->user) }}">{{$post->user->name}}</a></p>
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{$post->content}}</p>
                     <p class="text-muted">{{$post->created_at}}</p>
                 </div>
+                @if(Auth::check() && Auth::id() == $post->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
                         <a href="" class="btn btn-primary">編集する</a>
                     </div>
+                @endif
             </div>
         </li>
     @endforeach

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,12 +19,29 @@
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
-                <li class="nav-item"><a href="" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">タイムライン</a></li>
-                <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
-                <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
+                <li class="nav-item">
+                    <a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/'. $user->id) ? 'active' : '' }}">
+                        タイムライン<br><div class="badge badge-secondary">{{ $countPosts }}</div>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="{{ route('users.followings', $user->id) }}" class="nav-link {{ Request::is('users/*/followings') ? 'active' : '' }}">
+                        フォロー中<br><div class="badge badge-secondary">{{ $countFollowings }}</div>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="{{ route('users.followers', $user->id) }}" class="nav-link {{ Request::is('users/*/followers') ? 'active' : '' }}">
+                        フォロワー<br><div class="badge badge-secondary">{{ $countFollowers }}</div>
+                    </a>
+                </li>
             </ul>
-    @include('posts.posts', ['posts' => $posts])
-        </div>  
-        
-    </div>
+            <div class="mt-2">
+                @if (Request::is('users/' . $user->id))
+                    @include('posts.posts', ['posts' => $posts])
+                @else
+                    @include('users.users', ['users' => $users])
+                @endif
+            </div>
+        </div>
+</div>
 @endsection

--- a/resources/views/users/users.blade.php
+++ b/resources/views/users/users.blade.php
@@ -1,0 +1,18 @@
+@if (count($users) > 0)
+    <ul class="list-unstyled">
+        @foreach ($users as $user)
+            <li class="media mb-3">
+                <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 50) }}" alt="">
+                <div class="media-body">
+                    <div>
+                        {{ $user->name }}
+                    </div>
+                    <div>
+                        <p><a href="{{ route('user.show', $user->id) }}">ユーザー情報を見る</a></p>
+                    </div>
+                </div>
+            </li>
+        @endforeach
+    </ul>
+    {{ $users->links() }}
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,9 +31,13 @@ Route::prefix('users')->group(function () {
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
     Route::post('posts', 'PostsController@store')->name('post.store');
-//フォロー機能
+
+// フォロー機能
     Route::group(['prefix' => 'users/{id}'],function(){
         Route::post('follow','FollowController@store')->name('follow');
         Route::delete('unfollow','FollowController@destroy')->name('unfollow');
+// フォロー、フォロワーの表示
+        Route::get('followings', 'UsersController@followings')->name('users.followings');
+        Route::get('followers', 'UsersController@followers')->name('users.followers');
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,13 +30,14 @@ Route::prefix('users')->group(function () {
 
 // ログイン後
 Route::group(['middleware' => 'auth'], function () {
+    // 投稿に関するルート
     Route::post('posts', 'PostsController@store')->name('post.store');
-
-// フォロー機能
+    // フォロー関連
     Route::group(['prefix' => 'users/{id}'],function(){
+        // フォロー、解除
         Route::post('follow','FollowController@store')->name('follow');
         Route::delete('unfollow','FollowController@destroy')->name('unfollow');
-// フォロー、フォロワーの表示
+        // フォロー、フォロワーの表示
         Route::get('followings', 'UsersController@followings')->name('users.followings');
         Route::get('followers', 'UsersController@followers')->name('users.followers');
     });


### PR DESCRIPTION
## issue
- Closes #1656

## 概要
- フォローによるタイムライン変更

## 動作確認手順
- ルーティング（'users.followings’）、(‘users.followers’)記載
- UsersControllerに3つのタブでそれぞれ取得するメソッド記載
- users.blade.php作成し「フォロー中」「フォロワー」の中身を記載後、show.blade.phpに組み込む
- その後、ブラウザで3つのタブの切り替え、それぞれの一覧の表示・相手方のユーザーへの遷移・11フォロワー持たせページネーション機能、count()関数の反映を確認

## 考慮して欲しいこと
- 派生としてユーザー詳細画面への遷移や、投稿に対しログイン中かつ自分のみ投稿の編集・削除ボタン出るようにしています。
## 確認して欲しいこと
-