### PR TITLE
#115 ユーザ詳細機能を実装 / Yosuke

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-// use App\Providers\RouteServiceProvider;
 use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,13 +10,4 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
-
-    public function userCounts($user)
-    {
-        $countPosts = $user->posts()->count();
-
-        return [
-            'countPosts' => $countPosts,
-        ];
-    }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,4 +10,13 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    public function userCounts($user)
+    {
+        $countPosts = $user->posts()->count();
+
+        return [
+            'countPosts' => $countPosts,
+        ];
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\User;
-// use Illuminate\Http\Request;
 
 class UsersController extends Controller
 {
@@ -18,14 +17,12 @@ class UsersController extends Controller
 
         $posts = $user->posts()
             ->orderBy('id', 'desc')
-            ->paginate(9);
+            ->paginate(10);
 
         $data = [
             'user' => $user,
             'posts' => $posts,
         ];
-
-        $data += $this->userCounts($user);
 
         return view('users.show', $data);
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -2,12 +2,31 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\User;
+// use Illuminate\Http\Request;
 
 class UsersController extends Controller
 {
     public function index()
     {
         return view('welcome');
+    }
+
+    public function show($id)
+    {
+        $user = User::findOrFail($id);
+
+        $posts = $user->posts()
+            ->orderBy('id', 'desc')
+            ->paginate(9);
+
+        $data = [
+            'user' => $user,
+            'posts' => $posts,
+        ];
+
+        $data += $this->userCounts($user);
+
+        return view('users.show', $data);
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Post extends Model
+{
+    use SoftDeletes;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -38,4 +38,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "php": "^7.2.5|^8.0",
         "fideloper/proxy": "^4.4",
         "laravel/framework": "^6.20.26",
-        "laravel/tinker": "^2.5"
+        "laravel/tinker": "^2.5",
+        "thomaswelton/laravel-gravatar": "^1.3"
     },
     "require-dev": {
         "facade/ignition": "^1.16.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e4a9dd2476552506dba12be3b05aeec",
+    "content-hash": "ed0a0136aeded502d0b4d0b0d25fdd2b",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -3742,6 +3742,133 @@
             "time": "2022-05-21T10:00:54+00:00"
         },
         {
+            "name": "thomaswelton/gravatarlib",
+            "version": "0.1.1",
+            "target-dir": "thomaswelton/GravatarLib",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thomaswelton/gravatarlib.git",
+                "reference": "8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thomaswelton/gravatarlib/zipball/8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8",
+                "reference": "8cb3b8c4b6c98881c666d7d09641e3cc4a5896d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "suggest": {
+                "twig/twig": ">=1.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "thomaswelton\\GravatarLib\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Thompson",
+                    "email": "sam@emberlabs.org"
+                },
+                {
+                    "name": "Damian Bushong",
+                    "email": "damian@emberlabs.org"
+                },
+                {
+                    "name": "Thomas Welton",
+                    "email": "thomaswelton@me.com"
+                }
+            ],
+            "description": "A lightweight PHP 5.3 OOP library providing easy gravatar integration.",
+            "keywords": [
+                "gravatar",
+                "templating",
+                "twig"
+            ],
+            "support": {
+                "issues": "https://github.com/thomaswelton/gravatarlib/issues",
+                "source": "https://github.com/thomaswelton/gravatarlib/tree/0.1.1"
+            },
+            "time": "2024-08-18T14:10:18+00:00"
+        },
+        {
+            "name": "thomaswelton/laravel-gravatar",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thomaswelton/laravel-gravatar.git",
+                "reference": "bdfa24847a5602aa9273967c8b6d5e3ec6860ed1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thomaswelton/laravel-gravatar/zipball/bdfa24847a5602aa9273967c8b6d5e3ec6860ed1",
+                "reference": "bdfa24847a5602aa9273967c8b6d5e3ec6860ed1",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "~5.0|^6.0|^7.0|^8.0",
+                "php": ">=5.4.0",
+                "thomaswelton/gravatarlib": "0.1.x"
+            },
+            "require-dev": {
+                "mockery/mockery": "0.9.*",
+                "phpunit/phpunit": "4.8.*"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Thomaswelton\\LaravelGravatar\\LaravelGravatarServiceProvider"
+                    ],
+                    "aliases": {
+                        "Gravatar": "Thomaswelton\\LaravelGravatar\\Facades\\Gravatar"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Thomaswelton\\LaravelGravatar\\": "src/",
+                    "Thomaswelton\\Tests\\LaravelGravatar\\": "tests/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "ThomasWelton",
+                    "email": "thomaswelton@me.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Antoine Augusti",
+                    "email": "antoine.augusti@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel 5 Gravatar helper",
+            "homepage": "https://github.com/thomaswelton/laravel-gravatar",
+            "keywords": [
+                "gravatar",
+                "laravel",
+                "laravel5"
+            ],
+            "support": {
+                "issues": "https://github.com/thomaswelton/laravel-gravatar/issues",
+                "source": "https://github.com/thomaswelton/laravel-gravatar/tree/1.3.0"
+            },
+            "abandoned": "creativeorange/gravatar",
+            "time": "2020-10-12T14:45:23+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "2.2.4",
             "source": {
@@ -6551,12 +6678,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^7.2.5|^8.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,6 +8,18 @@
             <ul class="navbar-nav mr-auto"></ul>
             <ul class="navbar-nav">
                     <li class="nav-item"><a href="" class="nav-link text-light">ログインユーザ名</a></li>
+
+                    @if (Auth::check())
+                        <li class="nav-item">
+                            <a
+                                href="{{ route('user.show', Auth::id()) }}"
+                                class="nav-link text-light"
+                            >
+                                マイページ
+                            </a>
+                        </li>
+                    @endif
+
                     <li class="nav-item"><a href="" class="nav-link text-light">ログアウト</a></li>
                     <li class="nav-item"><a href="" class="nav-link text-light">ログイン</a></li>
                     <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link text-light">新規ユーザ登録</a></li>

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,0 +1,19 @@
+<div class="row mt-5">
+    @foreach ($posts as $post)
+        <div class="col-lg-4 mb-5">
+            <div class="card h-100 text-left">
+                <div class="card-body">
+                    <p class="card-text">
+                        {{ $post->content }}
+                    </p>
+                </div>
+
+                <div class="card-footer text-muted">
+                    {{ $post->created_at }}
+                </div>
+            </div>
+        </div>
+    @endforeach
+</div>
+
+{{ $posts->links('pagination::bootstrap-4') }}

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -1,19 +1,39 @@
-<div class="row mt-5">
-    @foreach ($posts as $post)
-        <div class="col-lg-4 mb-5">
-            <div class="card h-100 text-left">
-                <div class="card-body">
-                    <p class="card-text">
+<ul class="list-unstyled">
+    @forelse ($posts as $post)
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+                <img
+                    class="mr-2 rounded-circle"
+                    src="{{ Gravatar::src($post->user->email, 55) }}"
+                    alt="{{ $post->user->name }}のアバター画像"
+                >
+
+                <p class="mt-3 mb-0 d-inline-block">
+                    <a href="{{ route('user.show', $post->user->id) }}">
+                        {{ $post->user->name }}
+                    </a>
+                </p>
+            </div>
+
+            <div>
+                <div class="text-left d-inline-block w-75">
+                    <p class="mb-2">
                         {{ $post->content }}
                     </p>
-                </div>
 
-                <div class="card-footer text-muted">
-                    {{ $post->created_at }}
+                    <p class="text-muted">
+                        {{ $post->created_at }}
+                    </p>
                 </div>
             </div>
-        </div>
-    @endforeach
-</div>
+        </li>
+    @empty
+        <li class="text-center">
+            投稿はありません。
+        </li>
+    @endforelse
+</ul>
 
-{{ $posts->links('pagination::bootstrap-4') }}
+<div class="m-auto" style="width: fit-content">
+    {{ $posts->links('pagination::bootstrap-4') }}
+</div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,27 +1,58 @@
 @extends('layouts.app')
 
 @section('content')
-    <h1>{{ $user->name }}</h1>
-
-    <ul class="nav nav-tabs nav-justified mt-5 mb-2">
-        <li class="nav-item nav-link {{ Request::is('users/' . $user->id) ? 'active' : '' }}">
-            <a href="{{ route('user.show', $user->id) }}">
-                投稿（Oops）
-                <br>
-                <div class="badge badge-secondary">
-                    {{ $countPosts }}
+    <div class="row">
+        <aside class="col-sm-4 mb-5">
+            <div class="card bg-info">
+                <div class="card-header">
+                    <h3 class="card-title text-light">
+                        {{ $user->name }}
+                    </h3>
                 </div>
-            </a>
-        </li>
 
-        <li class="nav-item nav-link">
-            <a href="">
-                お気に入り
-                <br>
-                <div class="badge badge-secondary"></div>
-            </a>
-        </li>
-    </ul>
+                <div class="card-body">
+                    <img
+                        class="rounded-circle img-fluid d-block mx-auto"
+                        src="{{ Gravatar::src($user->email, 300) }}"
+                        alt="{{ $user->name }}のアバター画像"
+                    >
 
-    @include('posts.posts', ['posts' => $posts])
+                    @if (Auth::check() && Auth::id() === $user->id)
+                        <div class="mt-3">
+                            <a href="#" class="btn btn-primary btn-block">
+                                ユーザ情報の編集
+                            </a>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </aside>
+
+        <div class="col-sm-8">
+            <ul class="nav nav-tabs nav-justified mb-3">
+                <li class="nav-item">
+                    <a
+                        href="{{ route('user.show', $user->id) }}"
+                        class="nav-link {{ Request::is('users/' . $user->id) ? 'active' : '' }}"
+                    >
+                        タイムライン
+                    </a>
+                </li>
+
+                <li class="nav-item">
+                    <a href="#" class="nav-link">
+                        フォロー中
+                    </a>
+                </li>
+
+                <li class="nav-item">
+                    <a href="#" class="nav-link">
+                        フォロワー
+                    </a>
+                </li>
+            </ul>
+
+            @include('posts.posts', ['posts' => $posts])
+        </div>
+    </div>
 @endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.app')
+
+@section('content')
+    <h1>{{ $user->name }}</h1>
+
+    <ul class="nav nav-tabs nav-justified mt-5 mb-2">
+        <li class="nav-item nav-link {{ Request::is('users/' . $user->id) ? 'active' : '' }}">
+            <a href="{{ route('user.show', $user->id) }}">
+                投稿（Oops）
+                <br>
+                <div class="badge badge-secondary">
+                    {{ $countPosts }}
+                </div>
+            </a>
+        </li>
+
+        <li class="nav-item nav-link">
+            <a href="">
+                お気に入り
+                <br>
+                <div class="badge badge-secondary"></div>
+            </a>
+        </li>
+    </ul>
+
+    @include('posts.posts', ['posts' => $posts])
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,13 @@
 |
 */
 
+// ユーザ
 Route::get('/', 'UsersController@index');
+
+Route::prefix('users')->group(function () {
+    // ユーザ詳細画面を表示
+    Route::get('{id}', 'UsersController@show')->name('user.show');
+});
 
 // ユーザ新規登録画面を表示
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');


### PR DESCRIPTION
## Issue

- Closes #115

## 概要

- `Post` モデルを作成
- `Post::user()` と `User::posts()` のリレーションを定義
- ユーザ詳細用ルートを追加
- ユーザの投稿数を取得する `userCounts()` を追加
- `UsersController@show` を追加
- 対象ユーザの投稿をID降順・9件ずつ取得
- ユーザ詳細画面 `resources/views/users/show.blade.php` を作成
- 投稿一覧表示を `resources/views/posts/posts.blade.php` に分離
- ユーザ詳細画面から投稿一覧用Viewを `@include` で読み込む構成に変更
- ヘッダーに「マイページ」リンクを追加
- 前回のレビューで指摘された、未使用の `RouteServiceProvider` のコメントアウト行を削除

## 動作確認手順

1. 下記URLへアクセス

```text
http://localhost:8080/users/1
```

2. ユーザ詳細画面を確認
3. ユーザ名、投稿数、対象ユーザの投稿一覧が表示されることを確認
4. 投稿がIDの降順で表示されることを確認
5. 投稿がないユーザの詳細画面へアクセスし、エラーにならないことを確認
6. 存在しないユーザIDへアクセスし、404になることを確認
7. 未ログイン時に、ヘッダーの「マイページ」が表示されないことを確認

## 考慮してほしいこと

- ログイン・ログアウト機能が未実装のため、ログイン済み状態での「マイページ」の表示および遷移確認は未実施で、当該機能の実装・マージ後に実施する想定です
- トップページの投稿表示が未実装のため、トップページ上のユーザ名からユーザ詳細画面へ遷移するリンクは未対応です
- 投稿一覧表示は `resources/views/posts/posts.blade.php` に分離し、トップページでも再利用できる構成を想定しています
- `Post` モデルと投稿一覧用の共通Viewを作成したことは、他メンバーへSlackで共有済みです

## 確認してほしいこと

- 今後使用予定のため、`UsersController.php` に `Request` の `use` 文をコメントアウトで残していますが、現時点では削除した方がよいでしょうか（開発の通例ではどうするのが妥当でしょうか）