### PR TITLE
#119 投稿新規作成

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -14,7 +14,17 @@ class PostsController extends Controller
         return view('welcome');
     }
 
-    public function edit($id)
+    public function create(PostRequest $request)    // 投稿新規作成
+    {
+        $user = \Auth::user();
+        $post = new Post;
+        $post->user_id = $user->id;
+        $post->content = $request->content;
+        $post->save();
+        return back();
+    }
+
+    public function edit($id)   // 投稿編集画面の表示
     {
         $user = \Auth::user();
         $post = Post::findOrFail($id);
@@ -29,7 +39,7 @@ class PostsController extends Controller
         }
     }
 
-    public function update(PostRequest $request, $id)
+    public function update(PostRequest $request, $id)   // 投稿更新
     {
         $post = Post::findOrFail($id);
         $post->content = $request->content;

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -14,7 +14,7 @@ class PostsController extends Controller
         return view('welcome');
     }
 
-    public function create(PostRequest $request)    // 投稿新規作成
+    public function store(PostRequest $request)    // 投稿新規作成
     {
         $user = \Auth::user();
         $post = new Post;

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\User;
-use App\Post;
 
 class UsersController extends Controller
 {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -19,7 +19,7 @@ class UsersController extends Controller
     public function destroy($id)
     {
         $user = \Auth::user();
-        if ($id === $user->id) {
+        if ($id == $user->id) {
             $user->delete();
         }
         return redirect('/');

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -8,14 +8,16 @@
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
         <div class="w-75 m-auto">@include('commons.error_messages')</div>
         <div class="text-center mb-3">
-            <form method="POST" action="{{ route('post.create') }}" class="d-inline-block w-75">
+            @if(Auth::check())
+            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
                 @csrf
                 <div class="form-group">
-                    <textarea id="content" class="form-control" name="content" rows="" value="{{ old('content') }}"></textarea>
+                    <textarea id="content" class="form-control" name="content" rows="4" value="{{ old('content') }}"></textarea>
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-primary">投稿する</button>
                     </div>
                 </div>
             </form>
+            @endif
         </div>
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
             <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
                 @csrf
                 <div class="form-group">
-                    <textarea id="content" class="form-control" name="content" rows="4" value="{{ old('content') }}"></textarea>
+                    <textarea id="content" class="form-control" name="content" rows="4" value="">{{ old('content') }}</textarea>
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-primary">投稿する</button>
                     </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -8,9 +8,10 @@
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
         <div class="w-75 m-auto">@include('commons.error_messages')</div>
         <div class="text-center mb-3">
-            <form method="" action="" class="d-inline-block w-75">
+            <form method="POST" action="{{ route('post.create') }}" class="d-inline-block w-75">
+                @csrf
                 <div class="form-group">
-                    <textarea class="form-control" name="" rows=""></textarea>
+                    <textarea id="content" class="form-control" name="content" rows="" value="{{ old('content') }}"></textarea>
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-primary">投稿する</button>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,7 @@ Route::prefix('users')->group( function() {
 
 // ログイン後に可能な処理のグループ
 Route::group(['middleware' => 'auth'], function() {
+    Route::post('', 'PostsController@create')->name('post.create'); //投稿新規作成
     Route::delete('users/{id}', 'UsersController@destroy')->name('user.delete'); //退会
     Route::prefix('posts')->group( function() {
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit'); //投稿編集

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,9 +29,9 @@ Route::prefix('users')->group( function() {
 
 // ログイン後に可能な処理のグループ
 Route::group(['middleware' => 'auth'], function() {
-    Route::post('', 'PostsController@create')->name('post.create'); //投稿新規作成
     Route::delete('users/{id}', 'UsersController@destroy')->name('user.delete'); //退会
     Route::prefix('posts')->group( function() {
+        Route::post('', 'PostsController@store')->name('post.store'); //投稿新規作成
         Route::get('{id}/edit', 'PostsController@edit')->name('post.edit'); //投稿編集
         Route::put('{id}', 'PostsController@update')->name('post.update'); //投稿更新
     });


### PR DESCRIPTION
## issue
 - Closes #119

## 概要
 - 投稿新規作成

## 動作確認手順
 - ログイン状態でトップページの欄に文章を入力し「投稿する」ボタンを押すとpostテーブルに投稿が追加される。
 - 空白、140文字以上の入力に対してはそれぞれエラーメッセージが表示され、投稿は作成されない。
 - 作成した投稿は該当するユーザが"localhost:8080/posts/〇/editで編集可能