### PR TITLE
#117 ユーザ編集画面・更新（ヒロコ）

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\User;
+use App\Http\Requests\UserRequest;
 
 class UsersController extends Controller
 {
@@ -15,5 +16,36 @@ class UsersController extends Controller
             'posts' => $posts,
         ];
         return view('users.show',$data);
+    }
+
+    // ユーザ情報編集画面
+    public function edit($id)
+    {
+        // if (Auth::id() !== (int)$id) {
+        //     return redirect()->route('login'); // ログインページへ
+        // }
+
+        $user = User::findOrFail($id);
+        $data = [
+            'user' => $user,
+        ];
+        return view('users.edit', $data);
+    }
+
+    // ユーザ情報更新
+    public function update(UserRequest $request, $id)
+    {
+
+        // if (Auth::id() !== (int)$id) {
+        //     return redirect()->route('login'); // ログインページへ
+        // }
+
+        $user = User::findOrFail($id);
+        $user->name = $request->name;
+        $user->email = $request->email;
+        $user->password = bcrypt($request->password);
+        $user->save();
+
+        return redirect()->route('users.show', $id);
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\User;
 use App\Http\Requests\UserRequest;
+use Illuminate\Support\Facades\Auth;
 
 class UsersController extends Controller
 {
@@ -21,9 +22,9 @@ class UsersController extends Controller
     // ユーザ情報編集画面
     public function edit($id)
     {
-        // if (Auth::id() !== (int)$id) {
-        //     return redirect()->route('login'); // ログインページへ
-        // }
+        if (Auth::id() !== (int)$id) {
+            abort(403, 'このユーザは編集権限がありません。');
+        }
 
         $user = User::findOrFail($id);
         $data = [
@@ -35,10 +36,9 @@ class UsersController extends Controller
     // ユーザ情報更新
     public function update(UserRequest $request, $id)
     {
-
-        // if (Auth::id() !== (int)$id) {
-        //     return redirect()->route('login'); // ログインページへ
-        // }
+        if (Auth::id() !== (int)$id) {
+            abort(403, 'このユーザは編集権限がありません。');
+        }
 
         $user = User::findOrFail($id);
         $user->name = $request->name;

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+
+class UserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $id = $this->route('id');
+
+        return [
+            'name' => 'required|string|max:20',
+            'email'  => 'required|email|unique:users,email,' . $id,
+            'password' => 'required|min:8|confirmed',
+        ];
+    }
+}

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+@section('content')
+<h2 class="mt-5 mb-3">ユーザ情報を編集する</h2>
+@include('commons.error_messages')
+<form method="POST" action="{{route('users.update', $user->id)}}">
+    @csrf
+    @method('PUT')
+    <div class="form-group">
+        <label for="name">ユーザ名</label>
+        <input class="form-control" value="{{ old('name', $user->name)}}" name="name" />
+    </div>
+
+    <div class="form-group">
+        <label for="email">メールアドレス</label>
+        <input class="form-control" value="{{ old('email', $user->email)}}" name="email" />
+    </div>
+
+    <div class="form-group">
+        <label for="password">パスワード</label>
+        <input class="form-control" type="password" name="password" />
+    </div>
+
+    <div class="form-group">
+        <label for="password_confirmation">パスワードの確認</label>
+        <input class="form-control" type="password" name="password_confirmation" />
+    </div>
+
+    <div class="d-flex justify-content-between">
+        <a class="btn btn-danger text-light" data-toggle="modal" data-target="#deleteConfirmModal">退会する</a>
+        <button type="submit" class="btn btn-primary">更新する</button>
+    </div>
+</form>
+
+<div class="modal fade" id="deleteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>確認</h4>
+            </div>
+            <div class="modal-body">
+                <label>本当に退会しますか？</label>
+            </div>
+            <div class="modal-footer d-flex justify-content-between">
+                <form action="" method="POST">
+                    <button type="submit" class="btn btn-danger">退会する</button>
+                </form>
+                <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -8,9 +8,9 @@
                 </div>
                 <div class="card-body">
                     <img class="rounded-circle img-fluid" src="{{ Gravatar::src($user->email, 300) }}" alt="{{ $user->name }}">
-                        <div class="mt-3">
-                            <a href="" class="btn btn-primary btn-block">ユーザ情報の編集</a>
-                        </div>
+                    <div class="mt-3">
+                        <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-block">ユーザ情報の編集</a>
+                    </div>
                 </div>
             </div>
         </aside>
@@ -22,5 +22,5 @@
             </ul>
             @include('posts.posts', ['posts' => $posts])
         </div>
-    </div>
+</div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,10 +15,11 @@
 Route::get('/', 'PostsController@index')->name('posts');
 
 // ログイン機能完成後に有効化
-// Route::group(['middleware' => 'auth'],   function () {
+// Route::group(['middleware' => 'auth'], function () {
 Route::prefix('users')->group(function () {
-    // ユーザー詳細
+    // ユーザ詳細
     Route::get('{id}', 'UsersController@show')->name('users.show');
+    // ユーザ編集・更新
     Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
     Route::put('{id}', 'UsersController@update')->name('users.update');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,10 +13,16 @@
 
 // 投稿一覧
 Route::get('/', 'PostsController@index')->name('posts');
-// ユーザー詳細
+
+// ログイン機能完成後に有効化
+// Route::group(['middleware' => 'auth'],   function () {
 Route::prefix('users')->group(function () {
+    // ユーザー詳細
     Route::get('{id}', 'UsersController@show')->name('users.show');
+    Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
+    Route::put('{id}', 'UsersController@update')->name('users.update');
 });
+// });
 
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');


### PR DESCRIPTION
## issue
- Closes #117

## 概要
ユーザ編集画面・更新

ユーザー詳細画面（`/users/{id}`）からユーザー情報編集画面（`/users/{id}/edit`）に遷移し、
情報を更新後、ユーザー詳細画面に戻る機能を実装

## 動作確認手順

1. ユーザー詳細画面（`/users/{id}`）の「ユーザ情報の編集」ボタンをクリックし、編集画面に遷移することを確認
2. ユーザー名・メールアドレスが現在の値で初期表示されることを確認
3. 各フィールドを変更して「更新する」をクリックし、ユーザー詳細画面に戻ることを確認
4. 更新した内容が詳細画面に反映されていることを確認
5. Adminerで `users` テーブルを確認し、ユーザー名・メールアドレスが更新されていることを確認
6.  バリデーションエラーの確認
   - ユーザー名を空にして送信 → エラーメッセージが表示されること
   - 不正なメールアドレス形式で送信 → エラーメッセージが表示されること
   - すでに他のユーザーが使用しているメールアドレスを入力して送信 → エラーメッセージが表示されること
   - パスワードを空にして送信 → エラーメッセージが表示されること
   - パスワードが8文字未満で送信 → エラーメッセージが表示されること
   - パスワードと確認が不一致で送信 → エラーメッセージが表示されること
   - バリデーションエラー後、入力したユーザー名・メールアドレスがそのまま表示されること

## 考慮してほしいこと
## 確認したいこと
- ログイン機能が未完成のため、以下はコメントアウトしています。（ログイン機能完成後に有効化が必要）
  - `routes/web.php` の `middleware('auth')`（未認証ユーザーのアクセス制御）
  - `UsersController.php` の `edit()` / `update()` における本人チェック（`Auth::id() !== (int)$id` の場合はログインページ（`login`）にリダイレクト）

-  上記、忘れないようにコメントアウトで記載しましたが、まだ書かない方が良いのでしょうか？