### PR TITLE
Positive Oopsの文言調整

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
     <div class="text-center">
-        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Topic Posts</h1>
+        <h1><i class="fab fa-telegram fa-lg pr-3"></i>Positive Oops</h1>
     </div>
         <div class="text-center mt-3">
             <p class="text-left d-inline-block">ログインすると投稿で<br>コミュニケーションができるようになります。</p>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 @section('content')
         <div class="text-center">
-            <h1>Topic Posts</h1>
+            <h1>Positive Oops</h1>
         </div>
 
         <div class="text-center">

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -1,6 +1,6 @@
 <header class="mb-5">
     <nav class="navbar navbar-expand-sm navbar-dark bg-info">
-        <a class="navbar-brand" href="/">Topic Posts</a>
+        <a class="navbar-brand" href="/">Positive Oops</a>
 
         <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#nav-bar">
             <span class="navbar-toggler-icon"></span>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="ja">
     <head>
         <meta charset="utf-8">
-        <title>Topic Posts</title>
+        <title>Positive Oops</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     </head>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2,32 +2,36 @@
 @section('content')
     <div class="center jumbotron bg-info">
         <div class="text-center text-white mt-2 pt-1">
-            <h1><i class="pr-3"></i>Topic Posts</h1>
+            <h1><i class="pr-3"></i>Positive Oops</h1>
         </div>
     </div>
-    <h5 class="text-center mb-3">"○○"について140字以内で会話しよう！</h5>
-    @if (Auth::check())
-        <div class="text-center mb-3">
-            <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
-                @csrf
 
-                <div class="form-group">
-                    <textarea class="form-control" name="content" rows="3"></textarea>
-                    
+    <h5 class="text-center mb-3">"今日のやらかし"についてシェアしよう！</h5>
+
+        @if (Auth::check())
+            <div class="w-75 m-auto"></div>
+
+            <div class="text-center mb-3">
+                <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
+                    @csrf
+
+                    <div class="form-group">
+                        <textarea class="form-control" name="content" rows="3"></textarea>
+
                     @error('content')
-                    <div class='alert alert-danger mt-2'>
-                        {{ $message}}
-                    </div>
+                        <div class='alert alert-danger mt-2'>
+                            {{ $message}}
+                        </div>
                     @enderror
-                    
-                    <div class="text-left mt-3">
-                        <button type="submit" class="btn btn-primary">投稿する</button>
+
+                        <div class="text-left mt-3">
+                            <button type="submit" class="btn btn-primary">やらかしをシェア</button>
+                        </div>
                     </div>
-                </div>
-            </form>
-        </div>
-    @endif
+                </form>
+            </div>
+        @endif
 
         @include('posts.posts', ['posts' => $posts])
-       
+
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -9,8 +9,6 @@
     <h5 class="text-center mb-3">"今日のやらかし"についてシェアしよう！</h5>
 
         @if (Auth::check())
-            <div class="w-75 m-auto"></div>
-
             <div class="text-center mb-3">
                 <form method="POST" action="{{ route('post.store') }}" class="d-inline-block w-75">
                     @csrf


### PR DESCRIPTION
## issue
- Closes  #1739

## 概要
- アプリ名を「Positive Oops」に変更
- トップページの説明文を変更
- 投稿ボタンの文言を「やらかしをシェア」に変更
- ヘッダーの文言を「Positive Oops」に変更

## 動作確認手順
- ログインする
- トップページを表示する
- ヘッダーのアプリ名が「Positive Oops」になっていることを確認する
- 説明文と投稿ボタンの文言が変更されていることを確認する

## 考慮して欲しいこと
- 特になし

## 確認して欲しいこと
- トップページ画面の各文言がポジウプ向けになっているか
