### PR TITLE
#121　投稿削除（ヒロコ）

### DIFF
--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -14,4 +14,6 @@ class PostsController extends Controller
             'posts' => $posts,
         ]);
     }
+
+    
 }

--- a/app/Http/Controllers/PostsController.php
+++ b/app/Http/Controllers/PostsController.php
@@ -24,4 +24,15 @@ class PostsController extends Controller
         $post->save();
         return back();
     }
+
+    //投稿削除
+    public function destroy($postId)
+    {
+        $post = Post::findOrFail($postId);
+        if (\Auth::id() !== $post->user_id) {
+            abort(403, 'このユーザは削除権限がありません。');
+        }
+        $post->delete();
+        return back();
+    }
 }

--- a/resources/views/posts/posts.blade.php
+++ b/resources/views/posts/posts.blade.php
@@ -12,7 +12,9 @@
                 </div>
                 <div class="d-flex justify-content-between w-75 m-auto pb-3">
                     @if (Auth::id() === $post->user_id)
-                        <form method="" action="">
+                        <form method="POST" action="{{ route('post.delete', $post->id) }}">
+                            @csrf
+                            @method('DELETE')
                             <button type="submit" class="btn btn-danger">削除</button>
                         </form>
                         <a href="" class="btn btn-primary">編集する</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,17 +14,33 @@
 // 投稿一覧
 Route::get('/', 'PostsController@index')->name('posts');
 
-// ログイン機能完成後に有効化
-// Route::group(['middleware' => 'auth'], function () {
+// Route::prefix('posts')->middleware('auth')->group(function () { //login機能が実装されたらこちらを有効化し、下を削除
+Route::prefix('posts')->group(function () {
+    // Route::get('{id}/edit', 'PostsController@edit')->name('posts.edit'); //西川さんが追加することを想定
+    // Route::put('{id}', 'PostsController@update')->name('posts.update'); //西川さんが追加することを想定
+    Route::delete('{id}', 'PostsController@destroy')->name('posts.delete');
+});
+
 Route::prefix('users')->group(function () {
     // ユーザ詳細
     Route::get('{id}', 'UsersController@show')->name('users.show');
     // ユーザ編集・更新
-    Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
-    Route::put('{id}', 'UsersController@update')->name('users.update');
+    Route::get('{id}/edit', 'UsersController@edit')->name('users.edit'); //->middleware('auth') login機能が実装されたら入れる
+    Route::put('{id}', 'UsersController@update')->name('users.update'); //->middleware('auth') login機能が実装されたら入れる
 });
-// });
 
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
+
+
+// ▼▼▼ テスト用（動作確認用の仮ログイン）コミット前に削除すること ▼▼▼
+Route::get('/test-login/{id}', function ($id) {
+    \Illuminate\Support\Facades\Auth::loginUsingId($id);
+    return redirect('/');
+});
+Route::get('/test-logout', function () {
+    \Illuminate\Support\Facades\Auth::logout();
+    return redirect('/');
+});
+// ▲▲▲ テスト用ここまで ▲▲▲

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,9 @@ Route::get('users/{id}', 'UsersController@show')->name('users.show');
 // Route::group(['middleware' => 'auth'], function () {
 // 新規投稿
 Route::post('posts', 'PostsController@store')->name('posts.store');
+// 投稿削除
+Route::delete('posts/{id}', 'PostsController@destroy')->name('post.delete');
+
 Route::prefix('users')->group(function () {
     // ユーザ編集・更新
     Route::get('{id}/edit', 'UsersController@edit')->name('users.edit');
@@ -31,15 +34,3 @@ Route::prefix('users')->group(function () {
 // ユーザ新規登録
 Route::get('signup', 'Auth\RegisterController@showRegistrationForm')->name('signup');
 Route::post('signup', 'Auth\RegisterController@register')->name('signup.post');
-
-
-// ▼▼▼ テスト用（動作確認用の仮ログイン）コミット前に削除すること ▼▼▼
-Route::get('/test-login/{id}', function ($id) {
-    \Illuminate\Support\Facades\Auth::loginUsingId($id);
-    return redirect('/');
-});
-Route::get('/test-logout', function () {
-    \Illuminate\Support\Facades\Auth::logout();
-    return redirect('/');
-});
-// ▲▲▲ テスト用ここまで ▲▲▲


### PR DESCRIPTION
## issue
- Closes #121

## 概要

自分が投稿した投稿を削除できる機能を実装

- `PostsController.php` に `destroy($postId)` を追加
  - `Post::findOrFail($postId)` で対象の投稿を取得
  - ログイン中のユーザーが投稿の所有者（`$post->user_id`）と一致しない場合は `abort(403, 'このユーザは削除権限がありません。')`
  - `Post` モデルは `SoftDeletes` を利用しているため、`$post->delete()` で論理削除とする
- `routes/web.php` にルーティング `Route::delete('posts/{id}', 'PostsController@destroy')->name('post.delete');` を追加
- `resources/views/posts/posts.blade.php` の削除ボタンに `action`・`@csrf`・`@method('DELETE')` を実装

## 動作確認手順

1. `/signup` から2人分のアカウントを新規登録する（ログイン状態になる）
2. 1人目のアカウントでログインした状態で投稿を作成し、その投稿の「削除」ボタンを押して一覧から消えることを確認
3. 削除した投稿がDB上で論理削除（`deleted_at`が設定される）されていることを確認
4. 2人目のアカウントでログインし直し、1人目が投稿した別の投稿には「削除」ボタンが表示されないことを確認する
5. ブラウザの検証ツールで削除フォームの`action`を1人目の投稿IDに書き換えて送信し、403エラーになる（削除されない）ことを確認

## 考慮してほしいこと

- 「編集する」リンク（`href=""`）は投稿編集機能側の担当のため、今回は未実装のまま残しています
- `auth`ミドルウェアはログイン機能がまだないため、今回も引き続きコメントアウトしています
- web.phpの`// ユーザ詳細 Route::get('users/{id}', 'UsersController@show')->name('users.show');` を誤って「ログイン後機能」のブロック内に入れていたため、本来の位置（ログイン不要な箇所）に移動しました

## 確認してほしいこと
- PostsController.phpのdestroyメソッドで、引数名を'$postId' にしたのですが問題ないでしょうか。
- deleteとdestroyの言葉の使い分けがよくわからず、合っているか確認していただきたいです。
