### PR TITLE
#123 投稿編集画面・更新 / Yosuke

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Post;
-use App\Http\Requests\UpdatePostRequest;
+use App\Http\Requests\PostRequest;
 use Illuminate\Support\Facades\Auth;
 
 class PostsController extends Controller
@@ -21,7 +21,7 @@ class PostsController extends Controller
         ]);
     }
 
-    public function update(UpdatePostRequest $request, $id)
+    public function update(PostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
 

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Post;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class PostsController extends Controller
+{
+    public function edit($id)
+    {
+        $post = Post::findOrFail($id);
+
+        if (Auth::id() !== $post->user_id) {
+            abort(403);
+        }
+
+        return view('posts.edit', [
+            'post' => $post,
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $post = Post::findOrFail($id);
+
+        if (Auth::id() !== $post->user_id) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'content' => 'required|string|max:140',
+        ]);
+
+        $post->content = $validated['content'];
+
+        $post->save();
+
+        return redirect('/');
+    }
+}

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Post;
-use Illuminate\Http\Request;
+use App\Http\Requests\UpdatePostRequest;
 use Illuminate\Support\Facades\Auth;
 
 class PostsController extends Controller
@@ -21,7 +21,7 @@ class PostsController extends Controller
         ]);
     }
 
-    public function update(Request $request, $id)
+    public function update(UpdatePostRequest $request, $id)
     {
         $post = Post::findOrFail($id);
 
@@ -29,12 +29,9 @@ class PostsController extends Controller
             abort(403);
         }
 
-        $validated = $request->validate([
-            'content' => 'required|string|max:140',
-        ]);
+        $validated = $request->validated();
 
         $post->content = $validated['content'];
-
         $post->save();
 
         return redirect('/');

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class UpdatePostRequest extends FormRequest
+class PostRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/app/Http/Requests/UpdatePostRequest.php
+++ b/app/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePostRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'content' => 'required|string|max:140',
+        ];
+    }
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -30,7 +30,9 @@
                         >
 
                         @error('name')
-                            <p>{{ $message }}</p>
+                            <div class="alert alert-danger mt-2">
+                                {{ $message }}
+                            </div>
                         @enderror
                     </div>
 
@@ -48,7 +50,9 @@
                         >
 
                         @error('email')
-                            <p>{{ $message }}</p>
+                            <div class="alert alert-danger mt-2">
+                                {{ $message }}
+                            </div>
                         @enderror
                     </div>
 
@@ -65,7 +69,9 @@
                         >
 
                         @error('password')
-                            <p>{{ $message }}</p>
+                            <div class="alert alert-danger mt-2">
+                                {{ $message }}
+                            </div>
                         @enderror
                     </div>
 

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.app')
+
+@section('content')
+    <h2 class="mt-5">投稿を編集する</h2>
+    <form method="POST" action="{{ route('post.update', $post->id) }}">
+        @csrf
+        @method('PUT')
+
+        <div class="form-group">
+            <textarea
+                id="content"
+                class="form-control"
+                name="content"
+                rows="5"
+            >{{ old('content', $post->content) }}</textarea>
+
+            @error('content')
+                <div class="alert alert-danger mt-2">
+                    {{ $message }}
+                </div>
+            @enderror
+        </div>
+
+        <button type="submit" class="btn btn-primary">
+            更新する
+        </button>
+    </form>
+@endsection

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -25,6 +25,16 @@
                         {{ $post->created_at }}
                     </p>
                 </div>
+                @if (Auth::check() && Auth::id() === $post->user_id)
+                    <div class="d-flex justify-content-end w-75 pb-3 m-auto">
+                        <a
+                            href="{{ route('post.edit', $post->id) }}"
+                            class="btn btn-primary"
+                        >
+                            編集する
+                        </a>
+                    </div>
+                @endif
             </div>
         </li>
     @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,3 +24,9 @@ Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('sign
 
 // ユーザ新規登録処理
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
+
+// 投稿
+Route::prefix('posts')->middleware('auth')->group(function () {
+    Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
+    Route::put('{id}', 'PostsController@update')->name('post.update');
+});


### PR DESCRIPTION
## Issue

- Closes #123

## 概要

- 投稿編集画面および更新処理を実装
- 投稿者本人だけが投稿を編集できるよう認証・認可処理を追加
- 投稿本文に必須・140文字以内のバリデーションを設定

## 動作確認手順

1. 下記コマンドを実行

```bash
php artisan tinker
```

Tinkerで、ログイン中ユーザ本人の投稿と別ユーザの投稿を作成する。

```php
$post = new App\Post();
$post->user_id = ログイン中ユーザのID;
$post->content = '編集テスト用の投稿です';
$post->save();

$otherPost = new App\Post();
$otherPost->user_id = 別ユーザのID;
$otherPost->content = '他ユーザの投稿です';
$otherPost->save();
```

2. ログイン中ユーザの詳細画面を表示
3. 本人投稿にのみ「編集する」ボタンが表示されることを確認
4. 「編集する」を押し、`/posts/{id}/edit`へ遷移することを確認
5. textareaに既存の投稿本文が表示されることを確認
6. 投稿本文を変更して「更新する」を押す
7. トップページへリダイレクトされることを確認
8. ユーザ詳細画面およびAdminerで、投稿本文と`updated_at`が更新されていることを確認
9. 別ユーザの投稿編集URLへ直接アクセスし、403になることを確認
10. 存在しない投稿IDの編集URLへアクセスし、404になることを確認
11. 投稿本文を空欄にして更新し、ページ上部と入力欄直下にエラーが表示されることを確認
12. 日本語を141文字以上入力して更新し、140文字制限のエラーが表示され、入力内容が保持されることを確認

## 考慮してほしいこと

- 投稿新規作成機能が未実装のため、動作確認用の投稿データはTinkerから登録
- トップページの投稿表示機能が未実装のため、更新結果はユーザ詳細画面およびAdminerで確認
- 通常のログイン機能が未統合のため、新規登録後の自動ログイン状態で動作確認
- ページ上部の共通エラー表示ファイルには既存の記述誤りがあるため、動作確認時のみ一時修正し、確認後に元へ戻した
- バリデーションメッセージの日本語化は別タスクのため、現時点では英語で表示

## 確認してほしいこと

- 本人以外のアクセスに対して`abort(403)`を返す実装で問題ないか
- 投稿本文のバリデーションを`required|string|max:140`として問題ないか、別ファイルに分離させるべきか

PostsController.php
```php
if (Auth::id() !== $post->user_id) {
    abort(403);
}

$validated = $request->validate([
    'content' => 'required|string|max:140',
]);
```