### PR TITLE
#127 フォロー・フォロー中とフォロワーの一覧表示 / Yosuke

### DIFF
--- a/app/Http/Controllers/FollowsController.php
+++ b/app/Http/Controllers/FollowsController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+
+class FollowsController extends Controller
+{
+    public function store($id)
+    {
+        Auth::user()->follow($id);
+
+        return back();
+    }
+
+    public function destroy($id)
+    {
+        Auth::user()->unfollow($id);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -24,6 +24,37 @@ class UsersController extends Controller
         $data = [
             'user' => $user,
             'posts' => $posts,
+            'type' => 'timeline',
+        ];
+
+        return view('users.show', $data);
+    }
+
+    public function followings($id)
+    {
+        $user = User::findOrFail($id);
+
+        $followings = $user->followings()->paginate(10);
+
+        $data = [
+            'user' => $user,
+            'users' => $followings,
+            'type' => 'followings',
+        ];
+
+        return view('users.show', $data);
+    }
+
+    public function followers($id)
+    {
+        $user = User::findOrFail($id);
+
+        $followers = $user->followers()->paginate(10);
+
+        $data = [
+            'user' => $user,
+            'users' => $followers,
+            'type' => 'followers',
         ];
 
         return view('users.show', $data);

--- a/app/User.php
+++ b/app/User.php
@@ -48,8 +48,67 @@ class User extends Authenticatable
         });
     }
 
+    // ユーザーが投稿した投稿一覧を取得
     public function posts()
     {
         return $this->hasMany(Post::class);
+    }
+
+    // 自分がフォローしているユーザー一覧を取得
+    public function followings()
+    {
+        return $this->belongsToMany(
+            User::class,
+            'follows',
+            'follower_id',
+            'followed_id'
+        )->withTimestamps();
+    }
+
+    // 自分をフォローしているユーザー一覧を取得
+    public function followers()
+    {
+        return $this->belongsToMany(
+            User::class,
+            'follows',
+            'followed_id',
+            'follower_id'
+        )->withTimestamps();
+    }
+
+    // 指定ユーザーをフォロー
+    public function follow($userId)
+    {
+        if ($this->id == $userId) {
+            return false;
+        }
+
+        if ($this->isFollowing($userId)) {
+            return false;
+        }
+
+        $this->followings()->attach($userId);
+
+        return true;
+    }
+
+    // 指定ユーザーをフォロー済みか判定
+    public function isFollowing($userId)
+    {
+        return $this->followings()
+            ->where('followed_id', $userId)
+            ->exists();
+    }
+
+    // 指定ユーザーのフォローを解除
+    public function unfollow($userId)
+    {
+        if ($this->isFollowing($userId)) {
+            $this->followings()->detach($userId);
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/database/migrations/2026_07_03_111903_create_follows_table.php
+++ b/database/migrations/2026_07_03_111903_create_follows_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+
+            $table->unsignedBigInteger('follower_id')->index();
+            $table->unsignedBigInteger('followed_id')->index();
+
+            $table->timestamps();
+
+            $table->foreign('follower_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+
+            $table->foreign('followed_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+
+            $table->unique(['follower_id', 'followed_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -69,6 +69,27 @@
                                 </div>
                             </div>
                         </div>
+                    @elseif (Auth::check())
+                      <div class="mt-3">
+                        @if (Auth::user()->isFollowing($user->id))
+                          <form method="POST" action="{{ route('user.unfollow', $user->id) }}">
+                            @csrf
+                            @method('DELETE')
+
+                            <button type="submit" class="btn btn-danger btn-block">
+                              フォロー解除
+                            </button>
+                          </form>
+                        @else
+                          <form method="POST" action="{{ route('user.follow', $user->id) }}">
+                            @csrf
+
+                            <button type="submit" class="btn btn-primary btn-block">
+                              フォロー
+                            </button>
+                          </form>
+                        @endif
+                      </div>
                     @endif
                 </div>
             </div>
@@ -86,19 +107,38 @@
                 </li>
 
                 <li class="nav-item">
-                    <a href="#" class="nav-link">
+                    <a
+                        href="{{ route('user.followings', $user->id) }}"
+                        class="nav-link {{ Request::is('users/' . $user->id . '/followings') ? 'active' : '' }}"
+                    >
                         フォロー中
                     </a>
                 </li>
 
                 <li class="nav-item">
-                    <a href="#" class="nav-link">
+                    <a
+                        href="{{ route('user.followers', $user->id) }}"
+                        class="nav-link {{ Request::is('users/' . $user->id . '/followers') ? 'active' : '' }}"
+                    >
                         フォロワー
                     </a>
                 </li>
             </ul>
 
-            @include('posts.posts', ['posts' => $posts])
+            @if ($type === 'timeline')
+              @include('posts.posts', ['posts' => $posts])
+            @elseif ($type === 'followings')
+              @include('users.users', [
+                'users' => $users,
+                'emptyMessage' => 'フォロー中のユーザはいません。'
+              ])
+            @elseif ($type === 'followers')
+              @include('users.users', [
+                'users' => $users,
+                'emptyMessage' => 'フォロワーはいません。'
+              ])
+            @endif
+
         </div>
     </div>
 @endsection

--- a/resources/views/users/users.blade.php
+++ b/resources/views/users/users.blade.php
@@ -1,0 +1,27 @@
+<ul class="list-unstyled">
+    @forelse ($users as $listUser)
+        <li class="mb-3 text-center">
+            <div class="text-left d-inline-block w-75 mb-2">
+                <img
+                    class="mr-2 rounded-circle"
+                    src="{{ Gravatar::src($listUser->email, 55) }}"
+                    alt="{{ $listUser->name }}のアバター画像"
+                >
+
+                <p class="mt-3 mb-0 d-inline-block">
+                    <a href="{{ route('user.show', $listUser->id) }}">
+                        {{ $listUser->name }}
+                    </a>
+                </p>
+            </div>
+        </li>
+    @empty
+        <li class="text-center">
+            {{ $emptyMessage ?? 'ユーザはいません。' }}
+        </li>
+    @endforelse
+</ul>
+
+<div class="m-auto" style="width: fit-content">
+    {{ $users->links('pagination::bootstrap-4') }}
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,14 @@ Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 Route::prefix('users')->group(function () {
     // ユーザ詳細画面を表示
     Route::get('{id}', 'UsersController@show')->name('user.show');
+    // フォロー中一覧
+    Route::get('{id}/followings', 'UsersController@followings')->name('user.followings');
+    // フォロワー一覧
+    Route::get('{id}/followers', 'UsersController@followers')->name('user.followers');
+    // フォロー実行
+    Route::post('{id}/follow', 'FollowsController@store')->name('user.follow')->middleware('auth');
+    // フォロー解除
+    Route::delete('{id}/unfollow', 'FollowsController@destroy')->name('user.unfollow')->middleware('auth');
     // ユーザ退会処理
     Route::delete('{id}', 'UsersController@destroy')->name('user.destroy')->middleware('auth');
 });


### PR DESCRIPTION
## Issue

Closes #127

## 概要

ユーザーフォロー機能を追加しました。

- ユーザー詳細画面で、他ユーザーをフォロー／フォロー解除できる
- フォロー状態に応じて、ボタン表示が「フォロー」「フォロー解除」に切り替わる
- `follows` テーブルを追加し、`follower_id` / `followed_id` でユーザー同士のフォロー関係を管理
- ユーザー詳細画面のタブから、「フォロー中」「フォロワー」の一覧を表示できる
- フォロー中・フォロワー一覧表示用に `resources/views/users/users.blade.php` を追加

## 構造概要

## 動作確認

- [x] ログイン中に他ユーザー詳細画面で「フォロー」ボタンが表示される
- [x] フォロー実行後、`follows` テーブルにレコードが追加される
- [x] フォロー実行後、ボタンが「フォロー解除」に切り替わる
- [x] フォロー解除後、`follows` テーブルからレコードが削除される
- [x] フォロー解除後、ボタンが「フォロー」に戻る
- [x] `/users/{id}/followings` でフォロー中ユーザー一覧が表示される
- [x] `/users/{id}/followers` でフォロワー一覧が表示される
- [x] フォロー中ユーザーがいない場合、「フォロー中のユーザはいません。」と表示される
- [x] フォロワーがいない場合、「フォロワーはいません。」と表示される

## 確認してほしいこと

- 講座ではいいね機能のコントローラは `FavoriteController` でしたが、既存の `UsersController` / `PostsController` に合わせて `FollowsController` という複数形のController名で実装しています。

- フォロー実行・解除は、`follows` テーブルの更新処理であるため `FollowsController@store` / `destroy` に実装しています。  
  一方、フォロー中一覧・フォロワー一覧はユーザー詳細画面のタブ表示に関する処理と考え、`UsersController@followings` / `followers` に実装しています。

- `UsersController@followings` / `followers` 内では、取得対象を明確にするため `$followings` / `$followers` としています。  
  Blade側ではどちらもユーザー一覧として同じpartialで表示するため、`'users' => $followings` / `'users' => $followers` として共通の `$users` に渡しています。

- `users/users.blade.php` は、フォロー中一覧・フォロワー一覧で共通利用するユーザー一覧表示用のpartialとして作成しています。  
  `users/show.blade.php` から、`$type` が `followings` / `followers` の場合に読み込む形にしています。

## 補足

今回作成したfollows中間テーブルは、講座のいいね機能の中間テーブルと同様に、`deleted_at` は追加せず、フォロー解除時は `detach()` による物理削除としています。