### PR TITLE
#119 投稿新規作成（ようこ）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -58,4 +58,13 @@ class PostsController extends Controller
 
         return redirect("/");
     }
+
+    public function store(PostRequest $request)
+    {
+        $request->user()->posts()->create([
+            'content' => $request->content,
+        ]);
+
+        return back();
+    }
 }

--- a/app/Http/Requests/PostRequest.php
+++ b/app/Http/Requests/PostRequest.php
@@ -27,4 +27,11 @@ class PostRequest extends FormRequest
             'content' => 'required|string|max:140',
         ];
     }
+
+    public function attributes()
+    {
+        return [
+            'content' => '投稿',
+        ];
+    }     
 }

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,17 +6,27 @@
         </div>
     </div>
     <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-        <div class="w-75 m-auto">エラーメッセージが入る場所</div>
+    @if (Auth::check())
         <div class="text-center mb-3">
-            <form method="" action="" class="d-inline-block w-75">
+            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+                @csrf
+
                 <div class="form-group">
-                    <textarea class="form-control" name="body" rows="3"></textarea>
+                    <textarea class="form-control" name="content" rows="3"></textarea>
+                    
+                    @error('content')
+                    <div class='alert alert-danger mt-2'>
+                        {{ $message}}
+                    </div>
+                    @enderror
+                    
                     <div class="text-left mt-3">
                         <button type="submit" class="btn btn-primary">投稿する</button>
                     </div>
                 </div>
             </form>
         </div>
+    @endif
 
         @include('posts.posts', ['posts' => $posts])
        

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,4 +47,5 @@ Route::prefix('posts')->middleware('auth')->group(function () {
     Route::get('{id}/edit', 'PostsController@edit')->name('post.edit');
     Route::put('{id}', 'PostsController@update')->name('post.update');
     Route::delete('{id}', 'PostsController@destroy')->name('post.destroy');
+    Route::post('', 'PostsController@store')->name('post.store');
 });


### PR DESCRIPTION
##　issue
- Closes #119 

## 概要
- 投稿新規作成

## 動作確認手順
- ログインユーザーが正常にテキストを入力し、投稿がデータベースに保存されタイムラインに戻ることを確認。
- 未入力の状態で投稿ボタンを押した際、画面が遷移せず直下に必須エラーメッセージが表示されることを確認。
- 140文字を超える長文を入力した際、文字数制限のエラーメッセージが表示されることを確認。

## 確認してほしいこと
- 項目のエラー表示がセンタリングになっていて、トップに表示されるエラーメッセージ同様、左寄せにしたほうがいいのかなと思ったのですが、いかがでしょうか？