### PR TITLE
#1674 投稿へのタグ追加機能（表示、投稿、編集・更新、削除など）(すさ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\User;
 use App\Post;
+use App\Tag;
 use App\Http\Requests\PostRequest;
 
 class PostsController extends Controller
@@ -11,27 +12,57 @@ class PostsController extends Controller
     public function index(Request $request)
     {
         $keyword = $request->input('keyword');
+        $tag = $request->input('tag');
         $query = Post::query();
         if (!empty($keyword)) {
             $query->where('content', 'LIKE', "%{$keyword}%");
         }
+        if (!empty($tag)) {
+        $query->whereHas('tags', function ($q) use ($tag) {
+            $q->where('name', $tag);
+        });
+        }
         $posts = $query->orderBy('id', 'desc')->paginate(10);
-        $posts->appends(['keyword' => $keyword]);
+        $posts->appends([
+        'keyword' => $keyword,
+        'tag'     => $tag,
+    ]);
         $ranking_posts = $this->getRanking();
         return view('welcome', [
             'posts' => $posts,
             'ranking_posts' => $ranking_posts,
             'keyword' => $keyword,
+            'tag' => $tag,
         ]);
     }
 
     public function store(PostRequest $request)
     {
+        // 投稿本体の保存
         $post = new Post;
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
         $post->favorite_flag = $request->favorite_flag ? 1 : 0;
         $post->save();
+        // タグの保存と紐付け
+        if ($request->filled('tags')) {
+            $tagNames = preg_split('/\s+/', $request->tags);
+            $tagNames = array_unique(
+                array_map('trim', $tagNames)
+            );
+            $tagIds = [];
+            foreach ($tagNames as $name) {
+                if ($name === '') {
+                    continue;
+                }
+                $tag = Tag::firstOrCreate([
+                    'name' => $name,
+                ]);
+                $tagIds[] = $tag->id;
+            }
+            // 投稿とタグを紐付け
+            $post->tags()->sync($tagIds);
+        }
         return back();
     }
 
@@ -50,8 +81,22 @@ class PostsController extends Controller
     {
         $post = Post::findOrFail($id);
         if (\Auth::id() === $post->user_id) {
+            // 本文の更新
             $post->content = $request->content;
             $post->save();
+            // タグの更新
+            if ($request->has('tags')) {
+                $tagNames = preg_split('/\s+/', $request->tags);
+                $tagNames = array_unique(array_map('trim', $tagNames));
+                $tagIds = [];
+                foreach ($tagNames as $name) {
+                    if ($name === '') continue;
+                    $tag = Tag::firstOrCreate(['name' => $name]);
+                    $tagIds[] = $tag->id;
+                }
+                // 紐付けの同期
+                $post->tags()->sync($tagIds);
+            }
         }
         return redirect('/');
     }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -24,8 +24,8 @@ class PostsController extends Controller
         }
         $posts = $query->orderBy('id', 'desc')->paginate(10);
         $posts->appends([
-        'keyword' => $keyword,
-        'tag'     => $tag,
+            'keyword' => $keyword,
+            'tag'     => $tag,
     ]);
         $ranking_posts = $this->getRanking();
         return view('welcome', [
@@ -99,5 +99,16 @@ class PostsController extends Controller
             }
         }
         return redirect('/');
+    }
+    
+    public function destroy($id)
+    {
+        $post = Post::findOrFail($id);
+
+        if (\Auth::id() === $post->user_id) {
+            $post->delete();
+        }
+
+        return redirect('/')->with('success', '投稿を削除しました');
     }
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -18,15 +18,15 @@ class PostsController extends Controller
             $query->where('content', 'LIKE', "%{$keyword}%");
         }
         if (!empty($tag)) {
-        $query->whereHas('tags', function ($q) use ($tag) {
+            $query->whereHas('tags', function ($q) use ($tag) {
             $q->where('name', $tag);
-        });
+            });
         }
         $posts = $query->orderBy('id', 'desc')->paginate(10);
         $posts->appends([
             'keyword' => $keyword,
             'tag'     => $tag,
-    ]);
+        ]);
         $ranking_posts = $this->getRanking();
         return view('welcome', [
             'posts' => $posts,

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,13 +24,17 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
-            'content' => 'required|max:140'
+            'content' => 'required|max:140',
+            'tags'          => 'nullable|string|max:30',
+            'favorite_flag' => 'nullable|boolean',
         ];
     }
     public function attributes()
     {
         return [
-            'content' => '投稿内容'
+            'content' => '投稿内容',
+            'tags' => 'タグ',
+            'favorite_flag' => 'いいね！の許可設定',
         ];
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -23,4 +23,9 @@ class Post extends Model
     {
         return $this->belongsToMany(User::class, 'favorites', 'post_id', 'user_id')->withTimestamps();
     }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class)->withTimestamps();
+    }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -28,4 +28,15 @@ class Post extends Model
     {
         return $this->belongsToMany(Tag::class)->withTimestamps();
     }
+    
+    protected static function boot()
+    {
+        parent::boot(); // 親クラスのbootを呼び出す
+        static::deleting(function ($post) {
+            // Postが削除（論理削除を含む）されたときに実行される
+            // 中間テーブルの紐付けを解除する
+            $post->tags()->detach();
+        });
+    }
+    
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = ['name'];
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class)->withTimestamps();
+    }
+}

--- a/database/migrations/2026_01_07_114111_create_tags_table.php
+++ b/database/migrations/2026_01_07_114111_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/database/migrations/2026_01_07_114126_create_post_tag_table.php
+++ b/database/migrations/2026_01_07_114126_create_post_tag_table.php
@@ -15,8 +15,8 @@ class CreatePostTagTable extends Migration
     {
         Schema::create('post_tag', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->integer('post_id')->unsigned()->index();
-            $table->integer('tag_id')->unsigned()->index();
+            $table->unsignedBigInteger('post_id')->index();
+            $table->unsignedBigInteger('tag_id')->index();
             $table->timestamps();
             // 外部キー制約
             $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');

--- a/database/migrations/2026_01_07_114126_create_post_tag_table.php
+++ b/database/migrations/2026_01_07_114126_create_post_tag_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('post_id')->unsigned()->index();
+            $table->integer('tag_id')->unsigned()->index();
+            $table->timestamps();
+            // 外部キー制約
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
+            $table->unique(['post_id', 'tag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('post_tag');
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,7 @@
         <title>Topic Posts</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css" rel="stylesheet">
     </head>
     <body>
         @include('commons.header')
@@ -16,5 +17,14 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script defer src="https://use.fontawesome.com/releases/v5.7.2/js/all.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
+        <script>
+            document.querySelectorAll('#tags').forEach(function(el) {
+                new Tagify(el, {
+                    delimiters: " ",
+                    originalInputValueFormat: valuesArr => valuesArr.map(item => item.value).join(' ')
+                });
+            });
+        </script>
     </body>
 </html>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -8,6 +8,18 @@
         <div class="form-group">
             <textarea id="content" class="form-control" name="content" rows="5">{{ old('content',$post->content) }}</textarea>
         </div>
-        <button type="submit" class="btn btn-primary">更新する</button>
+        <div class="form-group">
+            <label for="tags" class="small text-muted">
+                <i class="fas fa-tags"></i> タグ（×で削除 / Enterで追加 / ダブルクリックで編集）
+            </label>
+            
+            {{-- 普通のinputとして配置。値は今まで通りスペース区切りの文字列を渡すだけ --}}
+            <input id="tags" name="tags" class="form-control" 
+                value="{{ old('tags', $post->tags->pluck('name')->implode(' ')) }}">
+        </div>
+        <div class="mt-4">
+            <button type="submit" class="btn btn-primary">更新する</button>
+            <a href="/" class="btn btn-light ml-2">キャンセル</a>
+        </div>
     </form>
-    @endsection
+@endsection

--- a/resources/views/posts/form.blade.php
+++ b/resources/views/posts/form.blade.php
@@ -1,0 +1,27 @@
+<div class="w-75 m-auto">
+    @include('commons.error_messages')
+</div>
+<div class="text-center mb-3">
+    <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+        @csrf
+        <div class="form-group">
+            <textarea class="form-control" name="content" rows="4"></textarea>
+            <div class="text-left mt-3">
+                <label for="tags" class="small text-muted">
+                    <i class="fas fa-tags"></i> タグ（スペースまたはEnterで区切る）
+                </label>
+                {{-- IDを必ず "tags" に合わせる --}}
+                <input id="tags" type="text" name="tags" class="form-control form-control-sm" 
+                       placeholder="例: プログラミング Laravel" value="{{ old('tags', $tag ?? '') }}">
+            </div>
+            <div class="text-left mt-3">
+                <label for="favorite_flag" class="mt-3">
+                    <input id="favorite_flag" type="checkbox" name="favorite_flag" value="1" {{ old('favorite_flag', 1) == 1 ? 'checked' : '' }}>
+                    いいね！を許可する
+                </label>
+                <br>
+                <button type="submit" class="btn btn-primary mt-3">投稿する</button>
+            </div>
+        </div>          
+    </form>
+</div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -21,8 +21,12 @@
                 </div>
                 @if(Auth::check() && Auth::id() == $post->user_id)
                     <div class="d-flex justify-content-between w-75 pb-3 m-auto">
-                        <form method="" action="">
-                            <button type="submit" class="btn btn-danger">削除</button>
+                        <form method="POST" action="{{ route('posts.destroy', $post->id) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('本当に削除しますか？')">
+                                削除
+                            </button>
                         </form>
                         <a href="{{ route('posts.edit', $post->id) }}" class="btn btn-primary">編集する</a>
                     </div>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -8,6 +8,15 @@
             <div class="">
                 <div class="text-left d-inline-block w-75">
                     <p class="mb-2">{{$post->content}}</p>
+                    @if($post->tags->count() > 0)
+                        <div class="mb-2">
+                            @foreach($post->tags as $tag_item)
+                                <a href="{{ route('welcome', ['tag' => $tag_item->name]) }}" class="badge badge-info">
+                                    <i class="fas fa-tag small"></i> {{ $tag_item->name }}
+                                </a>
+                            @endforeach
+                        </div>
+                    @endif
                     <p class="text-muted">{{$post->created_at}}</p>
                 </div>
                 @if(Auth::check() && Auth::id() == $post->user_id)

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,25 +9,20 @@
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
         @if (Auth::check())
-        <div class="w-75 m-auto">
-            @include('commons.error_messages')
-        </div>
-        <div class="text-center mb-3">
-            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
-                @csrf
-                <div class="form-group">
-                    <textarea class="form-control" name="content" rows="4"></textarea>
-                    <div class="text-left mt-3">
-                        <label for="favorite_flag" class="mt-3">
-                            <input id="favorite_flag" type="checkbox" name="favorite_flag" value="1" {{ old('favorite_flag', 1) == 1 ? 'checked' : '' }}>
-                            いいね！を許可する
-                        </label>
-                        <br>
-                        <button type="submit" class="btn btn-primary">投稿する</button>
-                    </div>
-                </div>          
-            </form>
-        </div>
+        @include('posts.form')
+        @endif
+        @if(!empty($tag) || !empty($keyword))
+            <div class="w-75 m-auto alert alert-secondary px-3 py-2 mb-4">
+                @if(!empty($tag))
+                    タグ <strong>#{{ $tag }}</strong> で絞り込み中
+                @endif
+                @if(!empty($keyword))
+                    キーワード <strong>「{{ $keyword }}」</strong> で検索中
+                @endif
+                <a href="{{ route('welcome') }}" class="ml-2 text-dark">
+                    <i class="fas fa-times-circle"></i> 解除して全件表示
+                </a>
+            </div>
         @endif
         <div class="card mt-4 mb-4">
                 <div class="card-body">

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,8 @@ Route::group(['middleware' => 'auth'], function () {
     // 編集
     Route::get('posts/{id}/edit', 'PostsController@edit')->name('posts.edit');
     Route::put('posts/{id}', 'PostsController@update')->name('posts.update');
+    // 削除
+    Route::delete('posts/{id}', 'PostsController@destroy')->name('posts.destroy');
     
     Route::prefix('users/{id}')->group(function () {
         // ユーザー情報


### PR DESCRIPTION
## issue
- Closes #1674 

## 概要
- 投稿へのタグ追加機能（表示、投稿、編集・更新、削除など）

## 動作確認手順
＜表示、投稿、（検索）＞
- 下記コマンドを実行
php artisan make:migration create_tags_table --create=tags、php artisan make:migration create_post_tag_table --create=post_tag
- Tagモデル作成（php artisan make:model Tag ）し→php artisan migrate実行
- 投稿フォーム関連の機能をwelcome.blade.phpからposts/form.blade.php作り移動。そこにタグの入力欄記載（9〜16行目）
- PostsController（store メソッド）、PostRequestにバリデーション追記、posts.blade.phpに追記、PostsControllerのindex() に「tag検索」を追加

＜編集・更新、削除＞
- PostsControllerにupdate メソッド追記、関連view記載
- その後、
・「新規投稿」でタグの自動分割、複数のタグの入力、投稿の実行、一覧画面で投稿の下にタグが表示、DBの確認
・「編集と削除」で編集画面でバツ印での削除、ダブルクリックでの編集、「更新する」ボタンを押し一覧画面で変更を確認
・バリデーション（計30字より多い時はエラー）や、エラー時、ページ遷移時のタグの文字の保持も確認

## 考慮して欲しいこと
- イメージしたタグの扱い方（バツボタンで削除」や「一つずつ独立した編集」）を調べたら、①外部ライブラリ（Tagify）＋JavaScriptを使う。②ライブラリを使わずJavaScript用いいる。③JavaScriptを使用せず記載する、といった方法が出てきました。
②はコード長く理解に苦しみ、③は1件1件のタグを独立したチェックボックスで管理する形でイメージと少し違うのため①を選択。layouts/app.blade.phpにページ内に id="tags" があれば自動でTagifyにする内容追記し関連viewもGeminiを参考に書いています。

## 確認して欲しいこと
- 基本的な書き方、おすすめの書き方があれば、指摘いただけるとありがたいです。
- 外部キー制約の動作確認するために、（投稿削除機能が未実装なので）DBでpost削除しましたが、紐づいているtagは消えず。こういう時は実際に実装して試さないといけませんでしょうか？