### PR TITLE
#1679 リプライ機能 （表示、投稿、編集・更新、削除など）(すさ)

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -14,13 +14,30 @@ class PostsController extends Controller
         $keyword = $request->input('keyword');
         $tag = $request->input('tag');
         $query = Post::query();
-        if (!empty($keyword)) {
-            $query->where('content', 'LIKE', "%{$keyword}%");
-        }
-        if (!empty($tag)) {
-            $query->whereHas('tags', function ($q) use ($tag) {
-            $q->where('name', $tag);
-            });
+        $query->with(['user', 'replies.user', 'tags']);
+        // 検索やタグ絞り込みをしていない場合、リプライ（返信）が一覧のトップに混ざらないように親投稿のみ取得する
+        if (empty($keyword) && empty($tag)) {
+            // 通常時：親投稿のみ
+            $query->whereNull('parent_id');
+        } else {
+            // 検索時：キーワードかタグに一致する投稿を探す
+            $searchQuery = Post::query();
+        
+            if (!empty($keyword)) {
+                $searchQuery->where('content', 'LIKE', "%{$keyword}%");
+            }
+            if (!empty($tag)) {
+                $searchQuery->whereHas('tags', function ($q) use ($tag) {
+                    $q->where('name', $tag);
+                });
+            }
+            // ヒットした投稿の「親ID」を集める（親がいない場合は自分のID）
+            $targetIds = $searchQuery->get()->map(function ($post) {
+                return $post->parent_id ?? $post->id;
+            })->unique();
+
+            // 集めた親IDの投稿を表示対象にする
+            $query->whereIn('id', $targetIds);
         }
         $posts = $query->orderBy('id', 'desc')->paginate(10);
         $posts->appends([
@@ -42,6 +59,7 @@ class PostsController extends Controller
         $post = new Post;
         $post->content = $request->content;
         $post->user_id = $request->user()->id;
+        $post->parent_id = $request->parent_id;
         $post->favorite_flag = $request->favorite_flag ? 1 : 0;
         $post->save();
         // タグの保存と紐付け

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -31,13 +31,22 @@ class PostsController extends Controller
                     $q->where('name', $tag);
                 });
             }
-            // ヒットした投稿の「親ID」を集める（親がいない場合は自分のID）
-            $targetIds = $searchQuery->get()->map(function ($post) {
-                return $post->parent_id ?? $post->id;
-            })->unique();
+            $matchedPosts = $searchQuery->get();
+            // ヒットした投稿から「一番上の親」のIDを収集する
+            $rootIds = [];
+            foreach ($matchedPosts as $post) {
+                $current = $post;
+                // 親がいる間はずっと上に遡る（最上位を探す）
+                while ($current->parent_id !== null) {
+                    // 親投稿を取得（親を辿る）
+                    $current = Post::find($current->parent_id);
+                    if (!$current) break; // 親が見つからなければ終了
+                }
+                $rootIds[] = $current->id;
+            }
 
-            // 集めた親IDの投稿を表示対象にする
-            $query->whereIn('id', $targetIds);
+            // 重複を除去して、その最上位親IDの投稿を表示
+            $query->whereIn('id', array_unique($rootIds));
         }
         $posts = $query->orderBy('id', 'desc')->paginate(10);
         $posts->appends([

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -64,19 +64,30 @@ class PostsController extends Controller
 
     public function store(PostRequest $request)
     {
+        $parentId = $request->parent_id;
+        // 1. 本文(content)の取得
+        if ($parentId) {
+            $content = $request->input("content.$parentId");
+        } else {
+            $content = $request->content; // 親投稿用（通常の投稿フォーム）
+        }
+
+        // 2. タグ(tags)の取得
+        // 親投稿なら $request->tags、返信なら $request->input("tags.$parentId") を見る
+        $tagsInput = $parentId ? $request->input("tags.$parentId") : $request->input("tags.0");
+
         // 投稿本体の保存
         $post = new Post;
-        $post->content = $request->content;
+        $post->content = $content;
         $post->user_id = $request->user()->id;
-        $post->parent_id = $request->parent_id;
+        $post->parent_id = $parentId;
         $post->favorite_flag = $request->favorite_flag ? 1 : 0;
         $post->save();
-        // タグの保存と紐付け
-        if ($request->filled('tags')) {
-            $tagNames = preg_split('/\s+/', $request->tags);
-            $tagNames = array_unique(
-                array_map('trim', $tagNames)
-            );
+
+        // 3. タグの保存と紐付け
+        if (!empty($tagsInput)) {
+            $tagNames = preg_split('/[\s\r\n]+/', $tagsInput);
+            $tagNames = preg_split('/[\s\r\n]+/u', $tagsInput, -1, PREG_SPLIT_NO_EMPTY);
             $tagIds = [];
             foreach ($tagNames as $name) {
                 if ($name === '') {

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -24,8 +24,12 @@ class PostRequest extends FormRequest
     public function rules()
     {
         return [
-            'content' => 'required|max:140',
-            'tags'          => 'nullable|string|max:30',
+            'content.*' => 'required|max:140', // 配列形式（返信）に適用
+            'content'   => 'required_without:parent_id|max:140', // 親投稿用
+            // タグ：親投稿(tags[0])、返信(tags[parent_id])の両方を一括チェック
+            // ドット記法で「tags配列の中身すべて」を指定
+            'tags'      => 'nullable', 
+            'tags.*'    => 'nullable|max:30',
             'favorite_flag' => 'nullable|boolean',
         ];
     }
@@ -33,7 +37,9 @@ class PostRequest extends FormRequest
     {
         return [
             'content' => '投稿内容',
+            'content.*' => '投稿内容',
             'tags' => 'タグ',
+            'tags.*' => 'タグ',
             'favorite_flag' => 'いいね！の許可設定',
         ];
     }

--- a/app/Post.php
+++ b/app/Post.php
@@ -36,7 +36,20 @@ class Post extends Model
             // Postが削除（論理削除を含む）されたときに実行される
             // 中間テーブルの紐付けを解除する
             $post->tags()->detach();
+            // 子リプライを確実に連鎖削除
+            foreach ($post->replies as $reply) {
+                $reply->delete();
+            }
         });
     }
-    
+
+    public function replies()
+    {
+        return $this->hasMany(Post::class, 'parent_id');
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(Post::class, 'parent_id');
+    }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -36,10 +36,8 @@ class Post extends Model
             // Postが削除（論理削除を含む）されたときに実行される
             // 中間テーブルの紐付けを解除する
             $post->tags()->detach();
-            // 子リプライを確実に連鎖削除
-            foreach ($post->replies as $reply) {
-                $reply->delete();
-            }
+            // 子リプライを連鎖削除
+            $post->replies->each->delete();
         });
     }
 

--- a/database/migrations/2026_01_13_113606_add_parent_id_to_posts_table.php
+++ b/database/migrations/2026_01_13_113606_add_parent_id_to_posts_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddParentIdToPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->unsignedBigInteger('parent_id')->nullable()->after('user_id');
+            $table->foreign('parent_id')->references('id')->on('posts')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropForeign(['parent_id']); 
+            $table->dropColumn('parent_id');
+        });
+    }
+}

--- a/resources/views/favorites/favorite_button.blade.php
+++ b/resources/views/favorites/favorite_button.blade.php
@@ -1,5 +1,5 @@
 @if (Auth::check())
-    @if (Auth::id() != $post->user_id && $post->favorite_flag)
+    @if (Auth::id() != $post->user_id && ($post->favorite_flag || !is_null($post->parent_id)))
         @if (Auth::user()->isFavorite($post->id))
             <form method="POST" action="{{ route('favorites.unfavorite', $post->id) }}">
                 @csrf

--- a/resources/views/posts/form.blade.php
+++ b/resources/views/posts/form.blade.php
@@ -10,9 +10,9 @@
                 <label for="tags" class="small text-muted">
                     <i class="fas fa-tags"></i> タグ（スペースまたはEnterで区切る）
                 </label>
-                {{-- IDを必ず "tags" に合わせる --}}
-                <input id="tags" type="text" name="tags" class="form-control form-control-sm" 
-                       placeholder="例: プログラミング Laravel" value="{{ old('tags', $tag ?? '') }}">
+                <input id="tags" type="text" name="tags[0]" class="form-control form-control-sm" 
+                    placeholder="例: プログラミング Laravel" 
+                    value="{{ is_array(old('tags')) ? old('tags.0') : old('tags', $tag ?? '') }}">
             </div>
             <div class="text-left mt-3">
                 <label for="favorite_flag" class="mt-3">

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -42,10 +42,14 @@
                 </div>
                 <div class="text-left w-75 m-auto">
                     @auth
-                        <details class="mb-2">
-                            <summary class="text-primary small" style="cursor: pointer;">
-                                <i class="fas fa-reply"></i> 返信する
-                            </summary>
+                        <details class="mb-2" {{ 
+                            old("content.{$post->id}") || 
+                            old("tags.{$post->id}") || 
+                            $errors->has("content.{$post->id}") || 
+                            $errors->has("tags.{$post->id}") 
+                            ? 'open' : '' 
+                        }}>
+                            <summary class="text-primary small" style="cursor: pointer;">返信する</summary>
                             @include('posts.reply_form', ['parent_id' => $post->id])
                         </details>
                     @endauth

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -34,6 +34,22 @@
                 <div class="d-flex justify-content-center pb-3">
                     @include('favorites.favorite_button', ['post' => $post])
                 </div>
+                <div class="text-left w-75 m-auto">
+                    @auth
+                        <details class="mb-2">
+                            <summary class="text-primary small" style="cursor: pointer;">
+                                <i class="fas fa-reply"></i> 返信する
+                            </summary>
+                            @include('posts.reply_form', ['parent_id' => $post->id])
+                        </details>
+                    @endauth
+                    @include('posts.reply_area', [
+                        'post' => $post, 
+                        'depth' => 0,
+                        'keyword' => $keyword ?? null,
+                        'tag' => $tag ?? null
+                    ])
+                </div>
             </div>
         </li>
     @endforeach

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -7,7 +7,13 @@
             </div>
             <div class="">
                 <div class="text-left d-inline-block w-75">
-                    <p class="mb-2">{{$post->content}}</p>
+                    <p class="mb-2">
+                        @if(!empty($keyword))
+                            {!! str_replace($keyword, '<mark class="p-0">' . $keyword . '</mark>', e($post->content)) !!}
+                        @else
+                            {{$post->content}}
+                        @endif
+                    </p>
                     @if($post->tags->count() > 0)
                         <div class="mb-2">
                             @foreach($post->tags as $tag_item)

--- a/resources/views/posts/reply_area.blade.php
+++ b/resources/views/posts/reply_area.blade.php
@@ -1,12 +1,8 @@
 @php $depth = $depth ?? 0; @endphp
 
 @if($post->replies->count() > 0)
-    @if($depth < 3)
-        <div class="replies-container mt-2 ml-4 border-left pl-3 text-left">
-    @else
-        <div class="replies-container mt-2 ml-0 border-top pt-2 text-left">
-    @endif
-
+    <div class="replies-container mt-2 {{ $depth < 2 ? 'ml-4 border-left pl-3' : 'ml-0 border-top pt-2' }} text-left">
+        
         <details {{ !empty($keyword) || !empty($tag) ? 'open' : '' }}>
             <summary class="text-muted small" style="cursor: pointer;">
                 <i class="fas fa-comments"></i> {{ $post->replies->count() }} 件の返信を表示
@@ -15,16 +11,34 @@
             <div class="mt-3">
                 @foreach($post->replies as $reply)
                     <div class="reply-item mb-3">
-                        <div class="d-flex align-items-center">
+
+                    <div class="d-flex align-items-center">
                             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 30) }}" alt="アバター" style="width: 30px;">
                             <small><strong>{{ $reply->user->name }}</strong></small>
+                            <small class="text-muted ml-2">{{ $reply->created_at->diffForHumans() }}</small>
                         </div>
 
-                        <div class="{{ $depth < 3 ? 'ml-5' : 'ml-4' }}">
-                            <p class="mb-1">{{ $reply->content }}</p>
+                        <div class="{{ $depth < 2 ? 'ml-5' : 'ml-4' }}">
+                            <p class="mb-1">
+                                @if(!empty($keyword))
+                                    {!! str_replace($keyword, '<mark class="p-0">' . $keyword . '</mark>', e($reply->content)) !!}
+                                @else
+                                    {{ $reply->content }}
+                                @endif
+                            </p>
 
-                            <div class="mb-2">
+                            <div class="d-flex align-items-center mb-2">
                                 @include('favorites.favorite_button', ['post' => $reply])
+                                
+                                @if(Auth::check() && Auth::id() == $reply->user_id)
+                                    <div class="ml-3 d-flex align-items-center">
+                                        <a href="{{ route('posts.edit', $reply->id) }}" class="btn btn-primary btn-sm mr-2">編集</a>
+                                        <form method="POST" action="{{ route('posts.destroy', $reply->id) }}">
+                                            @csrf @method('DELETE')
+                                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('この返信を削除しますか？')">削除</button>
+                                        </form>
+                                    </div>
+                                @endif
                             </div>
                             
                             @auth
@@ -47,12 +61,3 @@
         </details>
     </div>
 @endif
-
-<style>
-    /* 3階層目以降のコンテナのマージンを強制的にゼロにする */
-    .replies-container .replies-container .replies-container .replies-container {
-        margin-left: 0 !important;
-        padding-left: 0 !important;
-        border-left: none !important;
-    }
-</style>

--- a/resources/views/posts/reply_area.blade.php
+++ b/resources/views/posts/reply_area.blade.php
@@ -2,8 +2,31 @@
 
 @if($post->replies->count() > 0)
     <div class="replies-container mt-2 {{ $depth < 2 ? 'ml-4 border-left pl-3' : 'ml-0 border-top pt-2' }} text-left">
-        
-        <details {{ !empty($keyword) || !empty($tag) ? 'open' : '' }}>
+        @php
+            $currentParentId = old('parent_id');
+            $isSearching = !empty($keyword) || !empty($tag);
+            
+            // 下層のどこかにエラーがあるか判定する関数
+            $hasErrorInDescendants = function($p) use (&$hasErrorInDescendants, $currentParentId) {
+                foreach ($p->replies as $r) {
+                    if ($r->id == $currentParentId || $hasErrorInDescendants($r)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+            $shouldOpenOuter = false;
+            if ($isSearching) {
+                $shouldOpenOuter = true;
+            } elseif ($currentParentId) {
+                // 「自分の下」のどこかにエラーがあれば開く。
+                // ただし、自分自身がエラーの当事者の場合は、下のリスト（このdetails）は開かない。
+                $shouldOpenOuter = $hasErrorInDescendants($post);
+            }
+        @endphp
+
+        <details {{ $shouldOpenOuter ? 'open' : '' }}>
             <summary class="text-muted small" style="cursor: pointer;">
                 <i class="fas fa-comments"></i> {{ $post->replies->count() }} 件の返信を表示
             </summary>
@@ -11,8 +34,7 @@
             <div class="mt-3">
                 @foreach($post->replies as $reply)
                     <div class="reply-item mb-3">
-
-                    <div class="d-flex align-items-center">
+                        <div class="d-flex align-items-center">
                             <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 30) }}" alt="アバター" style="width: 30px;">
                             <small><strong>{{ $reply->user->name }}</strong></small>
                             <small class="text-muted ml-2">{{ $reply->created_at->diffForHumans() }}</small>
@@ -26,6 +48,16 @@
                                     {{ $reply->content }}
                                 @endif
                             </p>
+
+                            @if($reply->tags->count() > 0)
+                                <div class="mb-2">
+                                    @foreach($reply->tags as $tag_item)
+                                        <a href="{{ route('welcome', ['tag' => $tag_item->name]) }}" class="badge badge-info py-1 px-2" style="font-size: 0.75rem; border-radius: 12px;">
+                                            <i class="fas fa-tag small"></i> {{ $tag_item->name }}
+                                        </a>
+                                    @endforeach
+                                </div>
+                            @endif
 
                             <div class="d-flex align-items-center mb-2">
                                 @include('favorites.favorite_button', ['post' => $reply])
@@ -42,10 +74,10 @@
                             </div>
                             
                             @auth
-                                <details class="mb-2">
-                                    <summary class="text-primary small" style="cursor: pointer;">返信する</summary>
-                                    @include('posts.reply_form', ['parent_id' => $reply->id])
-                                </details>
+                            <details class="mb-2" {{ $currentParentId == $reply->id ? 'open' : '' }}>
+                                <summary class="text-primary small" style="cursor: pointer;">返信する</summary>
+                                @include('posts.reply_form', ['parent_id' => $reply->id])
+                            </details>
                             @endauth
 
                             @include('posts.reply_area', [

--- a/resources/views/posts/reply_area.blade.php
+++ b/resources/views/posts/reply_area.blade.php
@@ -1,0 +1,58 @@
+@php $depth = $depth ?? 0; @endphp
+
+@if($post->replies->count() > 0)
+    @if($depth < 3)
+        <div class="replies-container mt-2 ml-4 border-left pl-3 text-left">
+    @else
+        <div class="replies-container mt-2 ml-0 border-top pt-2 text-left">
+    @endif
+
+        <details {{ !empty($keyword) || !empty($tag) ? 'open' : '' }}>
+            <summary class="text-muted small" style="cursor: pointer;">
+                <i class="fas fa-comments"></i> {{ $post->replies->count() }} 件の返信を表示
+            </summary>
+            
+            <div class="mt-3">
+                @foreach($post->replies as $reply)
+                    <div class="reply-item mb-3">
+                        <div class="d-flex align-items-center">
+                            <img class="mr-2 rounded-circle" src="{{ Gravatar::src($reply->user->email, 30) }}" alt="アバター" style="width: 30px;">
+                            <small><strong>{{ $reply->user->name }}</strong></small>
+                        </div>
+
+                        <div class="{{ $depth < 3 ? 'ml-5' : 'ml-4' }}">
+                            <p class="mb-1">{{ $reply->content }}</p>
+
+                            <div class="mb-2">
+                                @include('favorites.favorite_button', ['post' => $reply])
+                            </div>
+                            
+                            @auth
+                                <details class="mb-2">
+                                    <summary class="text-primary small" style="cursor: pointer;">返信する</summary>
+                                    @include('posts.reply_form', ['parent_id' => $reply->id])
+                                </details>
+                            @endauth
+
+                            @include('posts.reply_area', [
+                                'post' => $reply, 
+                                'depth' => $depth + 1,
+                                'keyword' => $keyword ?? null,
+                                'tag' => $tag ?? null
+                            ])
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </details>
+    </div>
+@endif
+
+<style>
+    /* 3階層目以降のコンテナのマージンを強制的にゼロにする */
+    .replies-container .replies-container .replies-container .replies-container {
+        margin-left: 0 !important;
+        padding-left: 0 !important;
+        border-left: none !important;
+    }
+</style>

--- a/resources/views/posts/reply_form.blade.php
+++ b/resources/views/posts/reply_form.blade.php
@@ -1,0 +1,11 @@
+<form action="{{ route('post.store') }}" method="POST" class="mt-2">
+    @csrf
+    <input type="hidden" name="parent_id" value="{{ $parent_id }}">
+    
+    <div class="form-group mb-1">
+        <textarea name="content" class="form-control form-control-sm" rows="2" placeholder="返信を入力..." required></textarea>
+    </div>
+    <div class="text-right">
+        <button type="submit" class="btn btn-primary btn-sm">返信を投稿</button>
+    </div>
+</form>

--- a/resources/views/posts/reply_form.blade.php
+++ b/resources/views/posts/reply_form.blade.php
@@ -3,8 +3,31 @@
     <input type="hidden" name="parent_id" value="{{ $parent_id }}">
     
     <div class="form-group mb-1">
-        <textarea name="content" class="form-control form-control-sm" rows="2" placeholder="返信を入力..." required></textarea>
+        <textarea 
+            name="content[{{ $parent_id }}]" 
+            class="form-control form-control-sm" 
+            rows="2" 
+            placeholder="返信を入力..." 
+        >{{ old("content.$parent_id") }}</textarea>
+
+        @if($errors->has("content.$parent_id"))
+            <small class="text-danger">投稿内容は140文字以内で入力してください。</small>
+        @endif
     </div>
+
+    <div class="form-group mb-1">
+        <textarea 
+        name="tags[{{ $parent_id }}]" 
+        class="form-control form-control-sm" 
+        rows="1" 
+        placeholder="タグ（スペースやエンターで区切れます）"
+        >{{ old("tags.$parent_id") }}</textarea>
+
+        @if($errors->has("tags.$parent_id"))
+            <small class="text-danger">タグが長すぎます（30文字以内）。</small>
+        @endif
+    </div>
+
     <div class="text-right">
         <button type="submit" class="btn btn-primary btn-sm">返信を投稿</button>
     </div>


### PR DESCRIPTION
## issue
- Closes #1679 

## 概要
- リプライ機能 （表示、投稿、編集・更新、削除など）

## 動作確認手順
- 下記コマンドを実行
php artisan make:migration add_parent_id_to_posts_table --table=posts
- 下記ファイル作成
reply_area.blade.php
reply_form.blade.php
- ブラウザで以下確認
・各投稿に返信ボタン現れ、返信フォーム、「返信を投稿」で下に表示を確認。postsテーブルへの反映も確認
・自分の返信に対し編集、削除ボタンを確認。編集時にタグも付けれること確認。返信を削除するとそれより子の返信も削除されること確認。削除時のposts,tagsともにDBへの正しい反映確認
・depth < 2で、3段目以降の返信は右でなく下に続くこと確認
・検索機能で返信内容もヒットすること確認。
・検索画面で、ヒットした投稿（返信）から一番上の親の投稿までオープンした形で、検索ワードをハイライトにし検索結果に出ることを確認

## 考慮して欲しいこと
- さらに新しい表現が出てきて混乱していますが、view以外の箇所を優先的に整理して徐々にものにしていけたらと思います。
## 確認して欲しいこと