### PR TITLE
ひとことハゲマシ入力欄のEnter送信を修正 / Yosuke

### DIFF
--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -138,6 +138,7 @@
                     maxlength="30"
                     value="{{ old('encouragement') }}"
                     placeholder="30文字以内で入力できます"
+                    onkeydown="if (event.key === 'Enter' && !event.isComposing) { event.preventDefault(); document.getElementById('encouragementSubmitButton').click(); }"
                 >
 
                 @error('encouragement')
@@ -149,6 +150,7 @@
 
             <div class="d-flex align-items-center">
                 <button
+                    id="encouragementSubmitButton"
                     type="submit"
                     form="reactionForm"
                     formaction="{{ route('reaction.encourage', $post->id) }}"


### PR DESCRIPTION
## Issue
- なし

## 概要
- ひとことハゲマシ入力欄でEnterを押したとき、リアクション更新ではなくハゲマシ更新として送信されるように修正
- 日本語入力の変換確定時のEnterでは送信されないように調整
- 既存の `reactionForm` を使う構成は維持

## 動作確認手順
1. 投稿詳細画面を開く
2. ひとことハゲマシ入力欄に日本語を入力する
3. 日本語変換中にEnterを押しても送信されないことを確認
4. 変換確定後、通常のEnterを押す
5. 「ひとことハゲマシが送られました。ありがとう！」が表示されることを確認
6. 「ハゲます」ボタンをクリックした場合も、これまで通りハゲマシ更新になることを確認

## 考慮してほしいこと
- 前回の修正で、リアクション選択時にひとことハゲマシ入力欄の値を維持するため、リアクションボタンとハゲマシ入力欄は同じ `reactionForm` に紐づけています
- 今回はその構成を維持したまま、ハゲマシ入力欄でEnterを押した場合だけ「ハゲます」ボタンをクリックした扱いにしています
- 日本語入力の変換確定時のEnterでは送信されないよう、`event.isComposing` を見ています

## 変更前後
変更前:

```blade
<input
    id="encouragement"
    type="text"
    name="encouragement"
    form="reactionForm"
    class="form-control"
    maxlength="30"
    value="{{ old('encouragement') }}"
    placeholder="30文字以内で入力できます"
>
```

変更後:

```blade
<input
    id="encouragement"
    type="text"
    name="encouragement"
    form="reactionForm"
    class="form-control"
    maxlength="30"
    value="{{ old('encouragement') }}"
    placeholder="30文字以内で入力できます"
    onkeydown="if (event.key === 'Enter' && !event.isComposing) { event.preventDefault(); document.getElementById('encouragementSubmitButton').click(); }"
>
```

変更前:

```blade
<button
    type="submit"
    form="reactionForm"
    formaction="{{ route('reaction.encourage', $post->id) }}"
    class="btn btn-primary mr-3"
>
    ハゲます
</button>
```

変更後:

```blade
<button
    id="encouragementSubmitButton"
    type="submit"
    form="reactionForm"
    formaction="{{ route('reaction.encourage', $post->id) }}"
    class="btn btn-primary mr-3"
>
    ハゲます
</button>
```

## 確認してほしいこと
- 今回、Enterキーの制御にJavaScriptを使用しています。自分では動作確認済みですが、他のリアクション操作やハゲマシ送信への影響がないか確認していただきたいです。