### PR TITLE
#123 投稿編集画面・更新(すさ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -27,25 +27,22 @@ class PostsController extends Controller
 
     public function edit($id)
     {
-    $post = \App\Post::findOrFail($id);
-    if (\Auth::id() !== $post->user_id) {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() !== $post->user_id) {
         return redirect('/');
-    }
-    return view('posts.edit', [
+        }
+        return view('posts.edit', [
         'post' => $post,
-    ]);
+        ]);
     }
 
-    public function update(Request $request, $id)
+    public function update(PostRequest $request, $id)
     {
-    $request->validate([
-        'content' => 'required|max:140',
-    ]);
-    $post = \App\Post::findOrFail($id);
-    if (\Auth::id() === $post->user_id) {
+        $post = Post::findOrFail($id);
+        if (\Auth::id() === $post->user_id) {
         $post->content = $request->content;
         $post->save();
-    }
-    return redirect('/');
+        }
+        return redirect('/');
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -29,10 +29,10 @@ class PostsController extends Controller
     {
         $post = Post::findOrFail($id);
         if (\Auth::id() !== $post->user_id) {
-        return redirect('/');
+            return redirect('/');
         }
         return view('posts.edit', [
-        'post' => $post,
+            'post' => $post,
         ]);
     }
 
@@ -40,8 +40,8 @@ class PostsController extends Controller
     {
         $post = Post::findOrFail($id);
         if (\Auth::id() === $post->user_id) {
-        $post->content = $request->content;
-        $post->save();
+            $post->content = $request->content;
+            $post->save();
         }
         return redirect('/');
     }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -24,4 +24,28 @@ class PostsController extends Controller
         $post->save();
         return back();
     }
+
+    public function edit($id)
+    {
+    $post = \App\Post::findOrFail($id);
+    if (\Auth::id() !== $post->user_id) {
+        return redirect('/');
+    }
+    return view('posts.edit', [
+        'post' => $post,
+    ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+    $request->validate([
+        'content' => 'required|max:140',
+    ]);
+    $post = \App\Post::findOrFail($id);
+    if (\Auth::id() === $post->user_id) {
+        $post->content = $request->content;
+        $post->save();
+    }
+    return redirect('/');
+    }
 }

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,11 +1,12 @@
 @extends('layouts.app')
 @section('content')
 <h2 class="mt-5">投稿を編集する</h2>
+    @include('commons.error_messages')
     <form method="POST" action="{{ route('posts.update', $post->id) }}">
         @csrf
         @method('PUT')
         <div class="form-group">
-            <textarea id="content" class="form-control" name="content" rows="5">{{ $post->content }}</textarea>
+            <textarea id="content" class="form-control" name="content" rows="5">{{ old('content',$post->content) }}</textarea>
         </div>
         <button type="submit" class="btn btn-primary">更新する</button>
     </form>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5">投稿を編集する</h2>
+    <form method="POST" action="{{ route('posts.update', $post->id) }}">
+        @csrf
+        @method('PUT')
+        <div class="form-group">
+            <textarea id="content" class="form-control" name="content" rows="5">{{ $post->content }}</textarea>
+        </div>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </form>
+    @endsection

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -15,7 +15,7 @@
                         <form method="" action="">
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
-                        <a href="" class="btn btn-primary">編集する</a>
+                        <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
                     </div>
                 @endif
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,9 @@ Route::prefix('users')->group(function () {
 Route::group(['middleware' => 'auth'], function () {
     // 投稿に関するルート
     Route::post('posts', 'PostsController@store')->name('post.store');
+    // 編集
+    Route::get('posts/{id}/edit', 'PostsController@edit')->name('posts.edit');
+    Route::put('posts/{id}', 'PostsController@update')->name('posts.update');
     // フォロー関連
     Route::group(['prefix' => 'users/{id}'],function(){
         // フォロー、解除


### PR DESCRIPTION
## issue
- Closes #123

## 概要
- 投稿編集画面・更新

## 動作確認手順
- ログイン後のRoute::groupの中に編集 (edit)と更新 (update) のルートを追加
- PostsControllerにeditとupdateメソッド追加
- edit.blade.php作成しモックアップ引用し抜けを記載、posts.blade.phpの編集ボタン箇所のhref記載
- その後、ブラウザでログインユーザのみ自分の投稿に対して編集更新しトップページに遷移を確認。（140字より多い時はupdateされないことも確認）

## 考慮して欲しいこと
- 
## 確認して欲しいこと
-