### PR TITLE
#107　ユーザ新規登録(吉田)

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -29,7 +29,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
+    protected $redirectTo ='/';
 
     /**
      * Create a new controller instance.

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -18,10 +18,10 @@ class RedirectIfAuthenticated
      */
     public function handle($request, Closure $next, $guard = null)
     {
-        if (Auth::guard($guard)->check()) {
-            return redirect(RouteServiceProvider::HOME);
-        }
+    if (Auth::guard($guard)->check()) {
+        return redirect('/');
+    }
 
-        return $next($request);
+    return $next($request);
     }
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,34 @@
+    <div class="text-center">
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+    </div>
+    <div class="text-center mt-3">
+        <p class="text-left d-inline-block">新規ユーザ登録すると投稿で<br>コミュニケーションができるようになります。</p>
+        @include('commons.error_messages')
+    </div>
+    <div class="text-center">
+        <h3 class="login_title text-left d-inline-block mt-5">新規ユーザ登録</h3>
+    </div>
+    <div class="row mt-5 mb-5">
+        <div class="col-sm-6 offset-sm-3">
+            <form method="POST" action="{{ route('signup.post') }}">
+                @csrf
+                <div class="form-group">
+                    <label for="name">名前</label>
+                    <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}">
+                </div>
+                <div class="form-group">
+                    <label for="email">メールアドレス</label>
+                    <input id="email" type="text" class="form-control" name="email" value="{{ old('email') }}">
+                </div>
+                <div class="form-group">
+                    <label for="password">パスワード</label>
+                    <input id="password" type="password" class="form-control" name="password" value="{{ old('password') }}">
+                </div>
+                <div class="form-group">
+                    <label for="password_confirmation">パスワード確認</label>
+                    <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" value="{{ old('password_confirmation') }}">
+                </div>
+                <button type="submit" class="btn btn-primary mt-2">新規登録</button>
+            </form>
+        </div>
+    </div>

--- a/resources/views/commons/error_messages.blade.php
+++ b/resources/views/commons/error_messages.blade.php
@@ -1,0 +1,7 @@
+@if (count($errors) > 0)
+    <ul class="alert alert-danger" role="alert">
+        @foreach ($errors->all() as $error)
+            <li class="ml-4">{{ $error }}</li>
+        @endforeach
+    </ul>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,8 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
+Route::get('/', function () {return view('welcome');});
 
-Route::get('/', function () {
-    return view('welcome');
-});
+// ユーザ新規登録
+Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
+Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,9 @@
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::get('/', function () {return view('welcome');});
+Route::get('/', function () {
+    return view('welcome');
+});
 
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');


### PR DESCRIPTION
## issue
- Closes #107
## 概要
ユーザ新規登録機能を実装
- web.php(routeファイル)に、新規登録画面表示のgetメソッドを追加
- web.php(routeファイル)に、新規登録情報送信のpostメソッドを追加
- RegisterController(Controlleファイル)を新規作成
- 登録成功後に、遷移先画面を "/" に変更
- resources/views/auth/register.blade.php を新規作成
- 名前、メールアドレス、パスワード、パスワード確認の入力フォームを実装
- @csrf によるCSRF対策を実装
- resources/views/commons/error_messages.blade.php を新規作成
- 新規登録時にバリディーションのエラーメッセージが表示されるように、@include('commons.error_messages')を追記
- 指摘があったRedirectIfAuthenticatedファイルのhandleメソッドを修正いたしました。
## 動作確認手順
①下記URLへアクセス
```text
http://localhost:8080/signup
```

②新規登録画面が表示されていることを確認

③以下の内容を入力して送信を実行
```text
名前：test10
メールアドレス：test10@test.com
パスワード：password
パスワード確認：passwordp
```

④登録後、トップページへリダイレクトされることを確認

⑤Adminer の users テーブルを開き、以下の登録情報を確認
- 入力したユーザの表示
- パスワードが平文ではなく、ハッシュ化されている
- created_at と updated_at の日時の情報が登録されている
- deleted_at が NULL になっている

⑥再び、以下のURLにアクセス
```text
http://localhost:8080/signup
```

⑦全項目を空欄で送信し、バリデーションエラーが表示されることを確認

⑧登録画面遷移後に、以下のURLにアクセスにアクセスし、http://localhost:8080/homeにアクセスしないことを確認
```text
http://localhost:8080/signup
```

## 考慮してほしいこと
- 共通レイアウト（レイアウトファイル）、ヘッダー、フッターが未実装のため、ユーザー登録画面は暫定的に個別のHTML構成で作成しています。共通レイアウト実装後に適用予定です。
- 次回のタスクであるユーザー詳細のpullrequestの際に、register.blade.php に以下のコードを追記いたします。
```text
 @extends('layouts.app')
 @section('content')
    {{-- 登録画面本体 --}}
 @endsection
```

## 確認してほしいこと
- 6/25のMTGで確認したため、特になし。