### PR TITLE
#125 ユーザ退会機能を追加 / Yosuke

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class UsersController extends Controller
 {
@@ -25,5 +27,24 @@ class UsersController extends Controller
         ];
 
         return view('users.show', $data);
+    }
+
+    public function destroy(Request $request, $id)
+    {
+        $user = User::findOrFail($id);
+
+        if (Auth::id() !== $user->id) {
+            abort(403);
+        }
+
+        $user->posts()->delete();
+        $user->delete();
+
+        Auth::logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect('/');
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -37,7 +37,6 @@ class UsersController extends Controller
             abort(403);
         }
 
-        $user->posts()->delete();
         $user->delete();
 
         Auth::logout();

--- a/app/User.php
+++ b/app/User.php
@@ -39,6 +39,15 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::deleting(function ($user) {
+            $user->posts()->delete();
+        });
+    }
+
     public function posts()
     {
         return $this->hasMany(Post::class);

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -23,6 +23,52 @@
                                 ユーザ情報の編集
                             </a>
                         </div>
+
+                        <div class="mt-3">
+                            <a
+                                class="btn btn-danger text-light btn-block"
+                                data-toggle="modal"
+                                data-target="#deleteConfirmModal"
+                            >
+                                退会する
+                            </a>
+                        </div>
+
+                        <div
+                            class="modal fade"
+                            id="deleteConfirmModal"
+                            tabindex="-1"
+                            role="dialog"
+                            aria-labelledby="basicModal"
+                            aria-hidden="true"
+                        >
+                            <div class="modal-dialog">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h4>確認</h4>
+                                    </div>
+
+                                    <div class="modal-body">
+                                        <label>本当に退会しますか？</label>
+                                    </div>
+
+                                    <div class="modal-footer d-flex justify-content-between">
+                                        <form method="POST" action="{{ route('user.destroy', $user->id) }}">
+                                            @csrf
+                                            @method('DELETE')
+
+                                            <button type="submit" class="btn btn-danger">
+                                                退会する
+                                            </button>
+                                        </form>
+
+                                        <button type="button" class="btn btn-default" data-dismiss="modal">
+                                            閉じる
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     @endif
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,8 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 Route::prefix('users')->group(function () {
     // ユーザ詳細画面を表示
     Route::get('{id}', 'UsersController@show')->name('user.show');
+    // ユーザ退会処理
+    Route::delete('{id}', 'UsersController@destroy')->name('user.destroy')->middleware('auth');
 });
 
 // 投稿


### PR DESCRIPTION
## Issue

- Closes #125

## 概要

- ユーザー詳細画面に、ログイン中かつ本人の場合のみ退会ボタンを表示
- 退会ボタン押下時に確認モーダルを表示
- 退会処理でユーザー本人かを確認し、本人以外は403を返す
- 退会時に、対象ユーザーの投稿も論理削除
- ユーザー自身も論理削除
- 退会後はログアウトし、セッションを無効化してトップページへリダイレクト

## 動作確認手順

1. ログイン中の本人ユーザーで `/users/{id}` を表示
2. 「退会する」ボタンが表示されることを確認
3. 「退会する」ボタンを押し、確認モーダルが表示されることを確認
4. モーダル内の「退会する」を押す
5. トップページへリダイレクトされ、ログアウト状態になることを確認
6. Adminerで対象ユーザーの `users.deleted_at` に日時が入っていることを確認
7. Adminerで対象ユーザーの投稿の `posts.deleted_at` にも日時が入っていることを確認
8. 退会済みユーザーの詳細ページ `/users/{id}` へアクセスし、404になることを確認
9. 未ログインまたは本人以外のユーザー詳細画面では、退会ボタンが表示されないことを確認

## 考慮してほしいこと

- 投稿新規作成機能が未実装のため、退会確認用の投稿はTinkerで作成して動作確認しました
- 退会後のログアウト処理は、Laravel標準のログアウト処理に寄せて、`Auth::logout()`、セッション無効化、CSRFトークン再生成を行っています

## 確認してほしいこと

- 退会処理後のログアウト、セッション無効化、CSRFトークン再生成の書き方が適切か

```php
public function destroy(Request $request, $id)
{
    $user = User::findOrFail($id);

    if (Auth::id() !== $user->id) {
        abort(403);
    }

    $user->posts()->delete();
    $user->delete();

    Auth::logout();

    $request->session()->invalidate();
    $request->session()->regenerateToken();

    return redirect('/');
}
```