### PR TITLE
投稿へ写真追加機能（レッド）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -24,8 +24,25 @@ class PostsController extends Controller
         $post = new Post;
         $post->content = $request->content;
         $post->user_id = $user->id;
+        
+        // バリデーション
+        $request->validate([
+            'image' => [
+                'nullable',          // 必須チェック
+                'image',             // jpg, png, bmp, gif, svg, webp であること
+                'max:2048',          // サイズ制限（キロバイト単位。2048KB = 2MB）
+                'dimensions:min_width=100,min_height=100,max_width=3000,max_height=3000' // 縦横サイズ
+            ],
+        ]);
+
+        // 2. 画像があるかどうかをチェック！
+         if ($request->hasFile('image')) {
+        // 画像がある場合のみ、この中の store() が実行される
+        $path = $request->file('image')->store('posts', 'public');
+        $post->image_path = $path;
+        }
         $post->save();
-        return redirect()->back()->with('success', '新規投稿しました');;
+        return redirect()->back()->with('success', '新規投稿しました');
     }
 
     public function edit($id)

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -24,22 +24,11 @@ class PostsController extends Controller
         $post = new Post;
         $post->content = $request->content;
         $post->user_id = $user->id;
-        
-        // バリデーション
-        $request->validate([
-            'image' => [
-                'nullable',          // 必須チェック
-                'image',             // jpg, png, bmp, gif, svg, webp であること
-                'max:2048',          // サイズ制限（キロバイト単位。2048KB = 2MB）
-                'dimensions:min_width=100,min_height=100,max_width=3000,max_height=3000' // 縦横サイズ
-            ],
-        ]);
-
-        // 2. 画像があるかどうかをチェック！
-         if ($request->hasFile('image')) {
+        // 画像があるかどうかをチェック！
+        if ($request->hasFile('image')) {
         // 画像がある場合のみ、この中の store() が実行される
-        $path = $request->file('image')->store('posts', 'public');
-        $post->image_path = $path;
+            $path = $request->file('image')->store('posts', 'public');
+            $post->image_path = $path;
         }
         $post->save();
         return redirect()->back()->with('success', '新規投稿しました');

--- a/app/Http/Requests/PostsRequest.php
+++ b/app/Http/Requests/PostsRequest.php
@@ -25,6 +25,7 @@ class PostsRequest extends FormRequest
     {
         return [
             'content' => 'required|max:140',
+            'image' => 'nullable|image|max:2048|dimensions:min_width=100,min_height=100,max_width=3000,max_height=3000',
         ];
     }
     public function attributes()
@@ -33,4 +34,6 @@ class PostsRequest extends FormRequest
             'content' => '投稿',
         ];
     }
+
+
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -14,6 +14,7 @@ class Post extends Model
     protected $fillable = [
         'user_id',
         'content',
+        'image_path',
     ];
     
     public function user()

--- a/database/migrations/2026_01_14_230205_add_image_to_posts_table.php
+++ b/database/migrations/2026_01_14_230205_add_image_to_posts_table.php
@@ -15,7 +15,7 @@ class AddImageToPostsTable extends Migration
     {
         Schema::table('posts', function (Blueprint $table) {
             // 画像がない投稿も許容する場合は nullable() をつけます
-        $table->string('image_path')->nullable();
+            $table->string('image_path')->nullable();
         });
     }
 

--- a/database/migrations/2026_01_14_230205_add_image_to_posts_table.php
+++ b/database/migrations/2026_01_14_230205_add_image_to_posts_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddImageToPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            // 画像がない投稿も許容する場合は nullable() をつけます
+        $table->string('image_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('image_path');
+        });
+    }
+}

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,6 +1,6 @@
 <header class="mb-5">
     <nav class="navbar navbar-expand-sm navbar-dark bg-info">
-        <a class="navbar-brand" href="/">Topic Posts</a>
+        <a class="navbar-brand" href="/">Cチームエンジニア日報</a>
         <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
             <span class="navbar-toggler-icon"></span>
         </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="ja">
     <head>
         <meta charset="utf-8">
-        <title>Topic Posts</title>
+        <title>Cチームエンジニア日報</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     </head>

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -22,7 +22,18 @@
             rows="5"
         >{{ old('content', $post->content) }}</textarea>
     </div>
+    {{-- 現在の写真を表示 --}}
+    @if($post->image_path)
+        <div class="mb-3">
+            <p>現在の写真：</p>
+            <img src="{{ asset('storage/' . $post->image_path) }}" style="max-width: 200px;">
+        </div>
+    @endif
 
+    {{-- 新しい写真を選択 --}}
+    <div class="mb-3">
+        <input type="file" name="image">
+    </div>
     <button type="submit" class="btn btn-primary">更新する</button>
 </form>
 @endsection

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -22,18 +22,6 @@
             rows="5"
         >{{ old('content', $post->content) }}</textarea>
     </div>
-    {{-- 現在の写真を表示 --}}
-    @if($post->image_path)
-        <div class="mb-3">
-            <p>現在の写真：</p>
-            <img src="{{ asset('storage/' . $post->image_path) }}" style="max-width: 200px;">
-        </div>
-    @endif
-
-    {{-- 新しい写真を選択 --}}
-    <div class="mb-3">
-        <input type="file" name="image">
-    </div>
     <button type="submit" class="btn btn-primary">更新する</button>
 </form>
 @endsection

--- a/resources/views/posts/post.blade.php
+++ b/resources/views/posts/post.blade.php
@@ -7,6 +7,11 @@
         </div>
         <div class="">
             <div class="text-left d-inline-block w-75">
+                @if($post->image_path)
+                    <div class="post-image">
+                        <img src="{{ asset('storage/' . $post->image_path) }}" alt="投稿写真" style="max-width: 300px; height: auto; border-radius: 8px;">
+                    </div>
+                @endif
                 <p class="mb-2">{!! nl2br(e($post->content)) !!}</p>  <!-- 改行を表示させる --> 
                 <p class="text-muted">{{ $post->created_at }}</p>
             </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,22 +2,25 @@
 @section('content')
     <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
-            <h1><i class="fas fa-paper-plane pr-3"></i>Topic Posts</h1>
+            <h1><i class="fas fa-desktop"></i> Cチームエンジニア日報</h1>
         </div>
     </div>
-    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
+    <h5 class="text-center mb-3">参考になるもの、ためになるもの等について140字以内で共有しましょう！</h5>
     @if (Auth::check())
         <div class="text-center mb-3">
             <div class="w-75 m-auto">
             @include('commons.error_messages')
             </div>
-            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75" enctype="multipart/form-data" >
                 @csrf
                 <div class="form-group">
                     <textarea class="form-control" name="content" rows="4">{{ old('content') }}</textarea>
-                        <div class="text-left mt-3">
-                            <button type="submit" class="btn btn-primary">投稿する</button>
-                        </div>
+                    <div class="text-left mt-3">
+                    <input type="file" name="image">
+                    </div>
+                    <div class="text-left mt-3">
+                        <button type="submit" class="btn btn-primary">投稿する</button>
+                    </div>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Issue
- Closes #1658 

## 概要

- 投稿へ写真追加機能の実装

## 動作確認手順

- ログイン後、新投稿欄が表示される
- 投稿欄の下にファイル追加ボタンがあり、そちらからローカルの写真を選択
- 投稿のボタンがされたら、投稿完了メッセージとpost箇所に写真とコメントが表示される
- テキストの投稿が可能と確認した

## 考慮してほししいこと
- 一部レイアウトを変更（Topic Post等）
- 削除機能がまだ実装されていないため写真・postの削除が未確認
- 今回は写真追加のみ実装
- 編集等は時間あれば実施予定

## 確認してほしいこと
-