### PR TITLE
#115 ユーザ詳細(八重樫)

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\User;
+
+class UsersController extends Controller
+{
+    public function show($id)
+    {
+        $user = User::findOrFail($id);
+        return view('users.show', [
+            'user' => $user,
+        ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "php": "^7.2.5|^8.0",
         "fideloper/proxy": "^4.4",
         "laravel/framework": "^6.20.26",
-        "laravel/tinker": "^2.5"
+        "laravel/tinker": "^2.5",
+        "thomaswelton/laravel-gravatar": "^1.3"
     },
     "require-dev": {
         "facade/ignition": "^1.16.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e4a9dd2476552506dba12be3b05aeec",
+    "content-hash": "ed0a0136aeded502d0b4d0b0d25fdd2b",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -3742,6 +3742,133 @@
             "time": "2022-05-21T10:00:54+00:00"
         },
         {
+            "name": "thomaswelton/gravatarlib",
+            "version": "0.1.1",
+            "target-dir": "thomaswelton/GravatarLib",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thomaswelton/gravatarlib.git",
+                "reference": "8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thomaswelton/gravatarlib/zipball/8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8",
+                "reference": "8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "suggest": {
+                "twig/twig": ">=1.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "thomaswelton\\GravatarLib\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Thompson",
+                    "email": "sam@emberlabs.org"
+                },
+                {
+                    "name": "Damian Bushong",
+                    "email": "damian@emberlabs.org"
+                },
+                {
+                    "name": "Thomas Welton",
+                    "email": "thomaswelton@me.com"
+                }
+            ],
+            "description": "A lightweight PHP 5.3 OOP library providing easy gravatar integration.",
+            "keywords": [
+                "gravatar",
+                "templating",
+                "twig"
+            ],
+            "support": {
+                "issues": "https://github.com/thomaswelton/gravatarlib/issues",
+                "source": "https://github.com/thomaswelton/gravatarlib/tree/0.1.1"
+            },
+            "time": "2024-08-18T14:10:18+00:00"
+        },
+        {
+            "name": "thomaswelton/laravel-gravatar",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thomaswelton/laravel-gravatar.git",
+                "reference": "bdfa24847a5602aa9273967c8b6d5e3ec6860ed1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thomaswelton/laravel-gravatar/zipball/bdfa24847a5602aa9273967c8b6d5e3ec6860ed1",
+                "reference": "bdfa24847a5602aa9273967c8b6d5e3ec6860ed1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.0|^6.0|^7.0|^8.0",
+                "php": ">=5.4.0",
+                "thomaswelton/gravatarlib": "0.1.x"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.*",
+                "phpunit/phpunit": "4.8.*"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Thomaswelton\\LaravelGravatar\\LaravelGravatarServiceProvider"
+                    ],
+                    "aliases": {
+                        "Gravatar": "Thomaswelton\\LaravelGravatar\\Facades\\Gravatar"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Thomaswelton\\LaravelGravatar\\": "src/",
+                    "Thomaswelton\\Tests\\LaravelGravatar\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "ThomasWelton",
+                    "email": "thomaswelton@me.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Antoine Augusti",
+                    "email": "antoine.augusti@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel 5 Gravatar helper",
+            "homepage": "https://github.com/thomaswelton/laravel-gravatar",
+            "keywords": [
+                "gravatar",
+                "laravel",
+                "laravel5"
+            ],
+            "support": {
+                "issues": "https://github.com/thomaswelton/laravel-gravatar/issues",
+                "source": "https://github.com/thomaswelton/laravel-gravatar/tree/1.3.0"
+            },
+            "abandoned": "creativeorange/gravatar",
+            "time": "2020-10-12T14:45:23+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "2.2.4",
             "source": {
@@ -6551,12 +6678,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.2.5|^8.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -15,7 +15,7 @@ class UsersTableSeeder extends Seeder
             DB::table('users')->insert([
                 'name' => 'test'. $i,
                 'email' => 'test'. $i. '@test.com',
-                'password' => bcrypt('passtest'. $i)
+                'password' => bcrypt('test'. $i)
             ]);
         }
     }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -15,7 +15,7 @@ class UsersTableSeeder extends Seeder
             DB::table('users')->insert([
                 'name' => 'test'. $i,
                 'email' => 'test'. $i. '@test.com',
-                'password' => bcrypt('testtest'. $i)
+                'password' => bcrypt('passtest'. $i)
             ]);
         }
     }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -15,7 +15,7 @@ class UsersTableSeeder extends Seeder
             DB::table('users')->insert([
                 'name' => 'test'. $i,
                 'email' => 'test'. $i. '@test.com',
-                'password' => bcrypt('test'. $i)
+                'password' => bcrypt('testtest'. $i)
             ]);
         }
     }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -24,8 +24,7 @@
                 </div>
                 <button type="submit" class="btn btn-primary mt-2">ログイン</button>
             </form>
-            <div class="mt-2"><a href="">新規ユーザ登録する？</a></div>
-            <!-- 「新規ユーザ登録」完了後に調整 -->
+            <div class="mt-2"><a href="{{ route('signup') }}">新規ユーザ登録する？</a></div>
         </div>
     </div>
 @endsection

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -13,7 +13,6 @@
                 @else
                     <li class="nav-item"><a href="{{ route('login') }}" class="nav-link text-light">ログイン</a></li>
                     <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>
-                    <!-- 「新規ユーザ登録」完了後に調整 -->
                 @endif
             </ul>
         </div>

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,7 +8,7 @@
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
                 @if(Auth::check())
-                    <li class="nav-item"><a href="" class="nav-link text-light">{{ Auth::user()->name}}</a></li>
+                    <li class="nav-item"><a href="{{ route('user.show', Auth::id()) }}" class="nav-link text-light">{{ Auth::user()->name }}</a></li>
                     <li class="nav-item"><a href="{{ route('logout') }}" class="nav-link text-light">ログアウト</a></li>
                 @else
                     <li class="nav-item"><a href="{{ route('login') }}" class="nav-link text-light">ログイン</a></li>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -16,7 +16,7 @@
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
-                <li class="nav-item"><a href="" class="nav-link {{ Request::is() ? 'active' : '' }}">タイムライン</a></li>
+                <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('user/*') ? 'active' : '' }}">タイムライン</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
             </ul>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app')
+@section('content')
+    <div class="row">
+        <aside class="col-sm-4 mb-5">
+            <div class="card bg-info">
+                <div class="card-header">
+                    <h3 class="card-title text-light">{{ $user->name }}</h3>
+                </div>
+                <div class="card-body">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像">
+                        <div class="mt-3">
+                            <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                        </div>
+                </div>
+            </div>
+        </aside>
+        <div class="col-sm-8">
+            <ul class="nav nav-tabs nav-justified mb-3">
+                <li class="nav-item"><a href="" class="nav-link {{ Request::is() ? 'active' : '' }}">タイムライン</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
+            </ul>
+        </div>
+    </div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -7,7 +7,7 @@
                     <h3 class="card-title text-light">{{ $user->name }}</h3>
                 </div>
                 <div class="card-body">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 55) }}" alt="ユーザのアバター画像">
+                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 248) }}" alt="ユーザのアバター画像">
                         <div class="mt-3">
                             <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                         </div>
@@ -16,7 +16,7 @@
         </aside>
         <div class="col-sm-8">
             <ul class="nav nav-tabs nav-justified mb-3">
-                <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('user/*') ? 'active' : '' }}">タイムライン</a></li>
+                <li class="nav-item"><a href="{{ route('user.show', $user->id) }}" class="nav-link {{ Request::is('users/*') ? 'active' : '' }}">タイムライン</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロー中</a></li>
                 <li class="nav-item"><a href="#" class="nav-link">フォロワー</a></li>
             </ul>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -7,10 +7,12 @@
                     <h3 class="card-title text-light">{{ $user->name }}</h3>
                 </div>
                 <div class="card-body">
-                    <img class="mr-2 rounded-circle" src="{{ Gravatar::src($user->email, 248) }}" alt="ユーザのアバター画像">
+                    <img class="rounded-circle" src="{{ Gravatar::src($user->email, 200) }}" alt="ユーザのアバター画像" style="display: block; margin: 0 auto">
+                    @if(Auth::check() && $user->id === Auth::user()->id)
                         <div class="mt-3">
                             <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
                         </div>
+                    @endif
                 </div>
             </div>
         </aside>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,3 +22,7 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
+// ユーザ詳細
+Route::prefix('user')->group( function() {
+    Route::get('{id}', 'UsersController@show')->name('user.show');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,6 @@ Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
 // ユーザ詳細
-Route::prefix('user')->group( function() {
+Route::prefix('users')->group( function() {
     Route::get('{id}', 'UsersController@show')->name('user.show');
 });


### PR DESCRIPTION
## issue
 - Closes #115

## 概要
 - ユーザ詳細
 - 現状のusersテーブルのシーダーではパスワードが「test+番号」であるが、パスワードが「8文字以上」という規制に併せて「passtest+番号」に変更


## 動作確認手順
 - localhost:8080/user/〇（←id番号）でユーザ詳細ページに遷移することを確認
 - 任意のユーザでの+E496ログイン状態において、ヘッダーのユーザ名をクリックして当該ユーザの詳細ページに遷移することを確認
