### PR TITLE
#1665 投稿の検索機能(すさ)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -6,10 +6,12 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Routing\Controller as BaseController;
+use App\Post;
 
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
     public function userCounts($user)
     {
         $countPosts = $user->posts()->count();
@@ -23,5 +25,13 @@ class Controller extends BaseController
             'countFollowers' => $countFollowers,
             'countFavorites' => $countFavorites,
         ];
+    }
+
+    protected function getRanking()
+    {
+        return Post::withCount('favoriteUsers')
+                   ->orderBy('favorite_users_count', 'desc')
+                   ->take(5)
+                   ->get();
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -8,30 +8,19 @@ use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller
 {
-    public function index()
-    {
-        $posts = Post::withCount('favoriteUsers')->orderBy('id','desc')->paginate(10);
-        return view('welcome', [
-            'posts' => $posts,
-            'ranking_posts' => $this->getRanking(),
-        ]);
-    }
-
-    public function search(Request $request)
+    public function index(Request $request)
     {
         $keyword = $request->input('keyword');
-        $query = Post::withCount('favoriteUsers');
-
+        $query = Post::query();
         if (!empty($keyword)) {
             $query->where('content', 'LIKE', "%{$keyword}%");
         }
-
         $posts = $query->orderBy('id', 'desc')->paginate(10);
         $posts->appends(['keyword' => $keyword]);
-
+        $ranking_posts = $this->getRanking();
         return view('welcome', [
             'posts' => $posts,
-            'ranking_posts' => $this->getRanking(),
+            'ranking_posts' => $ranking_posts,
             'keyword' => $keyword,
         ]);
     }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -10,14 +10,29 @@ class PostsController extends Controller
 {
     public function index()
     {
-        $posts = Post::orderBy('id','desc')->paginate(10);
-        $ranking_posts = Post::withCount('favoriteUsers')
-        ->orderBy('favorite_users_count', 'desc')
-        ->take(5)
-        ->get();
+        $posts = Post::withCount('favoriteUsers')->orderBy('id','desc')->paginate(10);
         return view('welcome', [
             'posts' => $posts,
-            'ranking_posts' => $ranking_posts,
+            'ranking_posts' => $this->getRanking(),
+        ]);
+    }
+
+    public function search(Request $request)
+    {
+        $keyword = $request->input('keyword');
+        $query = Post::withCount('favoriteUsers');
+
+        if (!empty($keyword)) {
+            $query->where('content', 'LIKE', "%{$keyword}%");
+        }
+
+        $posts = $query->orderBy('id', 'desc')->paginate(10);
+        $posts->appends(['keyword' => $keyword]);
+
+        return view('welcome', [
+            'posts' => $posts,
+            'ranking_posts' => $this->getRanking(),
+            'keyword' => $keyword,
         ]);
     }
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -31,7 +31,7 @@
         @endif
         <div class="card mt-4 mb-4">
                 <div class="card-body">
-                    <form method="GET" action="{{ route('posts.search') }}">
+                    <form method="GET" action="{{ route('welcome') }}">
                         <div class="input-group">
                             <input type="text" name="keyword" class="form-control" placeholder="投稿内容で検索..." value="{{ $keyword ?? '' }}">
                             <div class="input-group-append">
@@ -43,7 +43,7 @@
                     </form>
                     @if(!empty($keyword))
                         <div class="mt-2 text-right">
-                            <a href="{{ url('/') }}" class="text-muted small">検索結果をクリア</a>
+                            <a href="{{ route('welcome') }}" class="text-muted small">検索結果をクリア</a>
                         </div>
                     @endif
                 </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -29,6 +29,25 @@
             </form>
         </div>
         @endif
+        <div class="card mt-4 mb-4">
+                <div class="card-body">
+                    <form method="GET" action="{{ route('posts.search') }}">
+                        <div class="input-group">
+                            <input type="text" name="keyword" class="form-control" placeholder="投稿内容で検索..." value="{{ $keyword ?? '' }}">
+                            <div class="input-group-append">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fas fa-search"></i> 検索
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                    @if(!empty($keyword))
+                        <div class="mt-2 text-right">
+                            <a href="{{ url('/') }}" class="text-muted small">検索結果をクリア</a>
+                        </div>
+                    @endif
+                </div>
+            </div>
 @include('posts.posts', ['posts' => $posts])
     </div>
     <aside class="col-sm-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,9 @@
 //トップページ
 Route::get('/', 'PostsController@index');
 
+// 投稿検索
+Route::get('search', 'PostsController@search')->name('posts.search');
+
 //新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,10 +12,7 @@
 */
 
 //トップページ
-Route::get('/', 'PostsController@index');
-
-// 投稿検索
-Route::get('search', 'PostsController@search')->name('posts.search');
+Route::get('/', 'PostsController@index')->name('welcome');
 
 //新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');


### PR DESCRIPTION
## issue
- Closes #1665 

## 概要
- 投稿の検索機能

## 動作確認手順
- 検索結果が表示された時にも右にランキング表示が出るよう、Controller.phpにgetRankingメソッド記載しPostsController修正。役割から一覧表示（index）とは別に「検索専用」のルート記載。

- 同じ文字をが入っている投稿を11回行った後、検索し以下確認
・where('content', 'LIKE', "%{$keyword}%”)の部分一致検索（LIKE）と、0文字以上(%~%)で検索結果が表示される
・$posts->appends(['keyword' => $keyword]);の検索ワードを維持しまま2ページ目に移動し、その検索結果が表示される
- 検索ワードを入れ検索すると”結果をクリア”の表示が出て、押すとトップページに遷移を確認
- 検索結果のページでもランキングのビューが正しく表示されていることを確認

## 考慮して欲しいこと
- 
## 確認して欲しいこと
-