### PR TITLE
#95 postsテーブルのマイグレーションとシーダー作成(ようこ)

### DIFF
--- a/database/migrations/2026_06_20_190337_create_posts_table.php
+++ b/database/migrations/2026_06_20_190337_create_posts_table.php
@@ -15,7 +15,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->string('post_text');
+            $table->string('content');
             $table->bigInteger('user_id')->unsigned()->index();
             $table->timestamps();
             $table->softDeletes();

--- a/database/migrations/2026_06_20_190337_create_posts_table.php
+++ b/database/migrations/2026_06_20_190337_create_posts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('post_text');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->timestamps();
+            $table->softDeletes();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -13,23 +13,51 @@ class PostsTableSeeder extends Seeder
     {
          DB::table('posts')->insert([
             'user_id' => 1,
-            'post_text' => 'テスト投稿１です',
-        
+            'content' => 'テスト投稿１です',
+        ]);
+         DB::table('posts')->insert([
+            'user_id' => 1,
+            'content' => 'テスト投稿２です',
          ]);
          DB::table('posts')->insert([
             'user_id' => 1,
-            'post_text' => 'テスト投稿２です',
-        
+            'content' => 'テスト投稿３です',
          ]);
          DB::table('posts')->insert([
-            'user_id' => 1,
-            'post_text' => 'テスト投稿３です',
-         
+            'user_id' => 2,
+            'content' => 'テスト投稿４です',
          ]);
          DB::table('posts')->insert([
-            'user_id' => 1,
-            'post_text' => 'テスト投稿４です',
-         
+            'user_id' => 2,
+            'content' => 'テスト投稿５です',
+        ]);
+         DB::table('posts')->insert([
+            'user_id' => 2,
+            'content' => 'テスト投稿６です',
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 3,
+            'content' => 'テスト投稿７です',
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 3,
+            'content' => 'テスト投稿８です',
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 3,
+            'content' => 'テスト投稿９です',
+        ]);
+         DB::table('posts')->insert([
+            'user_id' => 4,
+            'content' => 'テスト投稿１０です',
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 4,
+            'content' => 'テスト投稿１１です',
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 4,
+            'content' => 'テスト投稿１２です',
          ]);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+         DB::table('posts')->insert([
+            'user_id' => 1,
+            'post_text' => 'テスト投稿１です',
+        
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 1,
+            'post_text' => 'テスト投稿２です',
+        
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 1,
+            'post_text' => 'テスト投稿３です',
+         
+         ]);
+         DB::table('posts')->insert([
+            'user_id' => 1,
+            'post_text' => 'テスト投稿４です',
+         
+         ]);
+    }
+}


### PR DESCRIPTION
## issue
- closes #95

##概要
‐ postsテーブルのマイグレーションとシーダー作成

##動作確認手順
‐ 下記コマンドを実行
php artisan migrate --seed
- Adminerでpostsテーブルに4個のレコードが保存されていることを確認

##考慮してほしいこと
‐ 状況に応じて、下記コマンドで動作確認する必要あり。
php artisan migrate:fresh --seed

##確認してほしいこと
データベースの構成がこれで良かったのか確認したいです。
```
 Schema::create('posts', function (Blueprint $table) {
            $table->bigIncrements('id');
            $table->string('post_text');
            $table->bigInteger('user_id')->unsigned()->index();
            $table->timestamps();
            $table->softDeletes();
            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
        });
```
